### PR TITLE
Put back our original Logger

### DIFF
--- a/lib/rbi/cli_helper.rb
+++ b/lib/rbi/cli_helper.rb
@@ -17,7 +17,7 @@ module RBI
 
     sig { returns(Logger) }
     def logger
-      level = options[:verbose] ? ::Logger::Severity::DEBUG : ::Logger::Severity::INFO
+      level = options[:verbose] ? Logger::DEBUG : Logger::INFO
       Logger.new(level: level, color: options[:color], quiet: options[:quiet])
     end
   end

--- a/lib/rbi/client.rb
+++ b/lib/rbi/client.rb
@@ -26,14 +26,14 @@ module RBI
     sig { void }
     def clean
       FileUtils.rm_rf("#{@project_path}/#{GEM_RBI_DIRECTORY}")
-      @logger.unknown("Clean `#{@project_path}/#{GEM_RBI_DIRECTORY}` directory.")
+      @logger.success("Clean `#{@project_path}/#{GEM_RBI_DIRECTORY}` directory.")
     end
 
     sig { returns(T::Boolean) }
     def init
       unless Dir.glob("#{@project_path}/#{GEM_RBI_DIRECTORY}/*.rbi").empty?
-        @logger.error("Can't init while you RBI gems directory is not empty.\n" \
-                      "Run `rbi clean` to delete it.\n")
+        @logger.error("Can't init while you RBI gems directory is not empty.")
+        @logger.hint("Run `rbi clean` to delete it.")
         return false
       end
       file = Bundler.read_file("#{@project_path}/Gemfile.lock")
@@ -58,15 +58,15 @@ module RBI
         end
         pull_rbi(name, version)
       end
-      @logger.unknown("Gem RBIs successfully updated.")
+      @logger.success("Gem RBIs successfully updated.")
     end
 
     sig { params(name: String, version: String).returns(T::Boolean) }
     def pull_rbi(name, version)
       path = @repo.rbi_path(name, version)
       unless path
-        @logger.error("The RBI for `#{name}@#{version}` gem doesn't exist in the central repository\n" \
-                      "Run `rbi generate #{name}@#{version}` to generate it.\n")
+        @logger.error("The RBI for `#{name}@#{version}` gem doesn't exist in the central repository.")
+        @logger.hint("Run `rbi generate #{name}@#{version}` to generate it.")
         return false
       end
 

--- a/test/rbi/client_test.rb
+++ b/test/rbi/client_test.rb
@@ -45,10 +45,11 @@ module RBI
       res = client.init
 
       refute(res)
-      assert_equal(<<~MSG.strip, out.string.strip)
+      assert_log(<<~OUT, out.string)
         Error: Can't init while you RBI gems directory is not empty.
-        Run `rbi clean` to delete it.
-      MSG
+
+        Hint: Run `rbi clean` to delete it.
+      OUT
 
       assert(File.file?("#{project.path}/sorbet/rbi/gems/foo@1.0.0.rbi"))
       assert(File.file?("#{project.path}/sorbet/rbi/gems/foo@2.0.0.rbi"))
@@ -116,10 +117,11 @@ module RBI
       res = client.pull_rbi("foo", "1.0.0")
 
       refute(res)
-      assert_equal(<<~ERR.strip, out.string.strip)
-        Error: The RBI for `foo@1.0.0` gem doesn't exist in the central repository
-        Run `rbi generate foo@1.0.0` to generate it.
-      ERR
+      assert_log(<<~OUT, out.string)
+        Error: The RBI for `foo@1.0.0` gem doesn't exist in the central repository.
+
+        Hint: Run `rbi generate foo@1.0.0` to generate it.
+      OUT
     end
 
     def test_pull_rbi
@@ -215,8 +217,7 @@ module RBI
     end
 
     def client(mock, path)
-      out = StringIO.new
-      logger = Logger.new(logdev: out, color: false)
+      logger, out = self.logger
       [Client.new(logger, github_client: mock, project_path: path), out]
     end
   end

--- a/test/rbi/logger_test.rb
+++ b/test/rbi/logger_test.rb
@@ -1,0 +1,73 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+module RBI
+  class LoggerTest < Minitest::Test
+    include TestHelper
+
+    def test_logger_without_color
+      logger, out = self.logger(level: Logger::DEBUG)
+
+      logger.error("message `highlight`")
+      logger.success("message `highlight`")
+      logger.hint("message `highlight`")
+      logger.warn("message `highlight`")
+      logger.info("message `highlight`")
+      logger.debug("message `highlight`")
+
+      assert_log(<<~OUT, out.string)
+        Error: message `highlight`
+
+        Success: message `highlight`
+
+        Hint: message `highlight`
+
+        Warning: message `highlight`
+
+        Info: message `highlight`
+
+        Debug: message `highlight`
+      OUT
+    end
+
+    def test_logger_with_color
+      logger, out = self.logger(level: Logger::DEBUG, color: true)
+
+      logger.error("message `highlight`")
+      logger.success("message `highlight`")
+      logger.hint("message `highlight`")
+      logger.warn("message `highlight`")
+      logger.info("message `highlight`")
+      logger.debug("message `highlight`")
+
+      assert_log(<<~OUT, out.string)
+        \e[0;31;49mError\e[0m: message \e[0;34;49mhighlight\e[0m
+
+        \e[0;32;49mSuccess\e[0m: message \e[0;34;49mhighlight\e[0m
+
+        \e[0;32;49mHint\e[0m: message \e[0;34;49mhighlight\e[0m
+
+        \e[0;33;49mWarning\e[0m: message \e[0;34;49mhighlight\e[0m
+
+        \e[0;37;49mInfo\e[0m: message \e[0;34;49mhighlight\e[0m
+
+        \e[0;39;49mDebug\e[0m: message \e[0;34;49mhighlight\e[0m
+      OUT
+    end
+
+    def test_logger_quiet
+      logger, out = self.logger(level: Logger::DEBUG, quiet: true)
+
+      logger.error("message `highlight`")
+      logger.success("message `highlight`")
+      logger.hint("message `highlight`")
+      logger.warn("message `highlight`")
+      logger.info("message `highlight`")
+      logger.debug("message `highlight`")
+
+      assert_empty(out.string)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,6 +20,17 @@ module RBI
     def project(name)
       TestHelpers::Project.new("#{TEST_PROJECTS_PATH}/#{name}")
     end
+
+    sig { params(level: Integer, quiet: T::Boolean, color: T::Boolean).returns([Logger, StringIO]) }
+    def logger(level: Logger::INFO, quiet: false, color: false)
+      out = StringIO.new
+      [Logger.new(level: level, quiet: quiet, color: color, out: out), out]
+    end
+
+    sig { params(exp: String, out: String).void }
+    def assert_log(exp, out)
+      assert_equal(exp, "#{out.rstrip}\n")
+    end
   end
 end
 


### PR DESCRIPTION
Revert the use of `::Logger` and use our own implementation.

@paracycle after hours trying to workaround the original implementation we decided to use our own so we can control everything (add severity levels, play with the formatting and highlighting, etc.).