### PR TITLE
Promote Index#index as meaningful API service

### DIFF
--- a/lib/rbi/index.rb
+++ b/lib/rbi/index.rb
@@ -29,6 +29,11 @@ module RBI
       @index[id] ||= []
     end
 
+    sig { params(nodes: Node).void }
+    def index(*nodes)
+      nodes.each { |node| visit(node) }
+    end
+
     sig { override.params(node: T.nilable(Node)).void }
     def visit(node)
       return unless node

--- a/lib/rbi/rewriters/merge_trees.rb
+++ b/lib/rbi/rewriters/merge_trees.rb
@@ -203,7 +203,7 @@ module RBI
           left.nodes.each do |node|
             right_copy << node
           end
-          @index.visit(right_copy)
+          @index.index(right_copy)
           right_copy
         end
       end


### PR DESCRIPTION
### Problem

When building an index I kept calling `Index#index` as if this method is the right one to index a node while I should be calling `Index#visit`.

While `visit` makes sense since the `Index` is basically a `Visitor`, I would like to be able to use `index` for the sake of understanding and readability.

Problem is `index` was actually an internal method (that should have been private).

### Solution

1. Make the old `index` private
2. Rename it into `index_node`
3. Add a public `index` method that delegates to `visit`
