### PR TITLE
Move runtime dependencies to the gemspec file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,12 +3,7 @@
 
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in rbi.gemspec
 gemspec
-
-gem("rake", "~> 13.0")
-gem("sorbet-runtime")
-gem("thor")
 
 group(:development, :test) do
   gem("minitest")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,10 @@ PATH
   remote: .
   specs:
     rbi (0.1.0)
+      colorize
+      rake (~> 13.0)
+      sorbet-runtime
+      thor
 
 GEM
   remote: https://rubygems.org/
@@ -74,15 +78,12 @@ PLATFORMS
 DEPENDENCIES
   byebug
   minitest
-  rake (~> 13.0)
   rbi!
   rubocop (~> 1.7)
   rubocop-shopify
   rubocop-sorbet
   sorbet
-  sorbet-runtime
   tapioca
-  thor
 
 BUNDLED WITH
    2.2.6

--- a/rbi.gemspec
+++ b/rbi.gemspec
@@ -25,4 +25,9 @@ Gem::Specification.new do |spec|
     Gemfile
     Rakefile
   )
+
+  spec.add_dependency("colorize")
+  spec.add_dependency("rake", "~> 13.0")
+  spec.add_dependency("sorbet-runtime")
+  spec.add_dependency("thor")
 end


### PR DESCRIPTION
By moving the dependencies to the gemspec file we make sure the project requiring `rbi` will get them too.

So we can avoid errors like those:

```
~/src/github.com/Shopify/rbi/lib/rbi/cli_helper.rb:4:in `require': cannot load such file -- colorize (LoadError)
~/src/github.com/Shopify/rbi/lib/rbi/cli_helper.rb:4:in `require': cannot load such file -- sorbet-runtime (LoadError)
~/src/github.com/Shopify/rbi/lib/rbi/cli_helper.rb:4:in `require': cannot load such file -- thor (LoadError)
```