### PR TITLE
Allow replacing `File#root`

### DIFF
--- a/lib/rbi/model.rb
+++ b/lib/rbi/model.rb
@@ -136,7 +136,7 @@ module RBI
     attr_accessor :root
 
     sig { returns(T.nilable(String)) }
-    attr_reader :strictness
+    attr_accessor :strictness
 
     sig { returns(T::Array[Comment]) }
     attr_accessor :comments


### PR DESCRIPTION
There is no real/valid reason to forbid changing the `File#root` or `File#strictness` if the user needs to do it.