### PR TITLE
Allow arbitrary expression as argument to include and extend

### DIFF
--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -278,10 +278,10 @@ module RBI
         symbols = node.children[2..-1].map { |child| child.children[0] }
         AttrAccessor.new(*symbols, sigs: current_sigs, loc: loc, comments: comments)
       when :include
-        names = node.children[2..-1].map { |child| parse_name(child) }
+        names = node.children[2..-1].map { |child| parse_expr(child) }
         Include.new(*names, loc: loc, comments: comments)
       when :extend
-        names = node.children[2..-1].map { |child| parse_name(child) }
+        names = node.children[2..-1].map { |child| parse_expr(child) }
         Extend.new(*names, loc: loc, comments: comments)
       when :abstract!, :sealed!, :interface!
         Helper.new(method_name.to_s.delete_suffix("!"), loc: loc, comments: comments)

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -147,6 +147,10 @@ module RBI
         class Foo
           include A
           extend A
+          include self
+          extend self
+          include T.class_of(Bar)
+          extend T::Array[Bar]
         end
       RBI
 


### PR DESCRIPTION
## Motivation

Parse this properly:

```rbi
class Foo
  extend self

  def bar; end
end
```