### PR TITLE
Change to released tapioca dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,4 @@ group(:development, :test) do
   gem("rubocop-shopify", require: false)
   gem("rubocop-sorbet", require: false)
   gem("sorbet", ">= 0.5.9204", require: false)
-  gem("tapioca", require: false, github: "Shopify/tapioca", branch: "master")
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,3 @@
-GIT
-  remote: https://github.com/Shopify/tapioca.git
-  revision: faf5ee6abc3a925327c4d00e1081306710757126
-  branch: master
-  specs:
-    tapioca (0.4.23)
-      bundler (>= 1.17.3)
-      parlour (>= 2.1.0)
-      pry (>= 0.12.2)
-      sorbet-runtime
-      sorbet-static (>= 0.4.4471)
-      spoom
-      thor (>= 0.19.2)
-      unparser
-
 PATH
   remote: .
   specs:
@@ -29,18 +14,10 @@ GEM
     byebug (11.1.3)
     coderay (1.1.3)
     colorize (0.8.1)
-    commander (4.6.0)
-      highline (~> 2.0.0)
     diff-lcs (1.4.4)
-    highline (2.0.3)
     method_source (1.0.0)
     minitest (5.14.4)
     parallel (1.20.1)
-    parlour (6.0.1)
-      commander (~> 4.5)
-      parser
-      rainbow (~> 3.0)
-      sorbet-runtime (>= 0.5)
     parser (3.0.1.1)
       ast (~> 2.4.1)
     pry (0.14.1)
@@ -72,11 +49,20 @@ GEM
     sorbet-static (0.5.9204-universal-darwin-19)
     sorbet-static (0.5.9204-universal-darwin-20)
     sorbet-static (0.5.9204-x86_64-linux)
-    spoom (1.1.1)
+    spoom (1.1.4)
       colorize
-      sorbet (>= 0.5.6347)
-      sorbet-runtime
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
       thor (>= 0.19.2)
+    tapioca (0.5.2)
+      bundler (>= 1.17.3)
+      pry (>= 0.12.2)
+      rbi
+      sorbet-runtime
+      sorbet-static (>= 0.4.4471)
+      spoom
+      thor (>= 0.19.2)
+      unparser
     thor (1.1.0)
     unicode-display_width (2.0.0)
     unparser (0.6.0)
@@ -97,7 +83,7 @@ DEPENDENCIES
   rubocop-shopify
   rubocop-sorbet
   sorbet (>= 0.5.9204)
-  tapioca!
+  tapioca (~> 0.5.2)
 
 BUNDLED WITH
-   2.2.22
+   2.2.29

--- a/rbi.gemspec
+++ b/rbi.gemspec
@@ -28,4 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency("parser")
   spec.add_dependency("sorbet-runtime", ">= 0.5.9204")
   spec.add_dependency("unparser")
+
+  spec.add_development_dependency("tapioca", "~> 0.5.2")
 end


### PR DESCRIPTION
* The previous tapioca release referenced, via Gemfile.lock was 7 month old.
* It referenced the since deleted `master` branch.
* `bundle update` or similar operations would fail as the `master`
  refname cannot be resolved anymore.
* Changing to a `main` git reference alternative was dismissed as it
  looks like `tapioca` is more stable meanwhile and we should not
  reference a git repository unless we have a good reason.