### PR TITLE
Update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,7 @@ GEM
     sorbet-runtime (0.5.9204)
     sorbet-static (0.5.9204-universal-darwin-19)
     sorbet-static (0.5.9204-universal-darwin-20)
+    sorbet-static (0.5.9204-universal-darwin-21)
     sorbet-static (0.5.9204-x86_64-linux)
     spoom (1.1.5)
       sorbet (>= 0.5.9204)
@@ -75,9 +76,7 @@ GEM
       parser (>= 3.0.0)
 
 PLATFORMS
-  x86_64-darwin-19
-  x86_64-darwin-20
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   byebug
@@ -92,4 +91,4 @@ DEPENDENCIES
   tapioca (= 0.5.2)
 
 BUNDLED WITH
-   2.2.22
+   2.2.28


### PR DESCRIPTION
Update Bundler version and platform to match the ones used in https://github.com/Shopify/tapioca/blob/main/Gemfile.lock.