### PR TITLE
Refactor RBI parser

### DIFF
--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -114,7 +114,7 @@ module RBI
       when :casgn
         current_scope << parse_const_assign(node)
       when :def, :defs
-        visit_def(node)
+        current_scope << parse_def(node)
       when :send
         visit_send(node)
       when :block
@@ -166,9 +166,9 @@ module RBI
       Const.new(name, value, loc: loc, comments: comments)
     end
 
-    sig { params(node: AST::Node).void }
-    def visit_def(node)
-      current_scope << case node.type
+    sig { params(node: AST::Node).returns(Method) }
+    def parse_def(node)
+      case node.type
       when :def
         Method.new(
           node.children[0].to_s,

--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -173,7 +173,7 @@ module RBI
       when :def
         Method.new(
           node.children[0].to_s,
-          params: node.children[1].children.map { |child| visit_param(child) },
+          params: node.children[1].children.map { |child| parse_param(child) },
           sigs: current_sigs,
           loc: node_loc(node),
           comments: node_comments(node)
@@ -181,7 +181,7 @@ module RBI
       when :defs
         Method.new(
           node.children[1].to_s,
-          params: node.children[2].children.map { |child| visit_param(child) },
+          params: node.children[2].children.map { |child| parse_param(child) },
           is_singleton: true,
           sigs: current_sigs,
           loc: node_loc(node),
@@ -193,7 +193,7 @@ module RBI
     end
 
     sig { params(node: AST::Node).returns(Param) }
-    def visit_param(node)
+    def parse_param(node)
       name = node.children[0].to_s
       loc = node_loc(node)
       comments = node_comments(node)

--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -70,7 +70,7 @@ module RBI
     private
 
     sig { params(node: AST::Node).returns(String) }
-    def visit_name(node)
+    def parse_name(node)
       T.must(ConstBuilder.visit(node))
     end
 
@@ -139,10 +139,10 @@ module RBI
 
       scope = case node.type
       when :module
-        name = visit_name(node.children[0])
+        name = parse_name(node.children[0])
         Module.new(name, loc: loc, comments: comments)
       when :class
-        name = visit_name(node.children[0])
+        name = parse_name(node.children[0])
         superclass_name = ConstBuilder.visit(node.children[1])
         Class.new(name, superclass_name: superclass_name, loc: loc, comments: comments)
       when :sclass
@@ -159,8 +159,8 @@ module RBI
 
     sig { params(node: AST::Node).void }
     def visit_const_assign(node)
-      name = visit_name(node)
       value = visit_expr(node.children[2])
+      name = parse_name(node)
       loc = node_loc(node)
       comments = node_comments(node)
 
@@ -240,15 +240,15 @@ module RBI
         symbols = node.children[2..-1].map { |child| child.children[0] }
         AttrAccessor.new(*symbols, sigs: current_sigs, loc: loc, comments: comments)
       when :include
-        names = node.children[2..-1].map { |child| visit_name(child) }
+        names = node.children[2..-1].map { |child| parse_name(child) }
         Include.new(*names, loc: loc, comments: comments)
       when :extend
-        names = node.children[2..-1].map { |child| visit_name(child) }
+        names = node.children[2..-1].map { |child| parse_name(child) }
         Extend.new(*names, loc: loc, comments: comments)
       when :abstract!, :sealed!, :interface!
         Helper.new(method_name.to_s.delete_suffix("!"), loc: loc, comments: comments)
       when :mixes_in_class_methods
-        names = node.children[2..-1].map { |child| visit_name(child) }
+        names = node.children[2..-1].map { |child| parse_name(child) }
         MixesInClassMethods.new(*names, loc: loc, comments: comments)
       when :public, :protected, :private
         Visibility.new(method_name, loc: loc)
@@ -304,7 +304,7 @@ module RBI
     def visit_enum(node)
       enum = TEnumBlock.new
       node.children[2].children.each do |child|
-        enum << visit_name(child)
+        enum << parse_name(child)
       end
       enum.loc = node_loc(node)
       enum

--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -112,7 +112,7 @@ module RBI
         visit_all(node.children)
         @scopes_stack.pop
       when :casgn
-        visit_const_assign(node)
+        current_scope << parse_const_assign(node)
       when :def, :defs
         visit_def(node)
       when :send
@@ -156,14 +156,14 @@ module RBI
       end
     end
 
-    sig { params(node: AST::Node).void }
-    def visit_const_assign(node)
+    sig { params(node: AST::Node).returns(Const) }
+    def parse_const_assign(node)
       name = parse_name(node)
       value = parse_expr(node.children[2])
       loc = node_loc(node)
       comments = node_comments(node)
 
-      current_scope << Const.new(name, value, loc: loc, comments: comments)
+      Const.new(name, value, loc: loc, comments: comments)
     end
 
     sig { params(node: AST::Node).void }


### PR DESCRIPTION
Make it easier to parse nodes:
* Every method that parses a node returns it instead of adding it to the current scope
* Every method that returns a node is called `parse_*`

No functional change, only renaming and changing return types.