### PR TITLE
Add release.yml file

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+changelog:
+  exclude:
+    labels:
+      - dependencies
+    authors:
+      - dependabot
+  categories:
+    - title: 🚧 Breaking Changes
+      labels:
+        - breaking-change
+    - title: ✨ Enhancements
+      labels:
+        - enhancement
+        - feature
+    - title: 🐛 Bug Fixes
+      labels:
+        - bugfix
+    - title: 🛠 Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
Based on https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes.

Not that I really intend to maintain releases notes before v1.0 but at least it gives some guidance on how to use the labels.