### PR TITLE
Uniformize messages

### DIFF
--- a/lib/rbi/client.rb
+++ b/lib/rbi/client.rb
@@ -133,7 +133,7 @@ module RBI
         exit
       end
 
-      @logger.debug(out)
+      @logger.debug("#{out}\n")
     end
 
     sig { returns(String) }

--- a/lib/rbi/logger.rb
+++ b/lib/rbi/logger.rb
@@ -60,9 +60,9 @@ module RBI
     end
     def log(level, message, label: nil, label_color: nil)
       if label
-        puts(level, colorize(label, label_color), ": ", highlight(message), "\n\n")
+        puts(level, colorize(label, label_color), ": ", highlight(message))
       else
-        puts(level, highlight(message), "\n\n")
+        puts(level, highlight(message))
       end
     end
 

--- a/test/rbi/client_test.rb
+++ b/test/rbi/client_test.rb
@@ -48,7 +48,6 @@ module RBI
         refute(res)
         assert_log(<<~OUT, out.string)
           Error: Can't init while you RBI gems directory is not empty
-
           Hint: Run `rbi clean` to delete it
         OUT
 
@@ -74,7 +73,6 @@ module RBI
         assert(res)
         assert_log(<<~OUT, out.string)
           Success: Pulled `bar@2.0.0.rbi` from central repository
-
           Success: Pulled `foo@1.0.0.rbi` from central repository
         OUT
         assert_equal("FOO = 1", File.read("#{project.path}/sorbet/rbi/gems/foo@1.0.0.rbi"))

--- a/test/rbi/integration_test.rb
+++ b/test/rbi/integration_test.rb
@@ -128,7 +128,6 @@ module RBI
         assert(status)
         assert_log(<<~OUT, T.must(err))
           Info: Generating RBIs that were missing in the central repository using tapioca
-
           Debug: Requiring all gems to prepare for compiling...  Done
 
           Processing 'foo' gem:
@@ -136,7 +135,6 @@ module RBI
 
           All operations performed in working directory.
           Please review changes and commit them.
-
 
           Success: Gem RBIs successfully updated
         OUT

--- a/test/rbi/logger_test.rb
+++ b/test/rbi/logger_test.rb
@@ -19,15 +19,10 @@ module RBI
 
       assert_log(<<~OUT, out.string)
         Error: message `highlight`
-
         Success: message `highlight`
-
         Hint: message `highlight`
-
         Warning: message `highlight`
-
         Info: message `highlight`
-
         Debug: message `highlight`
       OUT
     end
@@ -44,15 +39,10 @@ module RBI
 
       assert_log(<<~OUT, out.string)
         \e[0;31;49mError\e[0m: message \e[0;34;49mhighlight\e[0m
-
         \e[0;32;49mSuccess\e[0m: message \e[0;34;49mhighlight\e[0m
-
         \e[0;32;49mHint\e[0m: message \e[0;34;49mhighlight\e[0m
-
         \e[0;33;49mWarning\e[0m: message \e[0;34;49mhighlight\e[0m
-
         \e[0;37;49mInfo\e[0m: message \e[0;34;49mhighlight\e[0m
-
         \e[0;39;49mDebug\e[0m: message \e[0;34;49mhighlight\e[0m
       OUT
     end


### PR DESCRIPTION
Remove the trailing dot `.` from all messages as well as the blank lines between each logged message.