### PR TITLE
Fix indeterministic sort order for anonymous nodes

### DIFF
--- a/lib/rbi/rewriters/group_nodes.rb
+++ b/lib/rbi/rewriters/group_nodes.rb
@@ -67,6 +67,8 @@ module RBI
         else
           Group::Kind::Methods
         end
+      when SingletonClass
+        Group::Kind::SingletonClasses
       when Scope, Const
         Group::Kind::Consts
       else
@@ -97,6 +99,7 @@ module RBI
         TEnums              = new
         Inits               = new
         Methods             = new
+        SingletonClasses    = new
         Consts              = new
       end
     end

--- a/lib/rbi/rewriters/sort_nodes.rb
+++ b/lib/rbi/rewriters/sort_nodes.rb
@@ -45,7 +45,8 @@ module RBI
           else
             73
           end
-        when Scope, Const then 80
+        when SingletonClass       then 80
+        when Scope, Const         then 90
         else
           100
         end
@@ -62,7 +63,8 @@ module RBI
         when Group::Kind::TEnums              then 5
         when Group::Kind::Inits               then 6
         when Group::Kind::Methods             then 7
-        when Group::Kind::Consts              then 8
+        when Group::Kind::SingletonClasses    then 8
+        when Group::Kind::Consts              then 9
         else
           T.absurd(kind)
         end

--- a/lib/rbi/rewriters/sort_nodes.rb
+++ b/lib/rbi/rewriters/sort_nodes.rb
@@ -12,10 +12,16 @@ module RBI
         visit_all(node.nodes)
         original_order = node.nodes.map.with_index.to_h
         node.nodes.sort! do |a, b|
+          # First we try to compare the nodes by their node rank (based on the node type)
           res = node_rank(a) <=> node_rank(b)
-          res = node_name(a) <=> node_name(b) if res == 0
-          res = (original_order[a] || 0) <=> (original_order[b] || 0) if res == 0
-          res || 0
+          next res if res != 0 # we can sort the nodes by their rank, let's stop here
+
+          # Then, if the nodes ranks are the same (res == 0), we try to compare the nodes by their name
+          res = node_name(a) <=> node_name(b)
+          next res if res && res != 0 # we can sort the nodes by their name, let's stop here
+
+          # Finally, if the two nodes have the same rank and the same name or at least one node is anonymous then,
+          T.must(original_order[a]) <=> T.must(original_order[b]) # we keep the original order
         end
       end
 

--- a/test/rbi/rewriters/group_nodes_test.rb
+++ b/test/rbi/rewriters/group_nodes_test.rb
@@ -40,12 +40,13 @@ module RBI
         def m1; end
         def self.m2; end
 
+        class << self; end
+
         C = 42
         module S1; end
         class S2; end
         S3 = ::Struct.new
         class TE < ::T::Enum; end
-        class << self; end
         class TS < ::T::Struct; end
       RBI
     end
@@ -84,8 +85,9 @@ module RBI
           def m2; end
 
           module Scope2
-            C1 = 42
             class << self; end
+
+            C1 = 42
             C2 = 42
             module M1; end
 
@@ -135,10 +137,11 @@ module RBI
         def m1; end
         def self.m2; end
 
+        class << self; end
+
         C = 42
         module S1; end
         class S2; end
-        class << self; end
         S3 = ::Struct.new
         class TE < ::T::Enum; end
         class TS < ::T::Struct; end
@@ -229,8 +232,9 @@ module RBI
           def m1; end
           def self.m2; end
 
-          C = 42
           class << self; end
+
+          C = 42
           module S1; end
           class S2; end
           S3 = ::Struct.new
@@ -295,9 +299,10 @@ module RBI
         def m1; end
         def m2; end
 
+        class << self; end
+
         C1 = 42
         C2 = 42
-        class << self; end
         class S1; end
         module S2; end
         S3 = ::Struct.new

--- a/test/rbi/rewriters/group_nodes_test.rb
+++ b/test/rbi/rewriters/group_nodes_test.rb
@@ -20,6 +20,7 @@ module RBI
       rbi << RBI::TStructConst.new("SC", "Type")
       rbi << RBI::TStructProp.new("SP", "Type")
       rbi << RBI::TEnum.new("TE")
+      rbi << RBI::SingletonClass.new
       rbi << RBI::TStruct.new("TS")
 
       rbi.group_nodes!
@@ -44,6 +45,7 @@ module RBI
         class S2; end
         S3 = ::Struct.new
         class TE < ::T::Enum; end
+        class << self; end
         class TS < ::T::Struct; end
       RBI
     end
@@ -58,6 +60,7 @@ module RBI
 
       scope2 = RBI::Module.new("Scope2")
       scope2 << RBI::Const.new("C1", "42")
+      scope2 << RBI::SingletonClass.new
       scope2 << RBI::Const.new("C2", "42")
       scope2 << RBI::Module.new("M1")
 
@@ -82,6 +85,7 @@ module RBI
 
           module Scope2
             C1 = 42
+            class << self; end
             C2 = 42
             module M1; end
 
@@ -101,6 +105,7 @@ module RBI
       rbi << RBI::Const.new("C", "42")
       rbi << RBI::Module.new("S1")
       rbi << RBI::Class.new("S2")
+      rbi << RBI::SingletonClass.new
       rbi << RBI::Struct.new("S3")
       rbi << RBI::Method.new("m1")
       rbi << RBI::Method.new("m2", is_singleton: true)
@@ -133,6 +138,7 @@ module RBI
         C = 42
         module S1; end
         class S2; end
+        class << self; end
         S3 = ::Struct.new
         class TE < ::T::Enum; end
         class TS < ::T::Struct; end
@@ -184,6 +190,7 @@ module RBI
       rbi = RBI::Tree.new
       scope = RBI::Module.new("Scope")
       scope << RBI::Const.new("C", "42")
+      scope << RBI::SingletonClass.new
       scope << RBI::Module.new("S1")
       scope << RBI::Class.new("S2")
       scope << RBI::Struct.new("S3")
@@ -223,6 +230,7 @@ module RBI
           def self.m2; end
 
           C = 42
+          class << self; end
           module S1; end
           class S2; end
           S3 = ::Struct.new
@@ -235,6 +243,7 @@ module RBI
     def test_group_sort_groups_in_tree
       rbi = RBI::Tree.new
       rbi << RBI::Const.new("C2", "42")
+      rbi << RBI::SingletonClass.new
       rbi << RBI::Module.new("S2")
       rbi << RBI::Method.new("m2")
       rbi << RBI::Include.new("I2")
@@ -288,6 +297,7 @@ module RBI
 
         C1 = 42
         C2 = 42
+        class << self; end
         class S1; end
         module S2; end
         S3 = ::Struct.new

--- a/test/rbi/rewriters/sort_nodes_test.rb
+++ b/test/rbi/rewriters/sort_nodes_test.rb
@@ -240,15 +240,18 @@ module RBI
       rbi << RBI::Method.new("m1")
       rbi << RBI::MixesInClassMethods.new("MICM")
       rbi << RBI::Module.new("B")
+      rbi << RBI::SingletonClass.new
       rbi << RBI::Include.new("M3")
       rbi << RBI::TStructConst.new("SP2", "T")
       rbi << RBI::Method.new("m2")
       rbi << RBI::TStruct.new("D")
       rbi << RBI::TEnum.new("C")
+      rbi << RBI::SingletonClass.new
       rbi << RBI::Extend.new("M2")
       rbi << RBI::TStructConst.new("SP4", "T")
       rbi << RBI::Include.new("M1")
       rbi << RBI::Helper.new("h")
+      rbi << RBI::SingletonClass.new
       rbi << RBI::Class.new("E")
       rbi << RBI::TStructProp.new("SP1", "T")
       rbi << RBI::Method.new("m3", is_singleton: true)
@@ -272,8 +275,11 @@ module RBI
         def self.m3; end
         A = 42
         module B; end
+        class << self; end
         class C < ::T::Enum; end
         class D < ::T::Struct; end
+        class << self; end
+        class << self; end
         class E; end
       RBI
     end

--- a/test/rbi/rewriters/sort_nodes_test.rb
+++ b/test/rbi/rewriters/sort_nodes_test.rb
@@ -273,13 +273,13 @@ module RBI
         def m1; end
         def m2; end
         def self.m3; end
+        class << self; end
+        class << self; end
+        class << self; end
         A = 42
         module B; end
-        class << self; end
         class C < ::T::Enum; end
         class D < ::T::Struct; end
-        class << self; end
-        class << self; end
         class E; end
       RBI
     end


### PR DESCRIPTION
Two things here:

1. When a node didn't have a name (for example `class << self; end`) the comparison returned 0 (without preserving the original order like intended) which might result in indeterministic order
2. Always group and sort `class << self; end` nodes before other scopes and constants

See tests for more examples.

This should fix unstable order for RBI generation that was happening with `tapioca dsl --verify`.