### PR TITLE
Print long signatures as blocks

### DIFF
--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -650,19 +650,22 @@ module RBI
 
     private
 
+    sig { returns(T::Array[String]) }
+    def sig_modifiers
+      modifiers = T.let([], T::Array[String])
+      modifiers << "abstract" if is_abstract
+      modifiers << "override" if is_override
+      modifiers << "overridable" if is_overridable
+      modifiers << "type_parameters(#{type_params.map { |type| ":#{type}" }.join(", ")})" if type_params.any?
+      modifiers << "checked(:#{checked})" if checked
+      modifiers
+    end
+
     sig { params(v: Printer).void }
     def print_as_line(v)
       v.printt("sig { ")
-      v.print("abstract.") if is_abstract
-      v.print("override.") if is_override
-      v.print("overridable.") if is_overridable
-      unless type_params.empty?
-        v.print("type_parameters(")
-        type_params.each_with_index do |param, index|
-          v.print(":#{param}")
-          v.print(", ") if index < type_params.length - 1
-        end
-        v.print(").")
+      sig_modifiers.each do |modifier|
+        v.print("#{modifier}.")
       end
       unless params.empty?
         v.print("params(")
@@ -677,20 +680,12 @@ module RBI
       else
         v.print("void")
       end
-      if checked
-        v.print(".checked(:#{checked})")
-      end
       v.printn(" }")
     end
 
     sig { params(v: Printer).void }
     def print_as_block(v)
-      modifiers = T.let([], T::Array[String])
-      modifiers << "abstract" if is_abstract
-      modifiers << "override" if is_override
-      modifiers << "overridable" if is_overridable
-      modifiers << "type_parameters(#{type_params.map { |type| ":#{type}"}.join(", ")})" if type_params.any?
-      modifiers << "checked(:#{checked})" if checked
+      modifiers = sig_modifiers
 
       v.printl("sig do")
       v.indent

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -113,7 +113,7 @@ module RBI
         sig { returns(String) }
         sig { params(a: T.untyped, b: T::Array[String]).returns(T::Hash[String, Integer]) }
         sig { abstract.params(a: Integer).void }
-        sig { returns(T::Array[String]).checked(:never) }
+        sig { checked(:never).returns(T::Array[String]) }
         sig { override.params(printer: Spoom::LSP::SymbolPrinter).void }
         sig { returns(T.nilable(String)) }
         sig { params(requested_generators: T::Array[String]).returns(T.proc.params(klass: Class).returns(T::Boolean)) }
@@ -390,7 +390,7 @@ module RBI
         sig { void }
         sig { params(a: A, b: T.nilable(B), b: T.proc.void).returns(R) }
         sig { abstract.override.overridable.void }
-        sig { type_parameters(:U, :V).params(a: T.type_parameter(:U)).returns(T.type_parameter(:V)).checked(:never) }
+        sig { type_parameters(:U, :V).checked(:never).params(a: T.type_parameter(:U)).returns(T.type_parameter(:V)) }
         def m4; end
       RBI
 
@@ -410,7 +410,7 @@ module RBI
         # -:7:0-7:42
         sig { abstract.override.overridable.void }
         # -:8:0-8:109
-        sig { type_parameters(:U, :V).params(a: T.type_parameter(:U)).returns(T.type_parameter(:V)).checked(:never) }
+        sig { type_parameters(:U, :V).checked(:never).params(a: T.type_parameter(:U)).returns(T.type_parameter(:V)) }
         # -:9:0-9:11
         def m4; end
       RBI

--- a/test/rbi/printer_test.rb
+++ b/test/rbi/printer_test.rb
@@ -215,7 +215,7 @@ module RBI
       assert_equal(<<~RBI, method.string)
         sig { void }
         sig { params(a: A, b: T.nilable(B), b: T.proc.void).returns(R) }
-        sig { abstract.override.overridable.void.checked(:never) }
+        sig { abstract.override.overridable.checked(:never).void }
         sig { type_parameters(:U, :V).params(a: T.type_parameter(:U)).returns(T.type_parameter(:V)) }
         def foo; end
       RBI


### PR DESCRIPTION
If `max_line_length` is set when calling the `Printer` visitor, signature longer than `max_line_length` will be displayed as blocks.

This is a very naive approach and:

1. We only care about sigs regarding the length of the line (long class defs or methods will still be printed as oneliners)
2. We do not insert new lines for long params or return values (think long types with `T.proc`)
3. We do not inline sigs if they contain comments