### PR TITLE
Move exit code assertions after checking the stdout/stderr content

### DIFF
--- a/test/rbi/cli/generate_test.rb
+++ b/test/rbi/cli/generate_test.rb
@@ -22,10 +22,10 @@ module RBI
         project.run("bundle install")
 
         _, err, status = project.bundle_exec("rbi generate colorize --no-color")
-        assert(status)
         assert_log(<<~OUT, censor_version(err))
           Success: Generated `colorize@X.Y.Z.rbi`
         OUT
+        assert(status)
       end
       file = T.must(Dir["#{project.path}/colorize@*.rbi"].first)
       assert(File.file?(file))
@@ -51,10 +51,10 @@ module RBI
         refute(File.file?("#{project.absolute_path(filename)}.rbi"))
 
         _, err, status = project.bundle_exec("rbi generate #{name} #{version} --no-color")
-        assert(status)
         assert_log(<<~OUT, err)
           Success: Generated `#{filename}.rbi`
         OUT
+        assert(status)
       end
       assert(File.file?("#{project.path}/#{filename}.rbi"))
 
@@ -80,10 +80,10 @@ module RBI
 
         url = "https://rubygems.org"
         _, err, status = project.bundle_exec("rbi generate #{name} #{version} --source=#{url} --no-color")
-        assert(status)
         assert_log(<<~OUT, err)
           Success: Generated `#{filename}.rbi`
         OUT
+        assert(status)
       end
       assert(File.file?("#{project.path}/#{filename}.rbi"))
 
@@ -109,10 +109,10 @@ module RBI
 
         url = "https://github.com/fazibear/colorize.git"
         _, err, status = project.bundle_exec("rbi generate #{name} #{version} --git=#{url} --no-color")
-        assert(status)
         assert_log(<<~OUT, censor_version(err))
           Success: Generated `colorize@X.Y.Z.rbi`
         OUT
+        assert(status)
       end
 
       project.destroy
@@ -138,10 +138,10 @@ module RBI
         url = "https://github.com/fazibear/colorize.git"
         _, err, status = project.bundle_exec("rbi generate #{name} #{version} --git=#{url}" \
           " --branch=master --no-color")
-        assert(status)
         assert_log(<<~OUT, censor_version(err))
           Success: Generated `colorize@X.Y.Z.rbi`
         OUT
+        assert(status)
       end
 
       project.destroy
@@ -185,10 +185,10 @@ module RBI
 
         path = "#{project.path}/vendor/cache/"
         _, err, status = project.bundle_exec("rbi generate #{name} #{version} --path=#{path} --no-color")
-        assert(status)
         assert_log(<<~OUT, err)
           Success: Generated `foo@1.0.0.rbi`
         OUT
+        assert(status)
       end
       assert(File.file?("#{project.path}/#{filename}.rbi"))
 

--- a/test/rbi/cli/github_test.rb
+++ b/test/rbi/cli/github_test.rb
@@ -25,7 +25,6 @@ module RBI
       GEMFILE_LOCK
 
       out, err, status = project.run("bundle exec rbi update --no-color --no-netrc")
-      refute(status)
       assert_empty(out)
       assert_log(<<~OUT, err)
         Error: Can't fetch RBI content from shopify/rbi-repo
@@ -37,6 +36,7 @@ module RBI
 
         https://github.com/Shopify/rbi#using-a-netrc-file
       OUT
+      refute(status)
 
       project.destroy
     end
@@ -59,7 +59,6 @@ module RBI
       GEMFILE_LOCK
 
       out, err, status = project.run("bundle exec rbi update --no-color --netrc-file netrc")
-      refute(status)
       assert_empty(out)
       assert_log(<<~OUT, err)
         Error loading credentials from netrc file for https://api.github.com/
@@ -72,6 +71,7 @@ module RBI
 
         https://github.com/Shopify/rbi#using-a-netrc-file
       OUT
+      refute(status)
 
       project.destroy
     end
@@ -80,11 +80,11 @@ module RBI
       project = self.project("test_access_private_repo_without_netrc_but_netrc_file")
 
       out, err, status = project.run("bundle exec rbi update --no-color --no-netrc --netrc-file netrc")
-      refute(status)
       assert_empty(out)
       assert_log(<<~OUT, err)
         Error: Option `--netrc-file` can only be used with option `--netrc`
       OUT
+      refute(status)
 
       project.destroy
     end
@@ -109,7 +109,6 @@ module RBI
       repo = "Shopify/RBIRepoNotFound"
 
       out, err, status = project.bundle_exec("rbi update --no-color --no-netrc --central-repo-slug #{repo}")
-      refute(status)
       assert_empty(out)
       assert_log(<<~OUT, err)
         Error: Can't fetch RBI content from #{repo}
@@ -121,6 +120,7 @@ module RBI
 
         https://github.com/Shopify/rbi#using-a-netrc-file
       OUT
+      refute(status)
 
       project.destroy
     end

--- a/test/rbi/cli/init_test.rb
+++ b/test/rbi/cli/init_test.rb
@@ -24,12 +24,12 @@ module RBI
       JSON
 
       out, err, status = project.bundle_exec("rbi init --no-netrc --mock-fetcher-file index_mock.json --no-color")
-      refute(status)
       assert_empty(out)
       assert_log(<<~OUT, err)
         Error: Can't init while you RBI gems directory is not empty
         Hint: Run `rbi clean` to delete it. Or use `rbi update` to update gem RBIs
       OUT
+      refute(status)
 
       assert(File.file?("#{project.path}/sorbet/rbi/gems/foo@1.0.0.rbi"))
       assert(File.file?("#{project.path}/sorbet/rbi/gems/foo@2.0.0.rbi"))
@@ -100,7 +100,6 @@ module RBI
         project.run("bundle install")
 
         out, err, status = project.bundle_exec("rbi init --no-netrc --mock-fetcher-file index_mock.json --no-color")
-        assert(status)
         assert_empty(out)
         assert_log(<<~OUT, err)
           Success: Pulled `bar@2.0.0.rbi` from central repository
@@ -108,6 +107,7 @@ module RBI
           Info: Generating RBIs that were missing in the central repository using tapioca
           Success: Gem RBIs successfully updated
         OUT
+        assert(status)
       end
 
       assert_equal("FOO = 1", File.read("#{project.path}/sorbet/rbi/gems/foo@1.0.0.rbi").strip)

--- a/test/rbi/cli/update_test.rb
+++ b/test/rbi/cli/update_test.rb
@@ -46,7 +46,6 @@ module RBI
         refute(File.file?("#{project.path}/sorbet/rbi/gems/foo@1.0.0.rbi"))
 
         out, err, status = project.bundle_exec("rbi update --no-netrc --mock-fetcher-file index.json -v --no-color")
-        assert(status)
         assert_empty(out)
         assert_log(<<~OUT, err)
           Info: Generating RBIs that were missing in the central repository using tapioca
@@ -60,6 +59,7 @@ module RBI
 
           Success: Gem RBIs successfully updated
         OUT
+        assert(status)
       end
       assert(File.file?("#{project.path}/sorbet/rbi/gems/foo@1.0.0.rbi"))
 


### PR DESCRIPTION
This is a QoL change.

When we break something, it's better to fail on the stdout/stderr diff than on the exit code so we can see the error messages printed and understand what's going wrong.