### PR TITLE
Allow automatic conflict resolution on merges

### DIFF
--- a/test/rbi/rewriters/merge_trees_test.rb
+++ b/test/rbi/rewriters/merge_trees_test.rb
@@ -877,5 +877,105 @@ module RBI
         Conflicting definitions for `::B`
       STR
     end
+
+    def test_merge_keep_left
+      rbi1 = RBI::Parser.parse_string(<<~RBI)
+        module Foo
+          A = 10
+
+          class Bar
+            def m1; end
+
+            sig { void }
+            def m2; end
+
+            def m3; end
+          end
+        end
+      RBI
+
+      rbi2 = RBI::Parser.parse_string(<<~RBI)
+        module Foo
+          A = 42
+
+          module Bar
+            def m1(x); end
+
+            sig { returns(Integer) }
+            def m2; end
+
+            def m4; end
+          end
+        end
+      RBI
+
+      res = Rewriters::Merge.merge_trees(rbi1, rbi2, keep: Rewriters::Merge::Keep::LEFT)
+
+      assert_equal(<<~RBI, res.string)
+        module Foo
+          A = 10
+
+          class Bar
+            def m1; end
+
+            sig { void }
+            def m2; end
+
+            def m3; end
+            def m4; end
+          end
+        end
+      RBI
+    end
+
+    def test_merge_keep_right
+      rbi1 = RBI::Parser.parse_string(<<~RBI)
+        module Foo
+          A = 10
+
+          class Bar
+            def m1; end
+
+            sig { void }
+            def m2; end
+
+            def m3; end
+          end
+        end
+      RBI
+
+      rbi2 = RBI::Parser.parse_string(<<~RBI)
+        module Foo
+          A = 42
+
+          module Bar
+            def m1(x); end
+
+            sig { returns(Integer) }
+            def m2; end
+
+            def m4; end
+          end
+        end
+      RBI
+
+      res = Rewriters::Merge.merge_trees(rbi1, rbi2, keep: Rewriters::Merge::Keep::RIGHT)
+
+      assert_equal(<<~RBI, res.string)
+        module Foo
+          A = 42
+
+          module Bar
+            def m1(x); end
+
+            sig { returns(Integer) }
+            def m2; end
+
+            def m3; end
+            def m4; end
+          end
+        end
+      RBI
+    end
   end
 end


### PR DESCRIPTION
Add options to the merge rewriter so conflicts can be automatically resolved:

No automatic resolution:

```rb
left = RBI::Parser.parse_string(<<~RBI)
  module Foo
    A = 10

    class Bar
      def m1; end

      sig { void }
      def m2; end

      def m3; end
    end
  end
RBI

right = RBI::Parser.parse_string(<<~RBI)
  module Foo
    A = 42

    module Bar
      def m1(x); end

      sig { returns(Integer) }
      def m2; end

      def m4; end
    end
  end
RBI

res = Rewriters::Merge.merge_trees(left, right)

assert_equal(<<~RBI, res.string)
  module Foo
    <<<<<<< left
    A = 10
    =======
    A = 42
    >>>>>>> right

    <<<<<<< left
    class Bar
    =======
    module Bar
    >>>>>>> right
      <<<<<<< left
      def m1; end
      =======
      def m1(x); end
      >>>>>>> right
      <<<<<<< left
      sig { void }
      def m2; end
      =======
      sig { returns(Integer) }
      def m2; end
      >>>>>>> right
      def m3; end
      def m4; end
    end
  end
RBI
```

Resolve on keeping `left` definitions:

```rb
left = RBI::Parser.parse_string(<<~RBI)
  module Foo
    A = 10

    class Bar
      def m1; end

      sig { void }
      def m2; end

      def m3; end
    end
  end
RBI

right = RBI::Parser.parse_string(<<~RBI)
  module Foo
    A = 42

    module Bar
      def m1(x); end

      sig { returns(Integer) }
      def m2; end

      def m4; end
    end
  end
RBI

res = Rewriters::Merge.merge_trees(left, right, keep: Rewriters::Merge::Keep::LEFT)

assert_equal(<<~RBI, res.string)
  module Foo
    A = 10

    class Bar
      def m1; end

      sig { void }
      def m2; end

      def m3; end
      def m4; end
    end
  end
RBI
```

Resolve on keeping `right` definitions:

```rb
left = RBI::Parser.parse_string(<<~RBI)
  module Foo
    A = 10

    class Bar
      def m1; end

      sig { void }
      def m2; end

      def m3; end
    end
  end
RBI

right = RBI::Parser.parse_string(<<~RBI)
  module Foo
    A = 42

    module Bar
      def m1(x); end

      sig { returns(Integer) }
      def m2; end

      def m4; end
    end
  end
RBI

res = Rewriters::Merge.merge_trees(left, right, keep: Rewriters::Merge::Keep::RIGHT)

assert_equal(<<~RBI, res.string)
  module Foo
    A = 42

    module Bar
      def m1(x); end

      sig { returns(Integer) }
      def m2; end

      def m3; end
      def m4; end
    end
  end
RBI
```