### PR TITLE
Allow inserting arbitrary blank lines in trees and comments

### DIFF
--- a/lib/rbi/model.rb
+++ b/lib/rbi/model.rb
@@ -66,7 +66,8 @@ module RBI
     end
   end
 
-  class EmptyComment < Comment
+  # An arbitrary blank line that can be added both in trees and comments
+  class BlankLine < Comment
     extend T::Sig
 
     sig { params(loc: T.nilable(Loc)).void }

--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -178,7 +178,7 @@ module RBI
 
         if last_line && comment_line > last_line + 1
           # Preserve empty lines in file headers
-          tree.comments << EmptyComment.new(loc: loc)
+          tree.comments << BlankLine.new(loc: loc)
         end
 
         tree.comments << Comment.new(text, loc: loc)

--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -140,6 +140,7 @@ module RBI
     def print_blank_line_before(v)
       previous_node = v.previous_node
       return unless previous_node
+      return if previous_node.is_a?(BlankLine)
       return if previous_node.oneline? && oneline?
       v.printn
     end
@@ -179,7 +180,7 @@ module RBI
     end
   end
 
-  class EmptyComment
+  class BlankLine
     extend T::Sig
 
     sig { override.params(v: Printer).void }

--- a/test/rbi/printer_test.rb
+++ b/test/rbi/printer_test.rb
@@ -744,6 +744,54 @@ module RBI
       RBI
     end
 
+    def test_print_blank_lines
+      comments = [
+        RBI::Comment.new("comment 1"),
+        BlankLine.new,
+        RBI::Comment.new("comment 2"),
+      ]
+
+      rbi = Module.new("Foo", comments: comments) do |mod|
+        mod << BlankLine.new
+        mod << RBI::Method.new("foo")
+        mod << BlankLine.new
+        mod << BlankLine.new
+        mod << BlankLine.new
+
+        mod << Class.new("Bar") do |cls|
+          cls << RBI::Comment.new("begin")
+          cls << BlankLine.new
+          cls << BlankLine.new
+          cls << RBI::Comment.new("middle")
+          cls << BlankLine.new
+          cls << BlankLine.new
+          cls << RBI::Comment.new("end")
+        end
+      end
+
+      assert_equal(<<~RBI, rbi.string)
+        # comment 1
+
+        # comment 2
+        module Foo
+
+          def foo; end
+
+
+
+          class Bar
+            # begin
+
+
+            # middle
+
+
+            # end
+          end
+        end
+      RBI
+    end
+
     def test_print_new_lines_between_scopes
       rbi = RBI::Tree.new
       scope = RBI::Class.new("Bar")


### PR DESCRIPTION
So we can manually force some spacing when needed.

The first commit factorize the way we print the leading empty line for each node.