### PR TITLE
Hide `--mock-index-file` option

### DIFF
--- a/lib/rbi/cli.rb
+++ b/lib/rbi/cli.rb
@@ -14,7 +14,7 @@ module RBI
     class_option :netrc, type: :boolean, default: true
     class_option :netrc_file, type: :string
     class_option :central_repo_slug, type: :string
-    class_option :mock_index_file, type: :string
+    class_option :mock_index_file, type: :string, hide: true
 
     desc "clean", "Remove all gem RBIs from local project"
     def clean


### PR DESCRIPTION
It's purely internal and only used for testing, let's not trouble the end user with it.