### PR TITLE
Support `class_attributes` nodes in RBI files

### DIFF
--- a/lib/rbi/index.rb
+++ b/lib/rbi/index.rb
@@ -161,6 +161,16 @@ module RBI
     end
   end
 
+  class Send
+    extend T::Sig
+    include Indexable
+
+    sig { override.returns(T::Array[String]) }
+    def index_ids
+      ["#{parent_scope&.fully_qualified_name}.#{method}"]
+    end
+  end
+
   class TStructConst
     extend T::Sig
     include Indexable

--- a/lib/rbi/model.rb
+++ b/lib/rbi/model.rb
@@ -914,6 +914,106 @@ module RBI
     end
   end
 
+  # Sends
+
+  class Send < NodeWithComments
+    extend T::Sig
+
+    sig { returns(String) }
+    attr_reader :method
+
+    sig { returns(T::Array[Arg]) }
+    attr_reader :args
+
+    sig do
+      params(
+        method: String,
+        args: T::Array[Arg],
+        loc: T.nilable(Loc),
+        comments: T::Array[Comment],
+        block: T.nilable(T.proc.params(node: Send).void)
+      ).void
+    end
+    def initialize(method, args = [], loc: nil, comments: [], &block)
+      super(loc: loc, comments: comments)
+      @method = method
+      @args = args
+      block&.call(self)
+    end
+
+    sig { params(arg: Arg).void }
+    def <<(arg)
+      @args << arg
+    end
+
+    sig { params(other: T.nilable(Object)).returns(T::Boolean) }
+    def ==(other)
+      Send === other && method == other.method && args == other.args
+    end
+
+    sig { returns(String) }
+    def to_s
+      "#{parent_scope&.fully_qualified_name}.#{method}(#{args.join(", ")})"
+    end
+  end
+
+  class Arg < Node
+    extend T::Sig
+
+    sig { returns(String) }
+    attr_reader :value
+
+    sig do
+      params(
+        value: String,
+        loc: T.nilable(Loc)
+      ).void
+    end
+    def initialize(value, loc: nil)
+      super(loc: loc)
+      @value = value
+    end
+
+    sig { params(other: T.nilable(Object)).returns(T::Boolean) }
+    def ==(other)
+      Arg === other && value == other.value
+    end
+
+    sig { returns(String) }
+    def to_s
+      value
+    end
+  end
+
+  class KwArg < Arg
+    extend T::Sig
+
+    sig { returns(String) }
+    attr_reader :keyword
+
+    sig do
+      params(
+        keyword: String,
+        value: String,
+        loc: T.nilable(Loc)
+      ).void
+    end
+    def initialize(keyword, value, loc: nil)
+      super(value, loc: loc)
+      @keyword = keyword
+    end
+
+    sig { params(other: T.nilable(Object)).returns(T::Boolean) }
+    def ==(other)
+      KwArg === other && value == other.value && keyword == other.keyword
+    end
+
+    sig { returns(String) }
+    def to_s
+      "#{keyword}: #{value}"
+    end
+  end
+
   # Sorbet's sigs
 
   class Sig < Node

--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -555,6 +555,47 @@ module RBI
     end
   end
 
+  class Send
+    extend T::Sig
+
+    sig { override.params(v: Printer).void }
+    def accept_printer(v)
+      print_blank_line_before(v)
+
+      v.printl("# #{loc}") if loc && v.print_locs
+      v.visit_all(comments)
+      v.printt(method)
+      unless args.empty?
+        v.print(" ")
+        args.each_with_index do |arg, index|
+          v.visit(arg)
+          v.print(", ") if index < args.size - 1
+        end
+      end
+      v.printn
+    end
+  end
+
+  class Arg
+    extend T::Sig
+
+    sig { override.params(v: Printer).void }
+    def accept_printer(v)
+      v.print(value)
+    end
+  end
+
+  class KwArg
+    extend T::Sig
+
+    sig { override.params(v: Printer).void }
+    def accept_printer(v)
+      v.print(keyword)
+      v.print(": ")
+      v.print(value)
+    end
+  end
+
   class Sig
     extend T::Sig
 

--- a/lib/rbi/rewriters/group_nodes.rb
+++ b/lib/rbi/rewriters/group_nodes.rb
@@ -55,6 +55,8 @@ module RBI
         Group::Kind::TypeMembers
       when MixesInClassMethods
         Group::Kind::MixesInClassMethods
+      when Send
+        Group::Kind::Sends
       when TStructField
         Group::Kind::TStructFields
       when TEnumBlock
@@ -95,6 +97,7 @@ module RBI
         Helpers             = new
         TypeMembers         = new
         MixesInClassMethods = new
+        Sends               = new
         TStructFields       = new
         TEnums              = new
         Inits               = new

--- a/lib/rbi/rewriters/merge_trees.rb
+++ b/lib/rbi/rewriters/merge_trees.rb
@@ -512,6 +512,15 @@ module RBI
     end
   end
 
+  class Send
+    extend T::Sig
+
+    sig { override.params(other: Node).returns(T::Boolean) }
+    def compatible_with?(other)
+      other.is_a?(Send) && method == other.method && args == other.args
+    end
+  end
+
   class TStructField
     extend T::Sig
 

--- a/lib/rbi/rewriters/sort_nodes.rb
+++ b/lib/rbi/rewriters/sort_nodes.rb
@@ -35,20 +35,21 @@ module RBI
         when Helper               then 20
         when TypeMember           then 30
         when MixesInClassMethods  then 40
-        when TStructField         then 50
-        when TEnumBlock           then 60
+        when Send                 then 50
+        when TStructField         then 60
+        when TEnumBlock           then 70
         when Method
           if node.name == "initialize"
-            71
+            81
           elsif !node.is_singleton
-            72
+            82
           else
-            73
+            83
           end
-        when SingletonClass       then 80
-        when Scope, Const         then 90
+        when SingletonClass       then 90
+        when Scope, Const         then 100
         else
-          100
+          110
         end
       end
 
@@ -59,12 +60,13 @@ module RBI
         when Group::Kind::Helpers             then 1
         when Group::Kind::TypeMembers         then 2
         when Group::Kind::MixesInClassMethods then 3
-        when Group::Kind::TStructFields       then 4
-        when Group::Kind::TEnums              then 5
-        when Group::Kind::Inits               then 6
-        when Group::Kind::Methods             then 7
-        when Group::Kind::SingletonClasses    then 8
-        when Group::Kind::Consts              then 9
+        when Group::Kind::Sends               then 5
+        when Group::Kind::TStructFields       then 6
+        when Group::Kind::TEnums              then 7
+        when Group::Kind::Inits               then 8
+        when Group::Kind::Methods             then 9
+        when Group::Kind::SingletonClasses    then 10
+        when Group::Kind::Consts              then 11
         else
           T.absurd(kind)
         end

--- a/test/rbi/index_test.rb
+++ b/test/rbi/index_test.rb
@@ -47,12 +47,13 @@ module RBI
           include A, B
           extend T::Sig
           abstract!
+          foo :bar, baz: "baz"
         end
       RBI
 
       index_string = index_string(rbi.index)
       assert_equal(<<~IDX, index_string)
-        ::A: -:1:0-9:3
+        ::A: -:1:0-10:3
         ::A#a: -:2:2-2:20
         ::A#a=: -:3:2-3:20
         ::A#b: -:2:2-2:20
@@ -62,6 +63,7 @@ module RBI
         ::A#foo: -:5:2-5:17
         ::A.abstract!: -:8:2-8:11
         ::A.extend(T::Sig): -:7:2-7:15
+        ::A.foo: -:9:2-9:22
         ::A.include(A): -:6:2-6:14
         ::A.include(B): -:6:2-6:14
       IDX

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -242,6 +242,18 @@ module RBI
       assert_equal("-:1:0-2:14", tree.loc.to_s)
     end
 
+    def test_parse_arbitrary_sends
+      rbi = <<~RBI
+        class ActiveRecord::Base
+          class_attribute :typed_stores, :store_accessors, instance_accessor: false, default: "Foo"
+          foo bar, "bar", :bar
+        end
+      RBI
+
+      out = RBI::Parser.parse_string(rbi)
+      assert_equal(rbi, out.string)
+    end
+
     def test_parse_scopes_locations
       rbi = <<~RBI
         module Foo; end
@@ -770,14 +782,6 @@ module RBI
       end
       assert_equal("unexpected token $end", e.message)
       assert_equal("-:2:0-2:0", e.location.to_s)
-
-      e = assert_raises(RBI::ParseError) do
-        RBI::Parser.parse_string(<<~RBI)
-          foo
-        RBI
-      end
-      assert_equal("Unsupported send node with name `foo`", e.message)
-      assert_equal("-:1:0-1:3", e.location.to_s)
 
       e = assert_raises(RBI::ParseError) do
         RBI::Parser.parse_string(<<~RBI)

--- a/test/rbi/printer_test.rb
+++ b/test/rbi/printer_test.rb
@@ -253,6 +253,26 @@ module RBI
       RBI
     end
 
+    def test_print_sends
+      tree = RBI::Tree.new
+      tree << RBI::Send.new("class_attribute")
+      tree << RBI::Send.new("class_attribute") do |send|
+        send << RBI::Arg.new(":foo")
+      end
+      tree << RBI::Send.new("class_attribute") do |send|
+        send << RBI::Arg.new(":foo")
+        send << RBI::Arg.new(":bar")
+        send << RBI::KwArg.new("instance_accessor", "false")
+        send << RBI::KwArg.new("default", "\"Bar\"")
+      end
+
+      assert_equal(<<~RBI, tree.string)
+        class_attribute
+        class_attribute :foo
+        class_attribute :foo, :bar, instance_accessor: false, default: "Bar"
+      RBI
+    end
+
     def test_print_t_structs
       struct = RBI::TStruct.new("Foo")
       struct << RBI::TStructConst.new("a", "A")
@@ -377,6 +397,8 @@ module RBI
       rbi << RBI::Protected.new(comments: comments_single)
       rbi << RBI::Private.new(comments: comments_single)
 
+      rbi << RBI::Send.new("foo", comments: comments_single)
+
       struct = RBI::TStruct.new("Foo", comments: comments_single)
       struct << RBI::TStructConst.new("a", "A", comments: comments_multi)
       struct << RBI::TStructProp.new("c", "C", comments: comments_single)
@@ -421,6 +443,9 @@ module RBI
 
         # This is a single line comment
         private
+
+        # This is a single line comment
+        foo
 
         # This is a single line comment
         class Foo < ::T::Struct
@@ -870,6 +895,7 @@ module RBI
       rbi << RBI::Const.new("C", "42", loc: loc)
       rbi << RBI::Extend.new("E", loc: loc)
       rbi << RBI::Include.new("I", loc: loc)
+      rbi << RBI::Send.new("foo", loc: loc)
       rbi << RBI::MixesInClassMethods.new("MICM", loc: loc)
       rbi << RBI::Helper.new("abstract", loc: loc)
       rbi << RBI::TStructConst.new("SC", "Type", loc: loc)
@@ -893,6 +919,8 @@ module RBI
         extend E
         # file.rbi:1:3-2:4
         include I
+        # file.rbi:1:3-2:4
+        foo
         # file.rbi:1:3-2:4
         mixes_in_class_methods MICM
         # file.rbi:1:3-2:4

--- a/test/rbi/rewriters/group_nodes_test.rb
+++ b/test/rbi/rewriters/group_nodes_test.rb
@@ -22,6 +22,7 @@ module RBI
       rbi << RBI::TEnum.new("TE")
       rbi << RBI::SingletonClass.new
       rbi << RBI::TStruct.new("TS")
+      rbi << RBI::Send.new("foo")
 
       rbi.group_nodes!
       rbi.sort_nodes!
@@ -33,6 +34,8 @@ module RBI
         h!
 
         mixes_in_class_methods MICM
+
+        foo
 
         const :SC, Type
         prop :SP, Type
@@ -58,6 +61,7 @@ module RBI
       scope1 << RBI::Include.new("I1")
       scope1 << RBI::Method.new("m1")
       scope1 << RBI::Method.new("m2")
+      scope1 << RBI::Send.new("foo")
 
       scope2 = RBI::Module.new("Scope2")
       scope2 << RBI::Const.new("C1", "42")
@@ -80,6 +84,8 @@ module RBI
       assert_equal(<<~RBI, rbi.string)
         class Scope1
           include I1
+
+          foo
 
           def m1; end
           def m2; end
@@ -119,6 +125,7 @@ module RBI
       rbi << RBI::TStructProp.new("SP", "Type")
       rbi << RBI::TEnum.new("TE")
       rbi << RBI::TStruct.new("TS")
+      rbi << RBI::Send.new("foo")
 
       rbi.group_nodes!
       rbi.sort_nodes!
@@ -130,6 +137,8 @@ module RBI
         h!
 
         mixes_in_class_methods MICM
+
+        foo
 
         const :SC, Type
         prop :SP, Type
@@ -171,6 +180,24 @@ module RBI
       RBI
     end
 
+    def test_group_does_not_sort_sends
+      rbi = RBI::Tree.new
+      rbi << RBI::Send.new("send4")
+      rbi << RBI::Send.new("send2")
+      rbi << RBI::Send.new("send3")
+      rbi << RBI::Send.new("send1")
+
+      rbi.group_nodes!
+      rbi.sort_nodes!
+
+      assert_equal(<<~RBI, rbi.string)
+        send4
+        send2
+        send3
+        send1
+      RBI
+    end
+
     def test_group_does_not_sort_type_members
       rbi = RBI::Tree.new
       rbi << RBI::TypeMember.new("T4", "type_member")
@@ -209,6 +236,8 @@ module RBI
       scope << RBI::TStruct.new("TS")
       scope << RBI::TypeMember.new("TM2", "type_template")
       scope << RBI::TypeMember.new("TM1", "type_member")
+      scope << RBI::Send.new("send2")
+      scope << RBI::Send.new("send1")
       rbi << scope
 
       rbi.group_nodes!
@@ -225,6 +254,9 @@ module RBI
           TM1 = type_member
 
           mixes_in_class_methods MICM
+
+          send2
+          send1
 
           const :SC, Type
           prop :SP, Type

--- a/test/rbi/rewriters/sort_nodes_test.rb
+++ b/test/rbi/rewriters/sort_nodes_test.rb
@@ -122,7 +122,24 @@ module RBI
       RBI
     end
 
-    def test_sort_helpers
+    def test_does_not_sort_sends
+      rbi = RBI::Tree.new
+      rbi << RBI::Send.new("send4")
+      rbi << RBI::Send.new("send2")
+      rbi << RBI::Send.new("send3")
+      rbi << RBI::Send.new("send1")
+
+      rbi.sort_nodes!
+
+      assert_equal(<<~RBI, rbi.string)
+        send4
+        send2
+        send3
+        send1
+      RBI
+    end
+
+    def test_sort_helpers_test
       rbi = RBI::Tree.new
       rbi << RBI::Helper.new("c")
       rbi << RBI::Helper.new("b")


### PR DESCRIPTION
So we can generate/parse/merge/sort/etc files like this one: https://github.com/Shopify/tapioca/blob/main/sorbet/rbi/shims/activerecord_typedstore.rbi#L8.