### PR TITLE
Nest singleton methods before merging

### DIFF
--- a/lib/rbi/rewriters/merge_trees.rb
+++ b/lib/rbi/rewriters/merge_trees.rb
@@ -49,6 +49,8 @@ module RBI
 
       sig { params(left: Tree, right: Tree, left_name: String, right_name: String, keep: Keep).returns(Tree) }
       def self.merge_trees(left, right, left_name: "left", right_name: "right", keep: Keep::NONE)
+        left.nest_singleton_methods!
+        right.nest_singleton_methods!
         rewriter = Rewriters::Merge.new(left_name: left_name, right_name: right_name, keep: keep)
         rewriter.merge(left)
         rewriter.merge(right)


### PR DESCRIPTION
Working on [this](https://github.com/Shopify/tapioca/issues/139) issue in Tapioca, I found that singleton methods don't merge properly when they have different notations: `def self.foo; end` vs `class << self`. 

calling `nest_singleton_methods!` before merging, fixes this issue.

For tests, I added tests in merge_trees.rb