### PR TITLE
Clean merging rewriter API

### DIFF
--- a/lib/rbi/rewriters/merge_trees.rb
+++ b/lib/rbi/rewriters/merge_trees.rb
@@ -314,9 +314,9 @@ module RBI
   class Tree
     extend T::Sig
 
-    sig { params(other: Tree).returns(MergeTree) }
-    def merge(other)
-      Rewriters::Merge.merge_trees(self, other)
+    sig { params(other: Tree, left_name: String, right_name: String, keep: Rewriters::Merge::Keep).returns(MergeTree) }
+    def merge(other, left_name: "left", right_name: "right", keep: Rewriters::Merge::Keep::NONE)
+      Rewriters::Merge.merge_trees(self, other, left_name: left_name, right_name: right_name, keep: keep)
     end
   end
 

--- a/test/rbi/rewriters/merge_trees_test.rb
+++ b/test/rbi/rewriters/merge_trees_test.rb
@@ -908,7 +908,7 @@ module RBI
         end
       RBI
 
-      res = Rewriters::Merge.merge_trees(rbi1, rbi2, keep: Rewriters::Merge::Keep::LEFT)
+      res = rbi1.merge(rbi2, keep: Rewriters::Merge::Keep::LEFT)
 
       assert_equal(<<~RBI, res.string)
         module Foo
@@ -958,7 +958,7 @@ module RBI
         end
       RBI
 
-      res = Rewriters::Merge.merge_trees(rbi1, rbi2, keep: Rewriters::Merge::Keep::RIGHT)
+      res = rbi1.merge(rbi2, keep: Rewriters::Merge::Keep::RIGHT)
 
       assert_equal(<<~RBI, res.string)
         module Foo
@@ -998,7 +998,7 @@ module RBI
         end
       RBI
 
-      res = Rewriters::Merge.merge_trees(rbi1, rbi2, keep: Rewriters::Merge::Keep::RIGHT)
+      res = rbi1.merge(rbi2, keep: Rewriters::Merge::Keep::RIGHT)
 
       assert_equal(<<~RBI, res.string)
         module Foo
@@ -1033,7 +1033,7 @@ module RBI
         end
       RBI
 
-      res = Rewriters::Merge.merge_trees(rbi1, rbi2, keep: Rewriters::Merge::Keep::RIGHT)
+      res = rbi1.merge(rbi2, keep: Rewriters::Merge::Keep::RIGHT)
 
       assert_equal(<<~RBI, res.string)
         module Foo


### PR DESCRIPTION
Make it easier to use the merge rewriter API:

1. Merge options can be passed directly to `Tree#merge`
2. Return a `TreeAndConflicts` node instead of a bare `Tree` so the conflicts are stored in the return

The plumbing doesn't change and code currently using it shouldn't be affected.