### PR TITLE
Add mutant setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,4 @@ group(:development, :test) do
   gem("rubocop-shopify", require: false)
   gem("rubocop-sorbet", require: false)
   gem("sorbet", ">= 0.5.9204", require: false)
-  gem("tapioca", require: false, github: "Shopify/tapioca", branch: "master")
 end

--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,9 @@ group(:development, :test) do
   gem("rubocop-shopify", require: false)
   gem("rubocop-sorbet", require: false)
   gem("sorbet", ">= 0.5.9204", require: false)
+
+  gem(
+    "mutant-license",
+    source: "https://oss:aIXdNDSSxs7ciqSM0yCrqkAM4lqoTzA6@gem.mutant.dev"
+  )
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,3 @@
-GIT
-  remote: https://github.com/Shopify/tapioca.git
-  revision: faf5ee6abc3a925327c4d00e1081306710757126
-  branch: master
-  specs:
-    tapioca (0.4.23)
-      bundler (>= 1.17.3)
-      parlour (>= 2.1.0)
-      pry (>= 0.12.2)
-      sorbet-runtime
-      sorbet-static (>= 0.4.4471)
-      spoom
-      thor (>= 0.19.2)
-      unparser
-
 PATH
   remote: .
   specs:
@@ -27,25 +12,11 @@ GEM
   specs:
     ast (2.4.2)
     byebug (11.1.3)
-    coderay (1.1.3)
-    colorize (0.8.1)
-    commander (4.6.0)
-      highline (~> 2.0.0)
     diff-lcs (1.4.4)
-    highline (2.0.3)
-    method_source (1.0.0)
     minitest (5.14.4)
     parallel (1.20.1)
-    parlour (6.0.1)
-      commander (~> 4.5)
-      parser
-      rainbow (~> 3.0)
-      sorbet-runtime (>= 0.5)
     parser (3.0.1.1)
       ast (~> 2.4.1)
-    pry (0.14.1)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
     rainbow (3.0.0)
     rake (13.0.6)
     regexp_parser (2.1.1)
@@ -72,12 +43,6 @@ GEM
     sorbet-static (0.5.9204-universal-darwin-19)
     sorbet-static (0.5.9204-universal-darwin-20)
     sorbet-static (0.5.9204-x86_64-linux)
-    spoom (1.1.1)
-      colorize
-      sorbet (>= 0.5.6347)
-      sorbet-runtime
-      thor (>= 0.19.2)
-    thor (1.1.0)
     unicode-display_width (2.0.0)
     unparser (0.6.0)
       diff-lcs (~> 1.3)
@@ -97,7 +62,6 @@ DEPENDENCIES
   rubocop-shopify
   rubocop-sorbet
   sorbet (>= 0.5.9204)
-  tapioca!
 
 BUNDLED WITH
-   2.2.22
+   2.2.29

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,14 +8,28 @@ PATH
       unparser
 
 GEM
+  remote: https://oss:aIXdNDSSxs7ciqSM0yCrqkAM4lqoTzA6@gem.mutant.dev/
+  specs:
+    mutant-license (0.1.1.2.1310633056264669049025896512792929666012.1)
+
+GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
     byebug (11.1.3)
     diff-lcs (1.4.4)
     minitest (5.14.4)
+    mutant (0.11.0)
+      diff-lcs (~> 1.3)
+      parser (~> 3.0.0)
+      regexp_parser (~> 2.0, >= 2.0.3)
+      sorbet-runtime (~> 0.5.0)
+      unparser (~> 0.6.0)
+    mutant-minitest (0.11.0)
+      minitest (~> 5.11)
+      mutant (= 0.11.0)
     parallel (1.20.1)
-    parser (3.0.1.1)
+    parser (3.0.2.0)
       ast (~> 2.4.1)
     rainbow (3.0.0)
     rake (13.0.6)
@@ -56,6 +70,8 @@ PLATFORMS
 DEPENDENCIES
   byebug
   minitest
+  mutant-license!
+  mutant-minitest (~> 0.11.0)
   rake (~> 13.0)
   rbi!
   rubocop (~> 1.7)

--- a/mutant.yml
+++ b/mutant.yml
@@ -1,0 +1,9 @@
+integration: minitest
+includes:
+- lib
+- test
+requires:
+- rbi
+matcher:
+  subjects:
+  - 'RBI*'

--- a/rbi.gemspec
+++ b/rbi.gemspec
@@ -28,4 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency("parser")
   spec.add_dependency("sorbet-runtime", ">= 0.5.9204")
   spec.add_dependency("unparser")
+
+  spec.add_development_dependency("mutant-minitest", "~> 0.11.0")
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,14 @@
 
 $LOAD_PATH.unshift(File.expand_path("../../lib", __FILE__))
 
+# Tag all test classes as covering all subjects.
+# Just a WIP state, not the final solution.
+#
+# This is a very primitive but also very effective initial setup.
+class MiniTest::Test
+  cover "RBI*"
+end
+
 require "rbi"
 require "minitest/test"
 require "minitest/autorun"


### PR DESCRIPTION
### Depends on: 

*  ~~https://github.com/Shopify/rbi/pull/92~~
* [ ] #94 

### TODO:

* [x] Pushdown sorbet detection to restore source locations. Done in `mutant-0.11.0` release.
* [x] Figure out why lots of subjects such as `RBI::Visitor` and its descendants do not yield any subjects. Done in `mutant-0.11.0` release.
* [ ] Setup basic test selection.
* [ ] Hook up type checks prior to test runs, allowing mutation coverage via type check failures.

### Howto

Take this with a grain of salt, as until the TODOs above are solved a "out of the box" experience on a "sorbet infected" (not meant in a negative way) code base is off the norm.

* Checkout this branch.
* Run `bundle exec mutant run` to see some uncovered mutations. 