### PR TITLE
Remove RBI:: prefixes where not needed

### DIFF
--- a/lib/rbi/rewriters/remove_known_definitions.rb
+++ b/lib/rbi/rewriters/remove_known_definitions.rb
@@ -50,9 +50,9 @@ module RBI
 
       sig do
         params(
-          tree: RBI::Tree,
-          index: RBI::Index
-        ).returns([RBI::Tree, T::Array[Operation]])
+          tree: Tree,
+          index: Index
+        ).returns([Tree, T::Array[Operation]])
       end
       def self.remove(tree, index)
         v = RemoveKnownDefinitions.new(index)
@@ -63,30 +63,30 @@ module RBI
       sig { returns(T::Array[Operation]) }
       attr_reader :operations
 
-      sig { params(index: RBI::Index).void }
+      sig { params(index: Index).void }
       def initialize(index)
         super()
         @index = index
         @operations = T.let([], T::Array[Operation])
       end
 
-      sig { params(nodes: T::Array[RBI::Node]).void }
+      sig { params(nodes: T::Array[Node]).void }
       def visit_all(nodes)
         nodes.dup.each { |node| visit(node) }
       end
 
-      sig { override.params(node: T.nilable(RBI::Node)).void }
+      sig { override.params(node: T.nilable(Node)).void }
       def visit(node)
         return unless node
 
         case node
-        when RBI::Scope
+        when Scope
           visit_all(node.nodes)
           previous = previous_definition_for(node)
           delete_node(node, previous) if previous && can_delete_node?(node, previous)
-        when RBI::Tree
+        when Tree
           visit_all(node.nodes)
-        when RBI::Indexable
+        when Indexable
           previous = previous_definition_for(node)
           delete_node(node, previous) if previous && can_delete_node?(node, previous)
         end
@@ -94,7 +94,7 @@ module RBI
 
       private
 
-      sig { params(node: RBI::Indexable).returns(T.nilable(RBI::Node)) }
+      sig { params(node: Indexable).returns(T.nilable(Node)) }
       def previous_definition_for(node)
         node.index_ids.each do |id|
           previous = @index[id].first
@@ -121,7 +121,7 @@ module RBI
         end
       end
 
-      sig { params(node: RBI::Node, previous: RBI::Node).void }
+      sig { params(node: Node, previous: Node).void }
       def delete_node(node, previous)
         node.detach
         @operations << Operation.new(deleted_node: node, duplicate_of: previous)
@@ -130,8 +130,8 @@ module RBI
       class Operation < T::Struct
         extend T::Sig
 
-        const :deleted_node, RBI::Node
-        const :duplicate_of, RBI::Node
+        const :deleted_node, Node
+        const :duplicate_of, Node
 
         sig { returns(String) }
         def to_s

--- a/test/rbi/index_test.rb
+++ b/test/rbi/index_test.rb
@@ -8,13 +8,13 @@ module RBI
     extend T::Sig
 
     def test_index_empty_trees
-      rbi = RBI::Tree.new
+      rbi = Tree.new
       index_string = index_string(rbi.index)
       assert_empty(index_string)
     end
 
     def test_index_scopes_and_consts
-      rbi = RBI::Parser.parse_string(<<~RBI)
+      rbi = Parser.parse_string(<<~RBI)
         class A
           module B
             module ::C; end
@@ -38,7 +38,7 @@ module RBI
     end
 
     def test_index_properties
-      rbi = RBI::Parser.parse_string(<<~RBI)
+      rbi = Parser.parse_string(<<~RBI)
         class A
           attr_reader :a, :b
           attr_writer :a, :b
@@ -70,7 +70,7 @@ module RBI
     end
 
     def test_index_sorbet_constructs
-      rbi = RBI::Parser.parse_string(<<~RBI)
+      rbi = Parser.parse_string(<<~RBI)
         class A < T::Struct
           const :a, Integer
           prop :b, String
@@ -103,7 +103,7 @@ module RBI
     end
 
     def test_index_multiple_trees
-      tree1 = RBI::Parser.parse_string(<<~RBI)
+      tree1 = Parser.parse_string(<<~RBI)
         class A
           module B
             module ::C; end
@@ -111,7 +111,7 @@ module RBI
         end
       RBI
 
-      tree2 = RBI::Parser.parse_string(<<~RBI)
+      tree2 = Parser.parse_string(<<~RBI)
         class A
           module B
             module ::C; end
@@ -128,7 +128,7 @@ module RBI
       IDX
     end
 
-    sig { params(index: RBI::Index).returns(String) }
+    sig { params(index: Index).returns(String) }
     def index_string(index)
       io = StringIO.new
       index.keys.sort.each do |key|

--- a/test/rbi/model_test.rb
+++ b/test/rbi/model_test.rb
@@ -31,92 +31,92 @@ module RBI
     end
 
     def test_model_block_builders
-      rbi = RBI::File.new do |file|
-        file << RBI::Tree.new do |tree|
-          tree << RBI::Module.new("Foo") do |node|
+      rbi = File.new do |file|
+        file << Tree.new do |tree|
+          tree << Module.new("Foo") do |node|
             node.comments << Comment.new("comment")
           end
-          tree << RBI::Class.new("Bar") do |node|
+          tree << Class.new("Bar") do |node|
             node.comments << Comment.new("comment")
           end
-          tree << RBI::SingletonClass.new do |node|
+          tree << SingletonClass.new do |node|
             node.comments << Comment.new("comment")
           end
-          tree << RBI::Const.new("C", "42") do |node|
+          tree << Const.new("C", "42") do |node|
             node.comments << Comment.new("comment")
           end
-          tree << RBI::AttrAccessor.new(:a1) do |node|
+          tree << AttrAccessor.new(:a1) do |node|
             node.comments << Comment.new("comment")
           end
-          tree << RBI::AttrReader.new(:a2) do |node|
+          tree << AttrReader.new(:a2) do |node|
             node.comments << Comment.new("comment")
           end
-          tree << RBI::AttrWriter.new(:a3) do |node|
+          tree << AttrWriter.new(:a3) do |node|
             node.comments << Comment.new("comment")
           end
-          tree << RBI::Method.new("foo") do |node|
-            node << RBI::ReqParam.new("p1") do |param|
+          tree << Method.new("foo") do |node|
+            node << ReqParam.new("p1") do |param|
               param.comments << Comment.new("comment")
             end
-            node << RBI::OptParam.new("p2", "42") do |param|
+            node << OptParam.new("p2", "42") do |param|
               param.comments << Comment.new("comment")
             end
-            node << RBI::RestParam.new("p3") do |param|
+            node << RestParam.new("p3") do |param|
               param.comments << Comment.new("comment")
             end
-            node << RBI::KwParam.new("p4") do |param|
+            node << KwParam.new("p4") do |param|
               param.comments << Comment.new("comment")
             end
-            node << RBI::KwOptParam.new("p5", "42") do |param|
+            node << KwOptParam.new("p5", "42") do |param|
               param.comments << Comment.new("comment")
             end
-            node << RBI::KwRestParam.new("p6") do |param|
+            node << KwRestParam.new("p6") do |param|
               param.comments << Comment.new("comment")
             end
-            node << RBI::BlockParam.new("p7") do |param|
+            node << BlockParam.new("p7") do |param|
               param.comments << Comment.new("comment")
             end
-            node.sigs << RBI::Sig.new do |sig|
-              sig << RBI::SigParam.new("x", "T.untyped") do |param|
+            node.sigs << Sig.new do |sig|
+              sig << SigParam.new("x", "T.untyped") do |param|
                 param.comments << Comment.new("comment")
               end
             end
           end
-          tree << RBI::Include.new("FOO") do |node|
+          tree << Include.new("FOO") do |node|
             node.comments << Comment.new("comment")
           end
-          tree << RBI::Extend.new("FOO") do |node|
+          tree << Extend.new("FOO") do |node|
             node.comments << Comment.new("comment")
           end
-          tree << RBI::Public.new do |node|
+          tree << Public.new do |node|
             node.comments << Comment.new("comment")
           end
-          tree << RBI::Protected.new do |node|
+          tree << Protected.new do |node|
             node.comments << Comment.new("comment")
           end
-          tree << RBI::Private.new do |node|
+          tree << Private.new do |node|
             node.comments << Comment.new("comment")
           end
-          tree << RBI::TStruct.new("Struct") do |node|
-            node << RBI::TStructConst.new("foo", "Foo") do |field|
+          tree << TStruct.new("Struct") do |node|
+            node << TStructConst.new("foo", "Foo") do |field|
               field.comments << Comment.new("comment")
             end
-            node << RBI::TStructProp.new("foo", "Foo") do |field|
+            node << TStructProp.new("foo", "Foo") do |field|
               field.comments << Comment.new("comment")
             end
           end
-          tree << RBI::TEnum.new("Enum") do |node|
-            node << RBI::TEnumBlock.new(["A", "B"]) do |block|
+          tree << TEnum.new("Enum") do |node|
+            node << TEnumBlock.new(["A", "B"]) do |block|
               block.comments << Comment.new("comment")
             end
           end
-          tree << RBI::Helper.new("foo") do |node|
+          tree << Helper.new("foo") do |node|
             node.comments << Comment.new("comment")
           end
-          tree << RBI::TypeMember.new("foo", "type_member") do |node|
+          tree << TypeMember.new("foo", "type_member") do |node|
             node.comments << Comment.new("comment")
           end
-          tree << RBI::MixesInClassMethods.new("FOO") do |node|
+          tree << MixesInClassMethods.new("FOO") do |node|
             node.comments << Comment.new("comment")
           end
         end
@@ -202,151 +202,151 @@ module RBI
     end
 
     def test_model_fully_qualified_names
-      mod = RBI::Module.new("Foo")
+      mod = Module.new("Foo")
       assert_equal("::Foo", mod.fully_qualified_name)
 
-      cls1 = RBI::Class.new("Bar")
+      cls1 = Class.new("Bar")
       mod << cls1
       assert_equal("::Foo::Bar", cls1.fully_qualified_name)
 
-      cls2 = RBI::Class.new("::Bar")
+      cls2 = Class.new("::Bar")
       mod << cls2
       assert_equal("::Bar", cls2.fully_qualified_name)
 
-      singleton_class = RBI::SingletonClass.new
+      singleton_class = SingletonClass.new
       cls1 << singleton_class
       assert_equal("::Foo::Bar::<self>", singleton_class.fully_qualified_name)
 
-      const = RBI::Const.new("Foo", "42")
+      const = Const.new("Foo", "42")
       assert_equal("::Foo", const.fully_qualified_name)
 
       mod << const
       assert_equal("::Foo::Foo", const.fully_qualified_name)
 
-      const2 = RBI::Const.new("Foo::Bar", "42")
+      const2 = Const.new("Foo::Bar", "42")
       assert_equal("::Foo::Bar", const2.fully_qualified_name)
 
       mod << const2
       assert_equal("::Foo::Foo::Bar", const2.fully_qualified_name)
 
-      const3 = RBI::Const.new("::Foo::Bar", "42")
+      const3 = Const.new("::Foo::Bar", "42")
       assert_equal("::Foo::Bar", const3.fully_qualified_name)
 
       mod << const3
       assert_equal("::Foo::Bar", const3.fully_qualified_name)
 
-      m1 = RBI::Method.new("m1")
+      m1 = Method.new("m1")
       assert_equal("#m1", m1.fully_qualified_name)
 
       mod << m1
       assert_equal("::Foo#m1", m1.fully_qualified_name)
 
-      m2 = RBI::Method.new("m2", is_singleton: true)
+      m2 = Method.new("m2", is_singleton: true)
       assert_equal("::m2", m2.fully_qualified_name)
 
       mod << m2
       assert_equal("::Foo::m2", m2.fully_qualified_name)
 
-      a1 = RBI::AttrReader.new(:m1)
+      a1 = AttrReader.new(:m1)
       assert_equal(["#m1"], a1.fully_qualified_names)
 
-      a2 = RBI::AttrWriter.new(:m2, :m3)
+      a2 = AttrWriter.new(:m2, :m3)
       mod << a2
       assert_equal(["::Foo#m2=", "::Foo#m3="], a2.fully_qualified_names)
 
-      a3 = RBI::AttrAccessor.new(:m4, :m5)
+      a3 = AttrAccessor.new(:m4, :m5)
       mod << a3
       assert_equal(["::Foo#m4", "::Foo#m4=", "::Foo#m5", "::Foo#m5="], a3.fully_qualified_names)
 
-      struct = RBI::TStruct.new("Struct")
+      struct = TStruct.new("Struct")
       mod << struct
       assert_equal("::Foo::Struct", struct.fully_qualified_name)
 
-      sc = RBI::TStructConst.new("a", "A")
+      sc = TStructConst.new("a", "A")
       struct << sc
       assert_equal(["::Foo::Struct#a"], sc.fully_qualified_names)
 
-      sp = RBI::TStructProp.new("b", "B")
+      sp = TStructProp.new("b", "B")
       struct << sp
       assert_equal(["::Foo::Struct#b", "::Foo::Struct#b="], sp.fully_qualified_names)
 
-      enum = RBI::TEnum.new("Enum")
+      enum = TEnum.new("Enum")
       mod << enum
       assert_equal("::Foo::Enum", enum.fully_qualified_name)
 
-      type = RBI::TypeMember.new("T", "type_template")
+      type = TypeMember.new("T", "type_template")
       mod << type
       assert_equal("::Foo::T", type.fully_qualified_name)
     end
 
     def test_model_nodes_as_strings
-      mod = RBI::Module.new("Foo")
+      mod = Module.new("Foo")
       assert_equal("::Foo", mod.to_s)
 
-      cls = RBI::Class.new("Bar")
+      cls = Class.new("Bar")
       mod << cls
       assert_equal("::Foo::Bar", cls.to_s)
 
-      singleton_class = RBI::SingletonClass.new
+      singleton_class = SingletonClass.new
       cls << singleton_class
       assert_equal("::Foo::Bar::<self>", singleton_class.to_s)
 
-      const = RBI::Const.new("Foo", "42")
+      const = Const.new("Foo", "42")
       assert_equal("::Foo", const.to_s)
 
       mod << const
       assert_equal("::Foo::Foo", const.to_s)
 
-      const2 = RBI::Const.new("Foo::Bar", "42")
+      const2 = Const.new("Foo::Bar", "42")
       assert_equal("::Foo::Bar", const2.to_s)
 
       mod << const2
       assert_equal("::Foo::Foo::Bar", const2.to_s)
 
-      m1 = RBI::Method.new("m1")
+      m1 = Method.new("m1")
       mod << m1
       assert_equal("::Foo#m1()", m1.to_s)
 
-      m2 = RBI::Method.new("m2", is_singleton: true)
+      m2 = Method.new("m2", is_singleton: true)
       assert_equal("::m2()", m2.to_s)
 
       mod << m2
       assert_equal("::Foo::m2()", m2.to_s)
 
-      m3 = RBI::Method.new("m3")
-      m3 << RBI::ReqParam.new("a")
-      m3 << RBI::OptParam.new("b", "42")
-      m3 << RBI::RestParam.new("c")
-      m3 << RBI::KwParam.new("d")
-      m3 << RBI::KwOptParam.new("e", "42")
-      m3 << RBI::KwRestParam.new("f")
-      m3 << RBI::BlockParam.new("g")
+      m3 = Method.new("m3")
+      m3 << ReqParam.new("a")
+      m3 << OptParam.new("b", "42")
+      m3 << RestParam.new("c")
+      m3 << KwParam.new("d")
+      m3 << KwOptParam.new("e", "42")
+      m3 << KwRestParam.new("f")
+      m3 << BlockParam.new("g")
       assert_equal("#m3(a, b, *c, d:, e:, **f:, &g)", m3.to_s)
 
-      a1 = RBI::AttrReader.new(:m1)
+      a1 = AttrReader.new(:m1)
       assert_equal(".attr_reader(:m1)", a1.to_s)
 
-      a2 = RBI::AttrWriter.new(:m2, :m3)
+      a2 = AttrWriter.new(:m2, :m3)
       mod << a2
       assert_equal("::Foo.attr_writer(:m2, :m3)", a2.to_s)
 
-      a3 = RBI::AttrAccessor.new(:m4, :m5)
+      a3 = AttrAccessor.new(:m4, :m5)
       mod << a3
       assert_equal("::Foo.attr_accessor(:m4, :m5)", a3.to_s)
 
-      struct = RBI::TStruct.new("Struct")
+      struct = TStruct.new("Struct")
       mod << struct
       assert_equal("::Foo::Struct", struct.to_s)
 
-      sc = RBI::TStructConst.new("a", "A")
+      sc = TStructConst.new("a", "A")
       struct << sc
       assert_equal("::Foo::Struct.const(:a)", sc.to_s)
 
-      sp = RBI::TStructProp.new("b", "B")
+      sp = TStructProp.new("b", "B")
       struct << sp
       assert_equal("::Foo::Struct.prop(:b)", sp.to_s)
 
-      enum = RBI::TEnum.new("Enum")
+      enum = TEnum.new("Enum")
       mod << enum
       assert_equal("::Foo::Enum", enum.to_s)
 
@@ -354,23 +354,23 @@ module RBI
       enum << block
       assert_equal("::Foo::Enum.enums", block.to_s)
 
-      type = RBI::TypeMember.new("T", "type_template")
+      type = TypeMember.new("T", "type_template")
       mod << type
       assert_equal("::Foo::T", type.to_s)
 
-      inc = RBI::Include.new("A")
+      inc = Include.new("A")
       mod << inc
       assert_equal("::Foo.include(A)", inc.to_s)
 
-      ext = RBI::Extend.new("A", "B")
+      ext = Extend.new("A", "B")
       mod << ext
       assert_equal("::Foo.extend(A, B)", ext.to_s)
 
-      micm = RBI::MixesInClassMethods.new("A")
+      micm = MixesInClassMethods.new("A")
       mod << micm
       assert_equal("::Foo.mixes_in_class_methods(A)", micm.to_s)
 
-      helper = RBI::Helper.new("foo")
+      helper = Helper.new("foo")
       mod << helper
       assert_equal("::Foo.foo!", helper.to_s)
     end

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -14,7 +14,7 @@ module RBI
         class << self; end
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(rbi, out.string)
     end
 
@@ -29,7 +29,7 @@ module RBI
         end
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(rbi, out.string)
     end
 
@@ -49,7 +49,7 @@ module RBI
         end
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(<<~RBI, out.string)
         A = ::Struct.new
         B = ::Struct.new(:a, :b)
@@ -82,7 +82,7 @@ module RBI
         A::B::C = Foo
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(rbi, out.string)
     end
 
@@ -99,7 +99,7 @@ module RBI
         attr_accessor :a, :b, :c
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(rbi, out.string)
     end
 
@@ -123,7 +123,7 @@ module RBI
         def m4; end
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(rbi, out.string)
     end
 
@@ -134,7 +134,7 @@ module RBI
         private attr_reader :a
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(<<~RBI, out.string)
         private def m1; end
         protected def self.m2; end
@@ -150,7 +150,7 @@ module RBI
         end
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(rbi, out.string)
     end
 
@@ -164,7 +164,7 @@ module RBI
         def m3; end
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(rbi, out.string)
     end
 
@@ -179,7 +179,7 @@ module RBI
         end
         RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(rbi, out.string)
     end
 
@@ -195,7 +195,7 @@ module RBI
         end
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(rbi, out.string)
     end
 
@@ -209,7 +209,7 @@ module RBI
         end
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(rbi, out.string)
     end
 
@@ -228,7 +228,7 @@ module RBI
         end
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(rbi, out.string)
     end
 
@@ -238,7 +238,7 @@ module RBI
         class Bar; end
       RBI
 
-      tree = RBI::Parser.parse_string(rbi)
+      tree = Parser.parse_string(rbi)
       assert_equal("-:1:0-2:14", tree.loc.to_s)
     end
 
@@ -250,7 +250,7 @@ module RBI
         end
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(rbi, out.string)
     end
 
@@ -262,7 +262,7 @@ module RBI
         class << self; end
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(<<~RBI, out.string(print_locs: true))
         # -:1:0-1:15
         module Foo; end
@@ -286,7 +286,7 @@ module RBI
         end
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(<<~RBI, out.string(print_locs: true))
         # -:1:0-7:3
         module Foo
@@ -310,7 +310,7 @@ module RBI
         end
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(<<~RBI, out.string(print_locs: true))
         # -:1:0-4:3
         Foo = ::Struct.new(:a) do
@@ -330,7 +330,7 @@ module RBI
         A::B::C = Foo
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(<<~RBI, out.string(print_locs: true))
         # -:1:0-1:8
         Foo = 42
@@ -356,7 +356,7 @@ module RBI
         attr_accessor :a, :b, :c
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(<<~RBI, out.string(print_locs: true))
         # -:1:0-1:14
         attr_reader :a
@@ -390,7 +390,7 @@ module RBI
         def m4; end
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(<<~RBI, out.string(print_locs: true))
         # -:1:0-1:11
         def m1; end
@@ -420,7 +420,7 @@ module RBI
         end
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(<<~RBI, out.string(print_locs: true))
         # -:1:0-4:3
         class Foo
@@ -442,7 +442,7 @@ module RBI
         def m3; end
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(<<~RBI, out.string(print_locs: true))
         # -:1:0-1:6
         public
@@ -470,7 +470,7 @@ module RBI
         end
         RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(<<~RBI, out.string(print_locs: true))
         # -:1:0-7:3
         class Foo < ::T::Struct
@@ -500,7 +500,7 @@ module RBI
         end
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(<<~RBI, out.string(print_locs: true))
         # -:1:0-8:3
         class Foo < ::T::Enum
@@ -526,7 +526,7 @@ module RBI
         end
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(<<~RBI, out.string(print_locs: true))
         # -:1:0-6:3
         class Foo
@@ -550,7 +550,7 @@ module RBI
         end
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(<<~RBI, out.string(print_locs: true))
         # -:1:0-4:3
         class Foo
@@ -574,7 +574,7 @@ module RBI
         # Preserving empty lines
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(<<~RBI, out.string)
         # typed: false
         # frozen_string_literal: true
@@ -593,7 +593,7 @@ module RBI
 
         module A; end
       RBI
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(<<~RBI, out.string)
         # typed: true
 
@@ -608,7 +608,7 @@ module RBI
 
         module A; end
       RBI
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(<<~RBI, out.string)
         # typed: true
         # frozen_string_literal: true
@@ -624,7 +624,7 @@ module RBI
         # A comment
         module A; end
       RBI
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(<<~RBI, out.string)
         # typed: true
 
@@ -644,7 +644,7 @@ module RBI
         # for the module
         module A; end
       RBI
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(<<~RBI, out.string)
         # typed: true
         # frozen_string_literal: true
@@ -675,7 +675,7 @@ module RBI
         end
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(rbi, out.string)
     end
 
@@ -692,7 +692,7 @@ module RBI
         end
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(rbi, out.string)
     end
 
@@ -705,7 +705,7 @@ module RBI
         end
       RBI
 
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(rbi, out.string)
     end
 
@@ -719,7 +719,7 @@ module RBI
           # A comment 3
         end
       RBI
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(<<~RBI, out.string)
         # A comment 1
         # A comment 2
@@ -737,7 +737,7 @@ module RBI
         module A; end
         # Orphan comment
       RBI
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(<<~RBI, out.string)
         # Orphan comment
 
@@ -758,7 +758,7 @@ module RBI
           e: _
         ); end
       RBI
-      out = RBI::Parser.parse_string(rbi)
+      out = Parser.parse_string(rbi)
       assert_equal(<<~RBI, out.string)
         def bar; end
 
@@ -775,32 +775,32 @@ module RBI
     end
 
     def test_parse_errors
-      e = assert_raises(RBI::ParseError) do
-        RBI::Parser.parse_string(<<~RBI)
+      e = assert_raises(ParseError) do
+        Parser.parse_string(<<~RBI)
           def bar
         RBI
       end
       assert_equal("unexpected token $end", e.message)
       assert_equal("-:2:0-2:0", e.location.to_s)
 
-      e = assert_raises(RBI::ParseError) do
-        RBI::Parser.parse_string(<<~RBI)
+      e = assert_raises(ParseError) do
+        Parser.parse_string(<<~RBI)
           private include Foo
         RBI
       end
       assert_equal("Unexpected token `private` before `send`", e.message)
       assert_equal("-:1:0-1:19", e.location.to_s)
 
-      e = assert_raises(RBI::ParseError) do
-        RBI::Parser.parse_string(<<~RBI)
+      e = assert_raises(ParseError) do
+        Parser.parse_string(<<~RBI)
           private class Foo; end
         RBI
       end
       assert_equal("Unexpected token `private` before `class`", e.message)
       assert_equal("-:1:0-1:22", e.location.to_s)
 
-      e = assert_raises(RBI::ParseError) do
-        RBI::Parser.parse_string(<<~RBI)
+      e = assert_raises(ParseError) do
+        Parser.parse_string(<<~RBI)
           private CST = 42
         RBI
       end
@@ -850,8 +850,8 @@ module RBI
         class Foo
       RBI
 
-      e = assert_raises(RBI::ParseError) do
-        RBI::Parser.parse_file(path)
+      e = assert_raises(ParseError) do
+        Parser.parse_file(path)
       end
       assert_equal("unexpected token $end", e.message)
       assert_equal("test_parse_real_file_with_error.rbi:2:0-2:0", e.location.to_s)

--- a/test/rbi/printer_test.rb
+++ b/test/rbi/printer_test.rb
@@ -6,8 +6,8 @@ require "test_helper"
 module RBI
   class PrinterTest < Minitest::Test
     def test_print_files_without_strictness
-      file = RBI::File.new
-      file.root << RBI::Module.new("Foo")
+      file = File.new
+      file.root << Module.new("Foo")
 
       assert_equal(<<~RBI, file.string)
         module Foo; end
@@ -15,8 +15,8 @@ module RBI
     end
 
     def test_print_files_with_strictness
-      file = RBI::File.new(strictness: "true")
-      file.root << RBI::Module.new("Foo")
+      file = File.new(strictness: "true")
+      file.root << Module.new("Foo")
 
       assert_equal(<<~RBI, file.string)
         # typed: true
@@ -26,11 +26,11 @@ module RBI
     end
 
     def test_print_modules_and_classes
-      rbi = RBI::Tree.new
-      rbi << RBI::Module.new("Foo")
-      rbi << RBI::Class.new("Bar")
-      rbi << RBI::Class.new("Baz", superclass_name: "Bar")
-      rbi << RBI::SingletonClass.new
+      rbi = Tree.new
+      rbi << Module.new("Foo")
+      rbi << Class.new("Bar")
+      rbi << Class.new("Baz", superclass_name: "Bar")
+      rbi << SingletonClass.new
 
       assert_equal(<<~RBI, rbi.string)
         module Foo; end
@@ -41,12 +41,12 @@ module RBI
     end
 
     def test_print_nested_scopes
-      scope1 = RBI::Module.new("Foo")
-      scope2 = RBI::Class.new("Bar")
-      scope3 = RBI::Class.new("Baz", superclass_name: "Bar")
-      scope4 = RBI::SingletonClass.new
+      scope1 = Module.new("Foo")
+      scope2 = Class.new("Bar")
+      scope3 = Class.new("Baz", superclass_name: "Bar")
+      scope4 = SingletonClass.new
 
-      rbi = RBI::Tree.new
+      rbi = Tree.new
       rbi << scope1
       scope1 << scope2
       scope2 << scope3
@@ -64,15 +64,15 @@ module RBI
     end
 
     def test_print_structs
-      rbi = RBI::Tree.new do |tree|
-        tree << RBI::Struct.new("Foo", members: [:foo, :bar])
-        tree << RBI::Struct.new("Bar", members: [:bar], keyword_init: true) do |struct1|
-          struct1 << RBI::Method.new("bar_method")
+      rbi = Tree.new do |tree|
+        tree << Struct.new("Foo", members: [:foo, :bar])
+        tree << Struct.new("Bar", members: [:bar], keyword_init: true) do |struct1|
+          struct1 << Method.new("bar_method")
         end
-        tree << RBI::Struct.new("Baz", members: [:baz], keyword_init: false) do |struct2|
-          struct2 << RBI::Method.new("baz_method")
-          struct2 << RBI::SingletonClass.new do |singleton_class|
-            singleton_class << RBI::Method.new("baz_class_method")
+        tree << Struct.new("Baz", members: [:baz], keyword_init: false) do |struct2|
+          struct2 << Method.new("baz_method")
+          struct2 << SingletonClass.new do |singleton_class|
+            singleton_class << Method.new("baz_class_method")
           end
         end
       end
@@ -95,10 +95,10 @@ module RBI
     end
 
     def test_print_constants
-      rbi = RBI::Tree.new
-      rbi << RBI::Const.new("Foo", "42")
-      rbi << RBI::Const.new("Bar", "'foo'")
-      rbi << RBI::Const.new("Baz", "Bar")
+      rbi = Tree.new
+      rbi << Const.new("Foo", "42")
+      rbi << Const.new("Bar", "'foo'")
+      rbi << Const.new("Baz", "Bar")
 
       assert_equal(<<~RBI, rbi.string)
         Foo = 42
@@ -108,11 +108,11 @@ module RBI
     end
 
     def test_print_attributes
-      rbi = RBI::Tree.new
-      rbi << RBI::AttrReader.new(:m1)
-      rbi << RBI::AttrWriter.new(:m2, :m3, visibility: Public.new)
-      rbi << RBI::AttrAccessor.new(:m4, visibility: Private.new)
-      rbi << RBI::AttrReader.new(:m5, visibility: Protected.new)
+      rbi = Tree.new
+      rbi << AttrReader.new(:m1)
+      rbi << AttrWriter.new(:m2, :m3, visibility: Public.new)
+      rbi << AttrAccessor.new(:m4, visibility: Private.new)
+      rbi << AttrReader.new(:m5, visibility: Protected.new)
 
       assert_equal(<<~RBI, rbi.string)
         attr_reader :m1
@@ -123,13 +123,13 @@ module RBI
     end
 
     def test_print_methods
-      rbi = RBI::Tree.new
-      rbi << RBI::Method.new("m1")
-      rbi << RBI::Method.new("m2", visibility: Public.new)
-      rbi << RBI::Method.new("m3", visibility: Private.new)
-      rbi << RBI::Method.new("m4", visibility: Protected.new)
-      rbi << RBI::Method.new("m5", is_singleton: true)
-      rbi << RBI::Method.new("m6", is_singleton: true, visibility: Private.new) # TODO: avoid this?
+      rbi = Tree.new
+      rbi << Method.new("m1")
+      rbi << Method.new("m2", visibility: Public.new)
+      rbi << Method.new("m3", visibility: Private.new)
+      rbi << Method.new("m4", visibility: Protected.new)
+      rbi << Method.new("m5", is_singleton: true)
+      rbi << Method.new("m6", is_singleton: true, visibility: Private.new) # TODO: avoid this?
 
       assert_equal(<<~RBI, rbi.string)
         def m1; end
@@ -142,14 +142,14 @@ module RBI
     end
 
     def test_print_methods_with_parameters
-      method = RBI::Method.new("foo")
-      method << RBI::ReqParam.new("a")
-      method << RBI::OptParam.new("b", "42")
-      method << RBI::RestParam.new("c")
-      method << RBI::KwParam.new("d")
-      method << RBI::KwOptParam.new("e", "'bar'")
-      method << RBI::KwRestParam.new("f")
-      method << RBI::BlockParam.new("g")
+      method = Method.new("foo")
+      method << ReqParam.new("a")
+      method << OptParam.new("b", "42")
+      method << RestParam.new("c")
+      method << KwParam.new("d")
+      method << KwOptParam.new("e", "'bar'")
+      method << KwRestParam.new("f")
+      method << BlockParam.new("g")
 
       assert_equal(<<~RBI, method.string)
         def foo(a, b = 42, *c, d:, e: 'bar', **f, &g); end
@@ -157,23 +157,23 @@ module RBI
     end
 
     def test_print_attributes_with_signatures
-      sig1 = RBI::Sig.new
+      sig1 = Sig.new
 
-      sig2 = RBI::Sig.new(return_type: "R")
-      sig2 << RBI::SigParam.new("a", "A")
-      sig2 << RBI::SigParam.new("b", "T.nilable(B)")
-      sig2 << RBI::SigParam.new("b", "T.proc.void")
+      sig2 = Sig.new(return_type: "R")
+      sig2 << SigParam.new("a", "A")
+      sig2 << SigParam.new("b", "T.nilable(B)")
+      sig2 << SigParam.new("b", "T.proc.void")
 
-      sig3 = RBI::Sig.new(is_abstract: true)
+      sig3 = Sig.new(is_abstract: true)
       sig3.is_override = true
       sig3.is_overridable = true
 
-      sig4 = RBI::Sig.new(return_type: "T.type_parameter(:V)")
+      sig4 = Sig.new(return_type: "T.type_parameter(:V)")
       sig4.type_params << "U"
       sig4.type_params << "V"
-      sig4 << RBI::SigParam.new("a", "T.type_parameter(:U)")
+      sig4 << SigParam.new("a", "T.type_parameter(:U)")
 
-      attr = RBI::AttrAccessor.new(:foo, :bar)
+      attr = AttrAccessor.new(:foo, :bar)
       attr.sigs << sig1
       attr.sigs << sig2
       attr.sigs << sig3
@@ -189,24 +189,24 @@ module RBI
     end
 
     def test_print_methods_with_signatures
-      sig1 = RBI::Sig.new
+      sig1 = Sig.new
 
-      sig2 = RBI::Sig.new(return_type: "R")
-      sig2 << RBI::SigParam.new("a", "A")
-      sig2 << RBI::SigParam.new("b", "T.nilable(B)")
-      sig2 << RBI::SigParam.new("b", "T.proc.void")
+      sig2 = Sig.new(return_type: "R")
+      sig2 << SigParam.new("a", "A")
+      sig2 << SigParam.new("b", "T.nilable(B)")
+      sig2 << SigParam.new("b", "T.proc.void")
 
-      sig3 = RBI::Sig.new(is_abstract: true)
+      sig3 = Sig.new(is_abstract: true)
       sig3.is_override = true
       sig3.is_overridable = true
       sig3.checked = :never
 
-      sig4 = RBI::Sig.new(return_type: "T.type_parameter(:V)")
+      sig4 = Sig.new(return_type: "T.type_parameter(:V)")
       sig4.type_params << "U"
       sig4.type_params << "V"
-      sig4 << RBI::SigParam.new("a", "T.type_parameter(:U)")
+      sig4 << SigParam.new("a", "T.type_parameter(:U)")
 
-      method = RBI::Method.new("foo")
+      method = Method.new("foo")
       method.sigs << sig1
       method.sigs << sig2
       method.sigs << sig3
@@ -222,9 +222,9 @@ module RBI
     end
 
     def test_print_mixins
-      scope = RBI::Class.new("Foo")
-      scope << RBI::Include.new("A")
-      scope << RBI::Extend.new("A", "B")
+      scope = Class.new("Foo")
+      scope << Include.new("A")
+      scope << Extend.new("A", "B")
 
       assert_equal(<<~RBI, scope.string)
         class Foo
@@ -235,13 +235,13 @@ module RBI
     end
 
     def test_print_visibility_labels
-      tree = RBI::Tree.new
-      tree << RBI::Public.new
-      tree << RBI::Method.new("m1")
-      tree << RBI::Protected.new
-      tree << RBI::Method.new("m2")
-      tree << RBI::Private.new
-      tree << RBI::Method.new("m3")
+      tree = Tree.new
+      tree << Public.new
+      tree << Method.new("m1")
+      tree << Protected.new
+      tree << Method.new("m2")
+      tree << Private.new
+      tree << Method.new("m3")
 
       assert_equal(<<~RBI, tree.string)
         public
@@ -254,16 +254,16 @@ module RBI
     end
 
     def test_print_sends
-      tree = RBI::Tree.new
-      tree << RBI::Send.new("class_attribute")
-      tree << RBI::Send.new("class_attribute") do |send|
-        send << RBI::Arg.new(":foo")
+      tree = Tree.new
+      tree << Send.new("class_attribute")
+      tree << Send.new("class_attribute") do |send|
+        send << Arg.new(":foo")
       end
-      tree << RBI::Send.new("class_attribute") do |send|
-        send << RBI::Arg.new(":foo")
-        send << RBI::Arg.new(":bar")
-        send << RBI::KwArg.new("instance_accessor", "false")
-        send << RBI::KwArg.new("default", "\"Bar\"")
+      tree << Send.new("class_attribute") do |send|
+        send << Arg.new(":foo")
+        send << Arg.new(":bar")
+        send << KwArg.new("instance_accessor", "false")
+        send << KwArg.new("default", "\"Bar\"")
       end
 
       assert_equal(<<~RBI, tree.string)
@@ -274,12 +274,12 @@ module RBI
     end
 
     def test_print_t_structs
-      struct = RBI::TStruct.new("Foo")
-      struct << RBI::TStructConst.new("a", "A")
-      struct << RBI::TStructConst.new("b", "B", default: "B.new")
-      struct << RBI::TStructProp.new("c", "C")
-      struct << RBI::TStructProp.new("d", "D", default: "D.new")
-      struct << RBI::Method.new("foo")
+      struct = TStruct.new("Foo")
+      struct << TStructConst.new("a", "A")
+      struct << TStructConst.new("b", "B", default: "B.new")
+      struct << TStructProp.new("c", "C")
+      struct << TStructProp.new("d", "D", default: "D.new")
+      struct << Method.new("foo")
 
       assert_equal(<<~RBI, struct.string)
         class Foo < ::T::Struct
@@ -293,11 +293,11 @@ module RBI
     end
 
     def test_print_t_enums
-      rbi = RBI::TEnum.new("Foo")
+      rbi = TEnum.new("Foo")
       block = TEnumBlock.new(["A", "B"])
       block.names << "C"
       rbi << block
-      rbi << RBI::Method.new("baz")
+      rbi << Method.new("baz")
 
       assert_equal(<<~RBI, rbi.string)
         class Foo < ::T::Enum
@@ -312,11 +312,11 @@ module RBI
     end
 
     def test_print_sorbet_helpers
-      rbi = RBI::Class.new("Foo")
-      rbi << RBI::Helper.new("foo")
-      rbi << RBI::Helper.new("sealed")
-      rbi << RBI::Helper.new("interface")
-      rbi << RBI::MixesInClassMethods.new("A")
+      rbi = Class.new("Foo")
+      rbi << Helper.new("foo")
+      rbi << Helper.new("sealed")
+      rbi << Helper.new("interface")
+      rbi << MixesInClassMethods.new("A")
 
       assert_equal(<<~RBI, rbi.string)
         class Foo
@@ -329,9 +329,9 @@ module RBI
     end
 
     def test_print_sorbet_type_members_and_templates
-      rbi = RBI::Class.new("Foo")
-      rbi << RBI::TypeMember.new("A", "type_member")
-      rbi << RBI::TypeMember.new("B", "type_template")
+      rbi = Class.new("Foo")
+      rbi << TypeMember.new("A", "type_member")
+      rbi << TypeMember.new("B", "type_template")
 
       assert_equal(<<~RBI, rbi.string)
         class Foo
@@ -343,12 +343,12 @@ module RBI
 
     def test_print_files_with_comments_but_no_strictness
       comments = [
-        RBI::Comment.new("This is a"),
-        RBI::Comment.new("Multiline Comment"),
+        Comment.new("This is a"),
+        Comment.new("Multiline Comment"),
       ]
 
-      file = RBI::File.new(comments: comments)
-      file.root << RBI::Module.new("Foo")
+      file = File.new(comments: comments)
+      file.root << Module.new("Foo")
 
       assert_equal(<<~RBI, file.string)
         # This is a
@@ -360,12 +360,12 @@ module RBI
 
     def test_print_with_comments_and_strictness
       comments = [
-        RBI::Comment.new("This is a"),
-        RBI::Comment.new("Multiline Comment"),
+        Comment.new("This is a"),
+        Comment.new("Multiline Comment"),
       ]
 
-      file = RBI::File.new(strictness: "true", comments: comments)
-      file.root << RBI::Module.new("Foo")
+      file = File.new(strictness: "true", comments: comments)
+      file.root << Module.new("Foo")
 
       assert_equal(<<~RBI, file.string)
         # typed: true
@@ -378,40 +378,40 @@ module RBI
     end
 
     def test_print_nodes_with_comments
-      comments_single = [RBI::Comment.new("This is a single line comment")]
+      comments_single = [Comment.new("This is a single line comment")]
 
       comments_multi = [
-        RBI::Comment.new("This is a"),
-        RBI::Comment.new("Multiline Comment"),
+        Comment.new("This is a"),
+        Comment.new("Multiline Comment"),
       ]
 
-      rbi = RBI::Tree.new
-      rbi << RBI::Module.new("Foo", comments: comments_single)
-      rbi << RBI::Class.new("Bar", comments: comments_multi)
-      rbi << RBI::SingletonClass.new(comments: comments_single)
-      rbi << RBI::Const.new("Foo", "42", comments: comments_multi)
-      rbi << RBI::Include.new("A", comments: comments_single)
-      rbi << RBI::Extend.new("A", comments: comments_multi)
+      rbi = Tree.new
+      rbi << Module.new("Foo", comments: comments_single)
+      rbi << Class.new("Bar", comments: comments_multi)
+      rbi << SingletonClass.new(comments: comments_single)
+      rbi << Const.new("Foo", "42", comments: comments_multi)
+      rbi << Include.new("A", comments: comments_single)
+      rbi << Extend.new("A", comments: comments_multi)
 
-      rbi << RBI::Public.new(comments: comments_single)
-      rbi << RBI::Protected.new(comments: comments_single)
-      rbi << RBI::Private.new(comments: comments_single)
+      rbi << Public.new(comments: comments_single)
+      rbi << Protected.new(comments: comments_single)
+      rbi << Private.new(comments: comments_single)
 
-      rbi << RBI::Send.new("foo", comments: comments_single)
+      rbi << Send.new("foo", comments: comments_single)
 
-      struct = RBI::TStruct.new("Foo", comments: comments_single)
-      struct << RBI::TStructConst.new("a", "A", comments: comments_multi)
-      struct << RBI::TStructProp.new("c", "C", comments: comments_single)
+      struct = TStruct.new("Foo", comments: comments_single)
+      struct << TStructConst.new("a", "A", comments: comments_multi)
+      struct << TStructProp.new("c", "C", comments: comments_single)
       rbi << struct
 
-      enum = RBI::TEnum.new("Foo", comments: comments_multi)
+      enum = TEnum.new("Foo", comments: comments_multi)
       enum << TEnumBlock.new(["A", "B"], comments: comments_single)
       rbi << enum
 
-      rbi << RBI::Helper.new("foo", comments: comments_multi)
-      rbi << RBI::MixesInClassMethods.new("A", comments: comments_single)
-      rbi << RBI::TypeMember.new("A", "type_member", comments: comments_multi)
-      rbi << RBI::TypeMember.new("B", "type_template", comments: comments_single)
+      rbi << Helper.new("foo", comments: comments_multi)
+      rbi << MixesInClassMethods.new("A", comments: comments_single)
+      rbi << TypeMember.new("A", "type_member", comments: comments_multi)
+      rbi << TypeMember.new("B", "type_template", comments: comments_single)
 
       assert_equal(<<~RBI, rbi.string)
         # This is a single line comment
@@ -484,28 +484,28 @@ module RBI
     end
 
     def test_print_nodes_with_multiline_comments
-      comments = [RBI::Comment.new("This is a\nmultiline comment")]
+      comments = [Comment.new("This is a\nmultiline comment")]
 
-      rbi = RBI::Tree.new do |tree|
-        tree << RBI::Module.new("Foo", comments: comments) do |mod|
-          mod << RBI::TypeMember.new("A", "type_member", comments: comments)
-          mod << RBI::Method.new("foo", comments: comments)
+      rbi = Tree.new do |tree|
+        tree << Module.new("Foo", comments: comments) do |mod|
+          mod << TypeMember.new("A", "type_member", comments: comments)
+          mod << Method.new("foo", comments: comments)
         end
       end
 
-      rbi << RBI::Method.new("foo", comments: comments) do |method|
-        method << RBI::ReqParam.new("a", comments: comments)
-        method << RBI::OptParam.new("b", "42", comments: comments)
-        method << RBI::RestParam.new("c", comments: comments)
-        method << RBI::KwParam.new("d", comments: comments)
-        method << RBI::KwOptParam.new("e", "'bar'", comments: comments)
-        method << RBI::KwRestParam.new("f", comments: comments)
-        method << RBI::BlockParam.new("g", comments: comments)
+      rbi << Method.new("foo", comments: comments) do |method|
+        method << ReqParam.new("a", comments: comments)
+        method << OptParam.new("b", "42", comments: comments)
+        method << RestParam.new("c", comments: comments)
+        method << KwParam.new("d", comments: comments)
+        method << KwOptParam.new("e", "'bar'", comments: comments)
+        method << KwRestParam.new("f", comments: comments)
+        method << BlockParam.new("g", comments: comments)
 
-        sig = RBI::Sig.new
-        sig << RBI::SigParam.new("a", "Integer", comments: comments)
-        sig << RBI::SigParam.new("b", "String", comments: comments)
-        sig << RBI::SigParam.new("c", "T.untyped", comments: comments)
+        sig = Sig.new
+        sig << SigParam.new("a", "Integer", comments: comments)
+        sig << SigParam.new("b", "String", comments: comments)
+        sig << SigParam.new("c", "T.untyped", comments: comments)
         method.sigs << sig
       end
 
@@ -554,7 +554,7 @@ module RBI
     end
 
     def test_print_nodes_with_heredoc_comments
-      comments = [RBI::Comment.new(<<~COMMENT)]
+      comments = [Comment.new(<<~COMMENT)]
         This
         is
         a
@@ -562,8 +562,8 @@ module RBI
         comment
       COMMENT
 
-      rbi = RBI::Tree.new do |tree|
-        tree << RBI::Module.new("Foo", comments: comments)
+      rbi = Tree.new do |tree|
+        tree << Module.new("Foo", comments: comments)
       end
 
       assert_equal(<<~RBI, rbi.string)
@@ -577,27 +577,27 @@ module RBI
     end
 
     def test_print_methods_with_signatures_and_comments
-      comments_single = [RBI::Comment.new("This is a single line comment")]
+      comments_single = [Comment.new("This is a single line comment")]
 
       comments_multi = [
-        RBI::Comment.new("This is a"),
-        RBI::Comment.new("Multiline Comment"),
+        Comment.new("This is a"),
+        Comment.new("Multiline Comment"),
       ]
 
-      rbi = RBI::Tree.new
-      rbi << RBI::Method.new("foo", comments: comments_multi)
+      rbi = Tree.new
+      rbi << Method.new("foo", comments: comments_multi)
 
-      method = RBI::Method.new("foo", comments: comments_single)
-      method.sigs << RBI::Sig.new
+      method = Method.new("foo", comments: comments_single)
+      method.sigs << Sig.new
       rbi << method
 
-      sig1 = RBI::Sig.new
-      sig2 = RBI::Sig.new(return_type: "R")
-      sig2 << RBI::SigParam.new("a", "A")
-      sig2 << RBI::SigParam.new("b", "T.nilable(B)")
-      sig2 << RBI::SigParam.new("b", "T.proc.void")
+      sig1 = Sig.new
+      sig2 = Sig.new(return_type: "R")
+      sig2 << SigParam.new("a", "A")
+      sig2 << SigParam.new("b", "T.nilable(B)")
+      sig2 << SigParam.new("b", "T.proc.void")
 
-      method = RBI::Method.new("bar", comments: comments_multi)
+      method = Method.new("bar", comments: comments_multi)
       method.sigs << sig1
       method.sigs << sig2
       rbi << method
@@ -620,11 +620,11 @@ module RBI
     end
 
     def test_print_tree_header_comments
-      rbi = RBI::Tree.new(comments: [
-        RBI::Comment.new("typed: true"),
-        RBI::Comment.new("frozen_string_literal: false"),
+      rbi = Tree.new(comments: [
+        Comment.new("typed: true"),
+        Comment.new("frozen_string_literal: false"),
       ])
-      rbi << RBI::Module.new("Foo", comments: [RBI::Comment.new("Foo comment")])
+      rbi << Module.new("Foo", comments: [Comment.new("Foo comment")])
 
       assert_equal(<<~RBI, rbi.string)
         # typed: true
@@ -636,11 +636,11 @@ module RBI
     end
 
     def test_print_empty_comments
-      tree = RBI::Tree.new(comments: [
-        RBI::Comment.new("typed: true"),
-        RBI::Comment.new(""),
-        RBI::Comment.new("Some intro comment"),
-        RBI::Comment.new("Some other comment"),
+      tree = Tree.new(comments: [
+        Comment.new("typed: true"),
+        Comment.new(""),
+        Comment.new("Some intro comment"),
+        Comment.new("Some other comment"),
       ])
 
       assert_equal(<<~RBI, tree.string)
@@ -652,8 +652,8 @@ module RBI
     end
 
     def test_print_empty_trees_with_comments
-      rbi = RBI::File.new(strictness: "true")
-      rbi.root.comments << RBI::Comment.new("foo")
+      rbi = File.new(strictness: "true")
+      rbi.root.comments << Comment.new("foo")
 
       assert_equal(<<~RBI, rbi.string)
         # typed: true
@@ -663,16 +663,16 @@ module RBI
     end
 
     def test_print_params_inline_comments
-      comments = [RBI::Comment.new("comment")]
+      comments = [Comment.new("comment")]
 
-      method = RBI::Method.new("foo", comments: comments)
-      method << RBI::ReqParam.new("a", comments: comments)
-      method << RBI::OptParam.new("b", "42", comments: comments)
-      method << RBI::RestParam.new("c", comments: comments)
-      method << RBI::KwParam.new("d", comments: comments)
-      method << RBI::KwOptParam.new("e", "'bar'", comments: comments)
-      method << RBI::KwRestParam.new("f", comments: comments)
-      method << RBI::BlockParam.new("g", comments: comments)
+      method = Method.new("foo", comments: comments)
+      method << ReqParam.new("a", comments: comments)
+      method << OptParam.new("b", "42", comments: comments)
+      method << RestParam.new("c", comments: comments)
+      method << KwParam.new("d", comments: comments)
+      method << KwOptParam.new("e", "'bar'", comments: comments)
+      method << KwRestParam.new("f", comments: comments)
+      method << BlockParam.new("g", comments: comments)
 
       assert_equal(<<~RBI, method.string)
         # comment
@@ -690,18 +690,18 @@ module RBI
 
     def test_print_params_multiline_comments
       comments = [
-        RBI::Comment.new("comment 1"),
-        RBI::Comment.new("comment 2"),
+        Comment.new("comment 1"),
+        Comment.new("comment 2"),
       ]
 
-      method = RBI::Method.new("foo", comments: comments)
-      method << RBI::ReqParam.new("a", comments: comments)
-      method << RBI::OptParam.new("b", "42", comments: comments)
-      method << RBI::RestParam.new("c", comments: comments)
-      method << RBI::KwParam.new("d", comments: comments)
-      method << RBI::KwOptParam.new("e", "'bar'", comments: comments)
-      method << RBI::KwRestParam.new("f", comments: comments)
-      method << RBI::BlockParam.new("g", comments: comments)
+      method = Method.new("foo", comments: comments)
+      method << ReqParam.new("a", comments: comments)
+      method << OptParam.new("b", "42", comments: comments)
+      method << RestParam.new("c", comments: comments)
+      method << KwParam.new("d", comments: comments)
+      method << KwOptParam.new("e", "'bar'", comments: comments)
+      method << KwRestParam.new("f", comments: comments)
+      method << BlockParam.new("g", comments: comments)
 
       assert_equal(<<~RBI, method.string)
         # comment 1
@@ -726,12 +726,12 @@ module RBI
     end
 
     def test_print_sig_params_inline_comments
-      comments = [RBI::Comment.new("comment")]
+      comments = [Comment.new("comment")]
 
-      sig = RBI::Sig.new
-      sig << RBI::SigParam.new("a", "Integer", comments: comments)
-      sig << RBI::SigParam.new("b", "String", comments: comments)
-      sig << RBI::SigParam.new("c", "T.untyped", comments: comments)
+      sig = Sig.new
+      sig << SigParam.new("a", "Integer", comments: comments)
+      sig << SigParam.new("b", "String", comments: comments)
+      sig << SigParam.new("c", "T.untyped", comments: comments)
 
       assert_equal(<<~RBI, sig.string)
         sig do
@@ -746,14 +746,14 @@ module RBI
 
     def test_print_sig_params_multiline_comments
       comments = [
-        RBI::Comment.new("comment 1"),
-        RBI::Comment.new("comment 2"),
+        Comment.new("comment 1"),
+        Comment.new("comment 2"),
       ]
 
-      sig = RBI::Sig.new
-      sig << RBI::SigParam.new("a", "Integer", comments: comments)
-      sig << RBI::SigParam.new("b", "String", comments: comments)
-      sig << RBI::SigParam.new("c", "T.untyped", comments: comments)
+      sig = Sig.new
+      sig << SigParam.new("a", "Integer", comments: comments)
+      sig << SigParam.new("b", "String", comments: comments)
+      sig << SigParam.new("c", "T.untyped", comments: comments)
 
       assert_equal(<<~RBI, sig.string)
         sig do
@@ -771,26 +771,26 @@ module RBI
 
     def test_print_blank_lines
       comments = [
-        RBI::Comment.new("comment 1"),
+        Comment.new("comment 1"),
         BlankLine.new,
-        RBI::Comment.new("comment 2"),
+        Comment.new("comment 2"),
       ]
 
       rbi = Module.new("Foo", comments: comments) do |mod|
         mod << BlankLine.new
-        mod << RBI::Method.new("foo")
+        mod << Method.new("foo")
         mod << BlankLine.new
         mod << BlankLine.new
         mod << BlankLine.new
 
         mod << Class.new("Bar") do |cls|
-          cls << RBI::Comment.new("begin")
+          cls << Comment.new("begin")
           cls << BlankLine.new
           cls << BlankLine.new
-          cls << RBI::Comment.new("middle")
+          cls << Comment.new("middle")
           cls << BlankLine.new
           cls << BlankLine.new
-          cls << RBI::Comment.new("end")
+          cls << Comment.new("end")
         end
       end
 
@@ -818,11 +818,11 @@ module RBI
     end
 
     def test_print_new_lines_between_scopes
-      rbi = RBI::Tree.new
-      scope = RBI::Class.new("Bar")
-      scope << RBI::Include.new("ModuleA")
+      rbi = Tree.new
+      scope = Class.new("Bar")
+      scope << Include.new("ModuleA")
       rbi << scope
-      rbi << RBI::Module.new("ModuleA")
+      rbi << Module.new("ModuleA")
 
       rbi.group_nodes!
       rbi.sort_nodes!
@@ -837,27 +837,27 @@ module RBI
     end
 
     def test_print_new_lines_between_methods_with_sigs
-      rbi = RBI::Tree.new
-      rbi << RBI::Method.new("m1")
-      rbi << RBI::Method.new("m2")
+      rbi = Tree.new
+      rbi << Method.new("m1")
+      rbi << Method.new("m2")
 
-      m3 = RBI::Method.new("m3")
-      m3.sigs << RBI::Sig.new
+      m3 = Method.new("m3")
+      m3.sigs << Sig.new
       rbi << m3
 
-      rbi << RBI::Method.new("m4")
+      rbi << Method.new("m4")
 
-      m5 = RBI::Method.new("m5")
-      m5.sigs << RBI::Sig.new
-      m5.sigs << RBI::Sig.new
+      m5 = Method.new("m5")
+      m5.sigs << Sig.new
+      m5.sigs << Sig.new
       rbi << m5
 
-      m6 = RBI::Method.new("m6")
-      m6.sigs << RBI::Sig.new
+      m6 = Method.new("m6")
+      m6.sigs << Sig.new
       rbi << m6
 
-      rbi << RBI::Method.new("m7")
-      rbi << RBI::Method.new("m8")
+      rbi << Method.new("m7")
+      rbi << Method.new("m8")
 
       rbi.group_nodes!
       rbi.sort_nodes!
@@ -884,23 +884,23 @@ module RBI
     end
 
     def test_print_nodes_locations
-      loc = RBI::Loc.new(file: "file.rbi", begin_line: 1, end_line: 2, begin_column: 3, end_column: 4)
+      loc = Loc.new(file: "file.rbi", begin_line: 1, end_line: 2, begin_column: 3, end_column: 4)
 
-      rbi = RBI::Tree.new(loc: loc)
-      rbi << RBI::Module.new("S1", loc: loc)
-      rbi << RBI::Class.new("S2", loc: loc)
-      rbi << RBI::SingletonClass.new(loc: loc)
-      rbi << RBI::TEnum.new("TE", loc: loc)
-      rbi << RBI::TStruct.new("TS", loc: loc)
-      rbi << RBI::Const.new("C", "42", loc: loc)
-      rbi << RBI::Extend.new("E", loc: loc)
-      rbi << RBI::Include.new("I", loc: loc)
-      rbi << RBI::Send.new("foo", loc: loc)
-      rbi << RBI::MixesInClassMethods.new("MICM", loc: loc)
-      rbi << RBI::Helper.new("abstract", loc: loc)
-      rbi << RBI::TStructConst.new("SC", "Type", loc: loc)
-      rbi << RBI::TStructProp.new("SP", "Type", loc: loc)
-      rbi << RBI::Method.new("m1", loc: loc)
+      rbi = Tree.new(loc: loc)
+      rbi << Module.new("S1", loc: loc)
+      rbi << Class.new("S2", loc: loc)
+      rbi << SingletonClass.new(loc: loc)
+      rbi << TEnum.new("TE", loc: loc)
+      rbi << TStruct.new("TS", loc: loc)
+      rbi << Const.new("C", "42", loc: loc)
+      rbi << Extend.new("E", loc: loc)
+      rbi << Include.new("I", loc: loc)
+      rbi << Send.new("foo", loc: loc)
+      rbi << MixesInClassMethods.new("MICM", loc: loc)
+      rbi << Helper.new("abstract", loc: loc)
+      rbi << TStructConst.new("SC", "Type", loc: loc)
+      rbi << TStructProp.new("SP", "Type", loc: loc)
+      rbi << Method.new("m1", loc: loc)
 
       assert_equal(<<~RBI, rbi.string(print_locs: true))
         # file.rbi:1:3-2:4
@@ -935,13 +935,13 @@ module RBI
     end
 
     def test_print_sigs_locations
-      loc = RBI::Loc.new(file: "file.rbi", begin_line: 1, end_line: 2, begin_column: 3, end_column: 4)
+      loc = Loc.new(file: "file.rbi", begin_line: 1, end_line: 2, begin_column: 3, end_column: 4)
 
-      sig1 = RBI::Sig.new(loc: loc)
-      sig2 = RBI::Sig.new(loc: loc)
+      sig1 = Sig.new(loc: loc)
+      sig2 = Sig.new(loc: loc)
 
-      rbi = RBI::Tree.new(loc: loc)
-      rbi << RBI::Method.new("m1", sigs: [sig1, sig2], loc: loc)
+      rbi = Tree.new(loc: loc)
+      rbi << Method.new("m1", sigs: [sig1, sig2], loc: loc)
 
       assert_equal(<<~RBI, rbi.string(print_locs: true))
         # file.rbi:1:3-2:4

--- a/test/rbi/rewriters/add_sig_templates_test.rb
+++ b/test/rbi/rewriters/add_sig_templates_test.rb
@@ -6,13 +6,13 @@ require "test_helper"
 module RBI
   class AddSigTemplatesTest < Minitest::Test
     def test_do_not_add_sig_if_already_one
-      rbi = RBI::Tree.new
+      rbi = Tree.new
 
-      rbi << RBI::AttrReader.new(:a) do |attr|
+      rbi << AttrReader.new(:a) do |attr|
         attr.sigs << Sig.new(return_type: "Integer")
       end
 
-      rbi << RBI::Method.new("m") do |meth|
+      rbi << Method.new("m") do |meth|
         meth.sigs << Sig.new(return_type: "Integer")
       end
 
@@ -28,10 +28,10 @@ module RBI
     end
 
     def test_add_empty_sigs_to_attributes
-      rbi = RBI::Tree.new
-      rbi << RBI::AttrReader.new(:a1)
-      rbi << RBI::AttrWriter.new(:a2)
-      rbi << RBI::AttrAccessor.new(:a3)
+      rbi = Tree.new
+      rbi << AttrReader.new(:a1)
+      rbi << AttrWriter.new(:a2)
+      rbi << AttrAccessor.new(:a3)
 
       rbi.add_sig_templates!(with_todo_comment: false)
 
@@ -48,10 +48,10 @@ module RBI
     end
 
     def test_add_empty_sigs_and_todo_comment_to_attributes
-      rbi = RBI::Tree.new
-      rbi << RBI::AttrReader.new(:a1)
-      rbi << RBI::AttrWriter.new(:a2)
-      rbi << RBI::AttrAccessor.new(:a3)
+      rbi = Tree.new
+      rbi << AttrReader.new(:a1)
+      rbi << AttrWriter.new(:a2)
+      rbi << AttrAccessor.new(:a3)
 
       rbi.add_sig_templates!(with_todo_comment: true)
 
@@ -71,15 +71,15 @@ module RBI
     end
 
     def test_add_empty_sigs_to_methods
-      rbi = RBI::Tree.new
-      rbi << RBI::Method.new("m1")
-      rbi << RBI::Method.new("m2") do |meth|
-        meth << RBI::Param.new("x")
+      rbi = Tree.new
+      rbi << Method.new("m1")
+      rbi << Method.new("m2") do |meth|
+        meth << Param.new("x")
       end
-      rbi << RBI::Method.new("m3", is_singleton: true) do |meth|
-        meth << RBI::Param.new("x")
-        meth << RBI::OptParam.new("y", "42")
-        meth << RBI::KwRestParam.new("z")
+      rbi << Method.new("m3", is_singleton: true) do |meth|
+        meth << Param.new("x")
+        meth << OptParam.new("y", "42")
+        meth << KwRestParam.new("z")
       end
 
       rbi.add_sig_templates!(with_todo_comment: false)
@@ -97,15 +97,15 @@ module RBI
     end
 
     def test_add_empty_sigs_and_todo_comment_to_methods
-      rbi = RBI::Tree.new
-      rbi << RBI::Method.new("m1")
-      rbi << RBI::Method.new("m2") do |meth|
-        meth << RBI::Param.new("x")
+      rbi = Tree.new
+      rbi << Method.new("m1")
+      rbi << Method.new("m2") do |meth|
+        meth << Param.new("x")
       end
-      rbi << RBI::Method.new("m3", is_singleton: true) do |meth|
-        meth << RBI::Param.new("x")
-        meth << RBI::OptParam.new("y", "42")
-        meth << RBI::KwRestParam.new("z")
+      rbi << Method.new("m3", is_singleton: true) do |meth|
+        meth << Param.new("x")
+        meth << OptParam.new("y", "42")
+        meth << KwRestParam.new("z")
       end
 
       rbi.add_sig_templates!(with_todo_comment: true)

--- a/test/rbi/rewriters/annotate_test.rb
+++ b/test/rbi/rewriters/annotate_test.rb
@@ -6,7 +6,7 @@ require "test_helper"
 module RBI
   class AnnotateTest < Minitest::Test
     def test_add_annotation_to_root_nodes
-      rbi = RBI::Parser.parse_string(<<~RBI)
+      rbi = Parser.parse_string(<<~RBI)
         module A
           class B
             def m; end
@@ -36,7 +36,7 @@ module RBI
     end
 
     def test_add_annotation_to_all_scopes
-      rbi = RBI::Parser.parse_string(<<~RBI)
+      rbi = Parser.parse_string(<<~RBI)
         module A
           FOO = type_member
 
@@ -78,7 +78,7 @@ module RBI
     end
 
     def test_add_annotation_to_all_properties
-      rbi = RBI::Parser.parse_string(<<~RBI)
+      rbi = Parser.parse_string(<<~RBI)
         # Root scope are always annotated
         module A
           FOO = type_member
@@ -132,7 +132,7 @@ module RBI
     end
 
     def test_add_annotation_to_all_nodes
-      rbi = RBI::Parser.parse_string(<<~RBI)
+      rbi = Parser.parse_string(<<~RBI)
         module A
           FOO = type_member
 
@@ -183,7 +183,7 @@ module RBI
     end
 
     def test_does_not_reannotate_already_annotated_nodes
-      rbi = RBI::Parser.parse_string(<<~RBI)
+      rbi = Parser.parse_string(<<~RBI)
         # @test
         module A
           # @test
@@ -209,7 +209,7 @@ module RBI
     end
 
     def test_add_different_annotation_to_nodes
-      rbi = RBI::Parser.parse_string(<<~RBI)
+      rbi = Parser.parse_string(<<~RBI)
         # @test
         module A
           # @test

--- a/test/rbi/rewriters/deannotate_test.rb
+++ b/test/rbi/rewriters/deannotate_test.rb
@@ -6,7 +6,7 @@ require "test_helper"
 module RBI
   class AnnotateTest < Minitest::Test
     def test_deannotate_nodes
-      rbi = RBI::Parser.parse_string(<<~RBI)
+      rbi = Parser.parse_string(<<~RBI)
         # @test
         module A
           # @test
@@ -56,7 +56,7 @@ module RBI
     end
 
     def test_deannotate_only_removes_the_matching_annotation
-      rbi = RBI::Parser.parse_string(<<~RBI)
+      rbi = Parser.parse_string(<<~RBI)
         # @test
         # @other
         module A

--- a/test/rbi/rewriters/group_nodes_test.rb
+++ b/test/rbi/rewriters/group_nodes_test.rb
@@ -6,23 +6,23 @@ require "test_helper"
 module RBI
   class GroupNodesTest < Minitest::Test
     def test_group_nodes_in_tree
-      rbi = RBI::Tree.new
-      rbi << RBI::Const.new("C", "42")
-      rbi << RBI::Module.new("S1")
-      rbi << RBI::Class.new("S2")
-      rbi << RBI::Struct.new("S3")
-      rbi << RBI::Method.new("m1")
-      rbi << RBI::Method.new("m2", is_singleton: true)
-      rbi << RBI::Extend.new("E")
-      rbi << RBI::Include.new("I")
-      rbi << RBI::MixesInClassMethods.new("MICM")
-      rbi << RBI::Helper.new("h")
-      rbi << RBI::TStructConst.new("SC", "Type")
-      rbi << RBI::TStructProp.new("SP", "Type")
-      rbi << RBI::TEnum.new("TE")
-      rbi << RBI::SingletonClass.new
-      rbi << RBI::TStruct.new("TS")
-      rbi << RBI::Send.new("foo")
+      rbi = Tree.new
+      rbi << Const.new("C", "42")
+      rbi << Module.new("S1")
+      rbi << Class.new("S2")
+      rbi << Struct.new("S3")
+      rbi << Method.new("m1")
+      rbi << Method.new("m2", is_singleton: true)
+      rbi << Extend.new("E")
+      rbi << Include.new("I")
+      rbi << MixesInClassMethods.new("MICM")
+      rbi << Helper.new("h")
+      rbi << TStructConst.new("SC", "Type")
+      rbi << TStructProp.new("SP", "Type")
+      rbi << TEnum.new("TE")
+      rbi << SingletonClass.new
+      rbi << TStruct.new("TS")
+      rbi << Send.new("foo")
 
       rbi.group_nodes!
       rbi.sort_nodes!
@@ -55,24 +55,24 @@ module RBI
     end
 
     def test_group_nested_nodes
-      rbi = RBI::Tree.new
+      rbi = Tree.new
 
-      scope1 = RBI::Class.new("Scope1")
-      scope1 << RBI::Include.new("I1")
-      scope1 << RBI::Method.new("m1")
-      scope1 << RBI::Method.new("m2")
-      scope1 << RBI::Send.new("foo")
+      scope1 = Class.new("Scope1")
+      scope1 << Include.new("I1")
+      scope1 << Method.new("m1")
+      scope1 << Method.new("m2")
+      scope1 << Send.new("foo")
 
-      scope2 = RBI::Module.new("Scope2")
-      scope2 << RBI::Const.new("C1", "42")
-      scope2 << RBI::SingletonClass.new
-      scope2 << RBI::Const.new("C2", "42")
-      scope2 << RBI::Module.new("M1")
+      scope2 = Module.new("Scope2")
+      scope2 << Const.new("C1", "42")
+      scope2 << SingletonClass.new
+      scope2 << Const.new("C2", "42")
+      scope2 << Module.new("M1")
 
-      scope3 = RBI::Struct.new("Scope3")
-      scope3 << RBI::Extend.new("E1")
-      scope3 << RBI::Extend.new("E2")
-      scope3 << RBI::MixesInClassMethods.new("MICM1")
+      scope3 = Struct.new("Scope3")
+      scope3 << Extend.new("E1")
+      scope3 << Extend.new("E2")
+      scope3 << MixesInClassMethods.new("MICM1")
 
       rbi << scope1
       scope1 << scope2
@@ -109,23 +109,23 @@ module RBI
     end
 
     def test_group_sort_nodes_in_groups
-      rbi = RBI::Tree.new
-      rbi << RBI::Const.new("C", "42")
-      rbi << RBI::Module.new("S1")
-      rbi << RBI::Class.new("S2")
-      rbi << RBI::SingletonClass.new
-      rbi << RBI::Struct.new("S3")
-      rbi << RBI::Method.new("m1")
-      rbi << RBI::Method.new("m2", is_singleton: true)
-      rbi << RBI::Extend.new("E")
-      rbi << RBI::Include.new("I")
-      rbi << RBI::MixesInClassMethods.new("MICM")
-      rbi << RBI::Helper.new("h")
-      rbi << RBI::TStructConst.new("SC", "Type")
-      rbi << RBI::TStructProp.new("SP", "Type")
-      rbi << RBI::TEnum.new("TE")
-      rbi << RBI::TStruct.new("TS")
-      rbi << RBI::Send.new("foo")
+      rbi = Tree.new
+      rbi << Const.new("C", "42")
+      rbi << Module.new("S1")
+      rbi << Class.new("S2")
+      rbi << SingletonClass.new
+      rbi << Struct.new("S3")
+      rbi << Method.new("m1")
+      rbi << Method.new("m2", is_singleton: true)
+      rbi << Extend.new("E")
+      rbi << Include.new("I")
+      rbi << MixesInClassMethods.new("MICM")
+      rbi << Helper.new("h")
+      rbi << TStructConst.new("SC", "Type")
+      rbi << TStructProp.new("SP", "Type")
+      rbi << TEnum.new("TE")
+      rbi << TStruct.new("TS")
+      rbi << Send.new("foo")
 
       rbi.group_nodes!
       rbi.sort_nodes!
@@ -158,13 +158,13 @@ module RBI
     end
 
     def test_group_does_not_sort_mixins
-      rbi = RBI::Tree.new
-      rbi << RBI::Include.new("I2")
-      rbi << RBI::Extend.new("E2")
-      rbi << RBI::MixesInClassMethods.new("M2")
-      rbi << RBI::Include.new("I1")
-      rbi << RBI::Extend.new("E1")
-      rbi << RBI::MixesInClassMethods.new("M1")
+      rbi = Tree.new
+      rbi << Include.new("I2")
+      rbi << Extend.new("E2")
+      rbi << MixesInClassMethods.new("M2")
+      rbi << Include.new("I1")
+      rbi << Extend.new("E1")
+      rbi << MixesInClassMethods.new("M1")
 
       rbi.group_nodes!
       rbi.sort_nodes!
@@ -181,11 +181,11 @@ module RBI
     end
 
     def test_group_does_not_sort_sends
-      rbi = RBI::Tree.new
-      rbi << RBI::Send.new("send4")
-      rbi << RBI::Send.new("send2")
-      rbi << RBI::Send.new("send3")
-      rbi << RBI::Send.new("send1")
+      rbi = Tree.new
+      rbi << Send.new("send4")
+      rbi << Send.new("send2")
+      rbi << Send.new("send3")
+      rbi << Send.new("send1")
 
       rbi.group_nodes!
       rbi.sort_nodes!
@@ -199,11 +199,11 @@ module RBI
     end
 
     def test_group_does_not_sort_type_members
-      rbi = RBI::Tree.new
-      rbi << RBI::TypeMember.new("T4", "type_member")
-      rbi << RBI::TypeMember.new("T3", "type_template")
-      rbi << RBI::TypeMember.new("T2", "type_member")
-      rbi << RBI::TypeMember.new("T1", "type_template")
+      rbi = Tree.new
+      rbi << TypeMember.new("T4", "type_member")
+      rbi << TypeMember.new("T3", "type_template")
+      rbi << TypeMember.new("T2", "type_member")
+      rbi << TypeMember.new("T1", "type_template")
 
       rbi.group_nodes!
       rbi.sort_nodes!
@@ -217,27 +217,27 @@ module RBI
     end
 
     def test_group_sort_nodes_in_scope
-      rbi = RBI::Tree.new
-      scope = RBI::Module.new("Scope")
-      scope << RBI::Const.new("C", "42")
-      scope << RBI::SingletonClass.new
-      scope << RBI::Module.new("S1")
-      scope << RBI::Class.new("S2")
-      scope << RBI::Struct.new("S3")
-      scope << RBI::Method.new("m1")
-      scope << RBI::Method.new("m2", is_singleton: true)
-      scope << RBI::Include.new("I")
-      scope << RBI::Extend.new("E")
-      scope << RBI::MixesInClassMethods.new("MICM")
-      scope << RBI::Helper.new("h")
-      scope << RBI::TStructProp.new("SP", "Type")
-      scope << RBI::TStructConst.new("SC", "Type")
-      scope << RBI::TEnum.new("TE")
-      scope << RBI::TStruct.new("TS")
-      scope << RBI::TypeMember.new("TM2", "type_template")
-      scope << RBI::TypeMember.new("TM1", "type_member")
-      scope << RBI::Send.new("send2")
-      scope << RBI::Send.new("send1")
+      rbi = Tree.new
+      scope = Module.new("Scope")
+      scope << Const.new("C", "42")
+      scope << SingletonClass.new
+      scope << Module.new("S1")
+      scope << Class.new("S2")
+      scope << Struct.new("S3")
+      scope << Method.new("m1")
+      scope << Method.new("m2", is_singleton: true)
+      scope << Include.new("I")
+      scope << Extend.new("E")
+      scope << MixesInClassMethods.new("MICM")
+      scope << Helper.new("h")
+      scope << TStructProp.new("SP", "Type")
+      scope << TStructConst.new("SC", "Type")
+      scope << TEnum.new("TE")
+      scope << TStruct.new("TS")
+      scope << TypeMember.new("TM2", "type_template")
+      scope << TypeMember.new("TM1", "type_member")
+      scope << Send.new("send2")
+      scope << Send.new("send1")
       rbi << scope
 
       rbi.group_nodes!
@@ -277,33 +277,33 @@ module RBI
     end
 
     def test_group_sort_groups_in_tree
-      rbi = RBI::Tree.new
-      rbi << RBI::Const.new("C2", "42")
-      rbi << RBI::SingletonClass.new
-      rbi << RBI::Module.new("S2")
-      rbi << RBI::Method.new("m2")
-      rbi << RBI::Include.new("I2")
-      rbi << RBI::Extend.new("E2")
-      rbi << RBI::MixesInClassMethods.new("MICM2")
-      rbi << RBI::Helper.new("h2")
-      rbi << RBI::TStructProp.new("SP2", "Type")
-      rbi << RBI::TStructConst.new("SC2", "Type")
-      rbi << RBI::TEnum.new("TE2")
-      rbi << RBI::TStruct.new("TS2")
-      rbi << RBI::Const.new("C1", "42")
-      rbi << RBI::Class.new("S1")
-      rbi << RBI::Method.new("m1")
-      rbi << RBI::Include.new("I1")
-      rbi << RBI::Extend.new("E1")
-      rbi << RBI::MixesInClassMethods.new("MICM1")
-      rbi << RBI::Helper.new("h1")
-      rbi << RBI::TStructProp.new("SP1", "Type")
-      rbi << RBI::TStructConst.new("SC1", "Type")
-      rbi << RBI::TEnum.new("TE1")
-      rbi << RBI::TStruct.new("TS1")
-      rbi << RBI::Struct.new("S3")
-      rbi << RBI::TypeMember.new("TM2", "type_template")
-      rbi << RBI::TypeMember.new("TM1", "type_member")
+      rbi = Tree.new
+      rbi << Const.new("C2", "42")
+      rbi << SingletonClass.new
+      rbi << Module.new("S2")
+      rbi << Method.new("m2")
+      rbi << Include.new("I2")
+      rbi << Extend.new("E2")
+      rbi << MixesInClassMethods.new("MICM2")
+      rbi << Helper.new("h2")
+      rbi << TStructProp.new("SP2", "Type")
+      rbi << TStructConst.new("SC2", "Type")
+      rbi << TEnum.new("TE2")
+      rbi << TStruct.new("TS2")
+      rbi << Const.new("C1", "42")
+      rbi << Class.new("S1")
+      rbi << Method.new("m1")
+      rbi << Include.new("I1")
+      rbi << Extend.new("E1")
+      rbi << MixesInClassMethods.new("MICM1")
+      rbi << Helper.new("h1")
+      rbi << TStructProp.new("SP1", "Type")
+      rbi << TStructConst.new("SC1", "Type")
+      rbi << TEnum.new("TE1")
+      rbi << TStruct.new("TS1")
+      rbi << Struct.new("S3")
+      rbi << TypeMember.new("TM2", "type_template")
+      rbi << TypeMember.new("TM1", "type_member")
 
       rbi.group_nodes!
       rbi.sort_nodes!
@@ -346,90 +346,90 @@ module RBI
     end
 
     def test_group_sort_nested_groups
-      rbi = RBI::Tree.new
+      rbi = Tree.new
 
-      sscope = RBI::Class.new("Scope2.1")
-      sscope << RBI::Const.new("C2", "42")
-      sscope << RBI::Module.new("S2")
-      sscope << RBI::Method.new("m2")
-      sscope << RBI::Include.new("I2")
-      sscope << RBI::Extend.new("E2")
-      sscope << RBI::MixesInClassMethods.new("MICM2")
-      sscope << RBI::Helper.new("h2")
-      sscope << RBI::TStructProp.new("SP2", "Type")
-      sscope << RBI::TStructConst.new("SC2", "Type")
-      sscope << RBI::TEnum.new("TE2")
-      sscope << RBI::TStruct.new("TS2")
-      sscope << RBI::Const.new("C1", "42")
-      sscope << RBI::Class.new("S1")
-      sscope << RBI::Method.new("m1")
-      sscope << RBI::Include.new("I1")
-      sscope << RBI::Extend.new("E1")
-      sscope << RBI::MixesInClassMethods.new("MICM1")
-      sscope << RBI::Helper.new("h1")
-      sscope << RBI::TStructProp.new("SP1", "Type")
-      sscope << RBI::TStructConst.new("SC1", "Type")
-      sscope << RBI::TEnum.new("TE1")
-      sscope << RBI::TStruct.new("TS1")
-      sscope << RBI::Struct.new("S3")
-      sscope << RBI::TypeMember.new("TM2", "type_template")
-      sscope << RBI::TypeMember.new("TM1", "type_member")
+      sscope = Class.new("Scope2.1")
+      sscope << Const.new("C2", "42")
+      sscope << Module.new("S2")
+      sscope << Method.new("m2")
+      sscope << Include.new("I2")
+      sscope << Extend.new("E2")
+      sscope << MixesInClassMethods.new("MICM2")
+      sscope << Helper.new("h2")
+      sscope << TStructProp.new("SP2", "Type")
+      sscope << TStructConst.new("SC2", "Type")
+      sscope << TEnum.new("TE2")
+      sscope << TStruct.new("TS2")
+      sscope << Const.new("C1", "42")
+      sscope << Class.new("S1")
+      sscope << Method.new("m1")
+      sscope << Include.new("I1")
+      sscope << Extend.new("E1")
+      sscope << MixesInClassMethods.new("MICM1")
+      sscope << Helper.new("h1")
+      sscope << TStructProp.new("SP1", "Type")
+      sscope << TStructConst.new("SC1", "Type")
+      sscope << TEnum.new("TE1")
+      sscope << TStruct.new("TS1")
+      sscope << Struct.new("S3")
+      sscope << TypeMember.new("TM2", "type_template")
+      sscope << TypeMember.new("TM1", "type_member")
 
-      scope = RBI::Class.new("Scope2")
+      scope = Class.new("Scope2")
       scope << sscope
-      scope << RBI::Const.new("C2", "42")
-      scope << RBI::Module.new("S2")
-      scope << RBI::Method.new("m2")
-      scope << RBI::Include.new("I2")
-      scope << RBI::Extend.new("E2")
-      scope << RBI::MixesInClassMethods.new("MICM2")
-      scope << RBI::Helper.new("h2")
-      scope << RBI::TStructProp.new("SP2", "Type")
-      scope << RBI::TStructConst.new("SC2", "Type")
-      scope << RBI::TEnum.new("TE2")
-      scope << RBI::TStruct.new("TS2")
-      scope << RBI::Const.new("C1", "42")
-      scope << RBI::Class.new("S1")
-      scope << RBI::Method.new("m1")
-      scope << RBI::Include.new("I1")
-      scope << RBI::Extend.new("E1")
-      scope << RBI::MixesInClassMethods.new("MICM1")
-      scope << RBI::Helper.new("h1")
-      scope << RBI::TStructProp.new("SP1", "Type")
-      scope << RBI::TStructConst.new("SC1", "Type")
-      scope << RBI::TEnum.new("TE1")
-      scope << RBI::TStruct.new("TS1")
-      scope << RBI::Struct.new("S3")
-      scope << RBI::TypeMember.new("TM2", "type_template")
-      scope << RBI::TypeMember.new("TM1", "type_member")
+      scope << Const.new("C2", "42")
+      scope << Module.new("S2")
+      scope << Method.new("m2")
+      scope << Include.new("I2")
+      scope << Extend.new("E2")
+      scope << MixesInClassMethods.new("MICM2")
+      scope << Helper.new("h2")
+      scope << TStructProp.new("SP2", "Type")
+      scope << TStructConst.new("SC2", "Type")
+      scope << TEnum.new("TE2")
+      scope << TStruct.new("TS2")
+      scope << Const.new("C1", "42")
+      scope << Class.new("S1")
+      scope << Method.new("m1")
+      scope << Include.new("I1")
+      scope << Extend.new("E1")
+      scope << MixesInClassMethods.new("MICM1")
+      scope << Helper.new("h1")
+      scope << TStructProp.new("SP1", "Type")
+      scope << TStructConst.new("SC1", "Type")
+      scope << TEnum.new("TE1")
+      scope << TStruct.new("TS1")
+      scope << Struct.new("S3")
+      scope << TypeMember.new("TM2", "type_template")
+      scope << TypeMember.new("TM1", "type_member")
       rbi << scope
 
-      scope = RBI::Class.new("Scope1")
-      scope << RBI::Const.new("C2", "42")
-      scope << RBI::Module.new("S2")
-      scope << RBI::Method.new("m2")
-      scope << RBI::Include.new("I2")
-      scope << RBI::Extend.new("E2")
-      scope << RBI::MixesInClassMethods.new("MICM2")
-      scope << RBI::Helper.new("h2")
-      scope << RBI::TStructProp.new("SP2", "Type")
-      scope << RBI::TStructConst.new("SC2", "Type")
-      scope << RBI::TEnum.new("TE2")
-      scope << RBI::TStruct.new("TS2")
-      scope << RBI::Const.new("C1", "42")
-      scope << RBI::Class.new("S1")
-      scope << RBI::Method.new("m1")
-      scope << RBI::Include.new("I1")
-      scope << RBI::Extend.new("E1")
-      scope << RBI::MixesInClassMethods.new("MICM1")
-      scope << RBI::Helper.new("h1")
-      scope << RBI::TStructProp.new("SP1", "Type")
-      scope << RBI::TStructConst.new("SC1", "Type")
-      scope << RBI::TEnum.new("TE1")
-      scope << RBI::TStruct.new("TS1")
-      scope << RBI::Struct.new("S3")
-      scope << RBI::TypeMember.new("TM2", "type_template")
-      scope << RBI::TypeMember.new("TM1", "type_member")
+      scope = Class.new("Scope1")
+      scope << Const.new("C2", "42")
+      scope << Module.new("S2")
+      scope << Method.new("m2")
+      scope << Include.new("I2")
+      scope << Extend.new("E2")
+      scope << MixesInClassMethods.new("MICM2")
+      scope << Helper.new("h2")
+      scope << TStructProp.new("SP2", "Type")
+      scope << TStructConst.new("SC2", "Type")
+      scope << TEnum.new("TE2")
+      scope << TStruct.new("TS2")
+      scope << Const.new("C1", "42")
+      scope << Class.new("S1")
+      scope << Method.new("m1")
+      scope << Include.new("I1")
+      scope << Extend.new("E1")
+      scope << MixesInClassMethods.new("MICM1")
+      scope << Helper.new("h1")
+      scope << TStructProp.new("SP1", "Type")
+      scope << TStructConst.new("SC1", "Type")
+      scope << TEnum.new("TE1")
+      scope << TStruct.new("TS1")
+      scope << Struct.new("S3")
+      scope << TypeMember.new("TM2", "type_template")
+      scope << TypeMember.new("TM1", "type_member")
       rbi << scope
 
       rbi.group_nodes!

--- a/test/rbi/rewriters/merge_trees_test.rb
+++ b/test/rbi/rewriters/merge_trees_test.rb
@@ -6,18 +6,18 @@ require "test_helper"
 module RBI
   class MergeTest < Minitest::Test
     def test_merge_empty_trees
-      rbi1 = RBI::Tree.new
-      rbi2 = RBI::Tree.new
+      rbi1 = Tree.new
+      rbi2 = Tree.new
       res = rbi1.merge(rbi2)
       assert_equal("", res.string)
     end
 
     def test_merge_empty_tree_into_tree
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         class Foo; end
       RBI
 
-      rbi2 = RBI::Tree.new
+      rbi2 = Tree.new
 
       res = rbi1.merge(rbi2)
       assert_equal(<<~RBI, res.string)
@@ -26,9 +26,9 @@ module RBI
     end
 
     def test_merge_tree_into_empty_tree
-      rbi1 = RBI::Tree.new
+      rbi1 = Tree.new
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         class Foo; end
       RBI
 
@@ -39,12 +39,12 @@ module RBI
     end
 
     def test_merge_scopes_together
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         class A; end
         class B; end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         class C; end
         class D; end
       RBI
@@ -59,13 +59,13 @@ module RBI
     end
 
     def test_merge_nested_scopes_together
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         class A
           class B; end
         end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         class C
           class D; end
         end
@@ -84,13 +84,13 @@ module RBI
     end
 
     def test_merge_same_scopes_together
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         class A
           class B; end
         end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         class A
           class B; end
           class C; end
@@ -107,14 +107,14 @@ module RBI
     end
 
     def test_merge_constants_together
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         class A
           A = 42
         end
         B = 42
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         class A
           A = 42
           B = 42
@@ -134,7 +134,7 @@ module RBI
     end
 
     def test_merge_attributes_together
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         class A
           attr_reader :a
           attr_writer :a
@@ -144,7 +144,7 @@ module RBI
         end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         class A
           attr_reader :a
           attr_writer :a
@@ -168,7 +168,7 @@ module RBI
     end
 
     def test_merge_methods_together
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         class A
           def a; end
           def b; end
@@ -177,7 +177,7 @@ module RBI
         end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         class A
           def a; end
           def b; end
@@ -199,7 +199,7 @@ module RBI
     end
 
     def test_merge_mixins_together
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         class A
           include A
           extend B
@@ -209,7 +209,7 @@ module RBI
         end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         class A
           include A
           extend B
@@ -233,14 +233,14 @@ module RBI
     end
 
     def test_merge_helpers_together
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         class A
           abstract!
           interface!
         end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         class A
           interface!
           sealed!
@@ -258,14 +258,14 @@ module RBI
     end
 
     def test_merge_sends_together
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         class A
           foo :bar, :baz
           bar
         end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         class A
           foo :bar, :baz
           baz
@@ -283,14 +283,14 @@ module RBI
     end
 
     def test_merge_structs_together
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         class A < T::Struct
           prop :a, Integer
           const :b, Integer
         end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         class A < T::Struct
           const :b, Integer
           prop :c, Integer
@@ -308,7 +308,7 @@ module RBI
     end
 
     def test_merge_enums_together
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         class A < T::Enum
           enums do
             A = new
@@ -317,7 +317,7 @@ module RBI
         end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         class A < T::Enum
           enums do
             B = new
@@ -339,7 +339,7 @@ module RBI
     end
 
     def test_merge_signatures
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         class A
           def m1; end
 
@@ -359,7 +359,7 @@ module RBI
         end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         class A
           sig { returns(Integer) }
           def m1; end
@@ -404,7 +404,7 @@ module RBI
     end
 
     def test_merge_comments
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         # Comment A1
         class A
           # Comment a1
@@ -414,7 +414,7 @@ module RBI
         end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         # Comment A1
         # Comment A2
         # Comment A3
@@ -445,13 +445,13 @@ module RBI
     end
 
     def test_merge_tree_comments_together
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         # typed: true
 
         # Some comments
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         # typed: true
 
         # Other comments
@@ -467,7 +467,7 @@ module RBI
     end
 
     def test_merge_create_conflict_tree_for_scopes
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         class Foo
           A = 10
         end
@@ -481,7 +481,7 @@ module RBI
         end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         module Foo
           A = 10
         end
@@ -524,7 +524,7 @@ module RBI
     end
 
     def test_merge_create_conflict_tree_for_structs
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         A = Struct.new(:a) do
           def m; end
         end
@@ -536,7 +536,7 @@ module RBI
         end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         A = Struct.new(:a) do
           def m1; end
         end
@@ -576,14 +576,14 @@ module RBI
     end
 
     def test_merge_create_conflict_tree_for_constants
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         class Foo
           A = 10
         end
         B = 10
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         class Foo
           A = 42
         end
@@ -608,7 +608,7 @@ module RBI
     end
 
     def test_merge_create_conflict_tree_constants_and_scopes
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         class A; end
         module B; end
         module C; end
@@ -618,7 +618,7 @@ module RBI
         end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         module A; end
         class B; end
         C = 42
@@ -656,7 +656,7 @@ module RBI
     end
 
     def test_merge_create_conflict_tree_for_attributes
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         class Foo
           attr_accessor :a
           attr_accessor :b
@@ -664,7 +664,7 @@ module RBI
         end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         class Foo
           attr_reader :a
           attr_writer :b
@@ -691,7 +691,7 @@ module RBI
     end
 
     def test_merge_create_conflict_tree_for_methods
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         class Foo
           def m1; end
           def m2(a); end
@@ -704,7 +704,7 @@ module RBI
         end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         class Foo
           def m1(a); end
           def m2; end
@@ -744,7 +744,7 @@ module RBI
     end
 
     def test_merge_create_conflict_tree_for_mixins
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         class A
           include A, B
           extend A, B
@@ -752,7 +752,7 @@ module RBI
         end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         class A
           include B
           extend B
@@ -777,7 +777,7 @@ module RBI
     end
 
     def test_merge_create_conflict_tree_for_sends
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         class A
           foo A
           bar :bar
@@ -785,7 +785,7 @@ module RBI
         end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         class A
           foo B
           bar "bar"
@@ -810,7 +810,7 @@ module RBI
     end
 
     def test_merge_create_conflict_tree_for_tstructs
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         class A < T::Struct
           prop :a, Integer
           const :b, Integer
@@ -819,7 +819,7 @@ module RBI
         end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         class A < T::Struct
           const :a, Integer
           prop :b, Integer
@@ -847,7 +847,7 @@ module RBI
     end
 
     def test_merge_create_conflict_tree_for_signatures
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         class Foo
           sig { returns(Integer) }
           attr_reader :a
@@ -863,7 +863,7 @@ module RBI
         end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         class Foo
           sig { returns(String) }
           attr_reader :a
@@ -912,14 +912,14 @@ module RBI
     end
 
     def test_merge_return_the_list_of_conflicts
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         class Foo
           A = 10
         end
         B = 10
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         module Foo
           A = 42
         end
@@ -936,7 +936,7 @@ module RBI
     end
 
     def test_merge_keep_left
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         module Foo
           A = 10
 
@@ -951,7 +951,7 @@ module RBI
         end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         module Foo
           A = 42
 
@@ -986,7 +986,7 @@ module RBI
     end
 
     def test_merge_keep_right
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         module Foo
           A = 10
 
@@ -1001,7 +1001,7 @@ module RBI
         end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         module Foo
           A = 42
 
@@ -1036,7 +1036,7 @@ module RBI
     end
 
     def test_merge_trees_with_singleton_classes
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         module Foo
           class << self
             def m1; end
@@ -1047,7 +1047,7 @@ module RBI
         end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         module Foo
           def self.m1(x); end
 
@@ -1071,7 +1071,7 @@ module RBI
     end
 
     def test_merge_trees_with_singleton_classes_with_scope
-      rbi1 = RBI::Parser.parse_string(<<~RBI)
+      rbi1 = Parser.parse_string(<<~RBI)
         module Foo
           def self.m1(x); end
 
@@ -1080,7 +1080,7 @@ module RBI
         end
       RBI
 
-      rbi2 = RBI::Parser.parse_string(<<~RBI)
+      rbi2 = Parser.parse_string(<<~RBI)
         module Foo
           class << self
             def m1; end

--- a/test/rbi/rewriters/nest_non_public_methods_test.rb
+++ b/test/rbi/rewriters/nest_non_public_methods_test.rb
@@ -6,11 +6,11 @@ require "test_helper"
 module RBI
   class NestNonPublicMethodsTest < Minitest::Test
     def test_nest_non_public_methods_in_tree
-      rbi = RBI::Tree.new
-      rbi << RBI::Method.new("m1")
-      rbi << RBI::Method.new("m2", visibility: RBI::Protected.new)
-      rbi << RBI::Method.new("m3", visibility: RBI::Private.new)
-      rbi << RBI::Method.new("m4", visibility: RBI::Public.new)
+      rbi = Tree.new
+      rbi << Method.new("m1")
+      rbi << Method.new("m2", visibility: Protected.new)
+      rbi << Method.new("m3", visibility: Private.new)
+      rbi << Method.new("m4", visibility: Public.new)
 
       rbi.nest_non_public_methods!
 
@@ -29,16 +29,16 @@ module RBI
     end
 
     def test_nest_non_public_methods_in_scopes
-      rbi = RBI::Tree.new
-      scope1 = RBI::Module.new("S1")
-      scope1 << RBI::Method.new("m1")
-      scope1 << RBI::Method.new("m2", visibility: RBI::Protected.new)
-      scope2 = RBI::Class.new("S2")
-      scope2 << RBI::Method.new("m3")
-      scope2 << RBI::Method.new("m4", visibility: RBI::Private.new)
-      scope3 = RBI::SingletonClass.new
-      scope3 << RBI::Method.new("m5")
-      scope3 << RBI::Method.new("m6", visibility: RBI::Protected.new)
+      rbi = Tree.new
+      scope1 = Module.new("S1")
+      scope1 << Method.new("m1")
+      scope1 << Method.new("m2", visibility: Protected.new)
+      scope2 = Class.new("S2")
+      scope2 << Method.new("m3")
+      scope2 << Method.new("m4", visibility: Private.new)
+      scope3 = SingletonClass.new
+      scope3 << Method.new("m5")
+      scope3 << Method.new("m6", visibility: Protected.new)
       rbi << scope1
       scope1 << scope2
       scope2 << scope3
@@ -73,10 +73,10 @@ module RBI
     end
 
     def test_nest_non_public_singleton_methods
-      rbi = RBI::Tree.new
-      rbi << RBI::Method.new("m1", is_singleton: true, visibility: RBI::Protected.new)
-      rbi << RBI::Method.new("m2", is_singleton: true, visibility: RBI::Private.new)
-      rbi << RBI::Method.new("m3", is_singleton: true, visibility: RBI::Public.new)
+      rbi = Tree.new
+      rbi << Method.new("m1", is_singleton: true, visibility: Protected.new)
+      rbi << Method.new("m2", is_singleton: true, visibility: Private.new)
+      rbi << Method.new("m3", is_singleton: true, visibility: Public.new)
 
       rbi.nest_non_public_methods!
 

--- a/test/rbi/rewriters/nest_singleton_methods_test.rb
+++ b/test/rbi/rewriters/nest_singleton_methods_test.rb
@@ -6,11 +6,11 @@ require "test_helper"
 module RBI
   class NestSingletonMethodsTest < Minitest::Test
     def test_nest_singleton_methods_in_trees
-      rbi = RBI::Tree.new
-      rbi << RBI::Method.new("m1")
-      rbi << RBI::Method.new("m2", is_singleton: true)
-      rbi << RBI::Method.new("m3")
-      rbi << RBI::Method.new("m4", is_singleton: true)
+      rbi = Tree.new
+      rbi << Method.new("m1")
+      rbi << Method.new("m2", is_singleton: true)
+      rbi << Method.new("m3")
+      rbi << Method.new("m4", is_singleton: true)
 
       rbi.nest_singleton_methods!
 
@@ -26,13 +26,13 @@ module RBI
     end
 
     def test_nest_singleton_methods_in_scopes
-      rbi = RBI::Tree.new
-      scope1 = RBI::Module.new("Foo")
-      scope1 << RBI::Method.new("m1")
-      scope1 << RBI::Method.new("m2", is_singleton: true)
-      scope2 = RBI::Class.new("Bar")
-      scope2 << RBI::Method.new("m3")
-      scope2 << RBI::Method.new("m4", is_singleton: true)
+      rbi = Tree.new
+      scope1 = Module.new("Foo")
+      scope1 << Method.new("m1")
+      scope1 << Method.new("m2", is_singleton: true)
+      scope2 = Class.new("Bar")
+      scope2 << Method.new("m3")
+      scope2 << Method.new("m4", is_singleton: true)
       rbi << scope1
       rbi << scope2
 
@@ -58,11 +58,11 @@ module RBI
     end
 
     def test_nest_singleton_methods_in_singleton_classes
-      rbi = RBI::Tree.new
-      scope1 = RBI::SingletonClass.new
-      scope1 << RBI::Method.new("m1", is_singleton: true)
-      scope2 = RBI::SingletonClass.new
-      scope2 << RBI::Method.new("m2", is_singleton: true)
+      rbi = Tree.new
+      scope1 = SingletonClass.new
+      scope1 << Method.new("m1", is_singleton: true)
+      scope2 = SingletonClass.new
+      scope2 << Method.new("m2", is_singleton: true)
       scope1 << scope2
       rbi << scope1
 
@@ -84,14 +84,14 @@ module RBI
     end
 
     def test_nest_does_not_nest_other_nodes
-      rbi = RBI::Tree.new
-      scope1 = RBI::Module.new("Foo")
-      scope1 << RBI::Const.new("C1", "42")
-      scope1 << RBI::Module.new("M1")
-      scope1 << RBI::Helper.new("h1")
-      scope2 = RBI::Class.new("Bar")
-      scope2 << RBI::Include.new("I1")
-      scope2 << RBI::Extend.new("E1")
+      rbi = Tree.new
+      scope1 = Module.new("Foo")
+      scope1 << Const.new("C1", "42")
+      scope1 << Module.new("M1")
+      scope1 << Helper.new("h1")
+      scope2 = Class.new("Bar")
+      scope2 << Include.new("I1")
+      scope2 << Extend.new("E1")
       rbi << scope1
       rbi << scope2
 

--- a/test/rbi/rewriters/sort_nodes_test.rb
+++ b/test/rbi/rewriters/sort_nodes_test.rb
@@ -6,10 +6,10 @@ require "test_helper"
 module RBI
   class SortNodesSpec < Minitest::Test
     def test_sorts_constants
-      rbi = RBI::Tree.new
-      rbi << RBI::Const.new("C", "42")
-      rbi << RBI::Const.new("B", "42")
-      rbi << RBI::Const.new("A", "42")
+      rbi = Tree.new
+      rbi << Const.new("C", "42")
+      rbi << Const.new("B", "42")
+      rbi << Const.new("A", "42")
 
       rbi.sort_nodes!
 
@@ -21,10 +21,10 @@ module RBI
     end
 
     def test_sort_modules
-      rbi = RBI::Tree.new
-      rbi << RBI::Module.new("C")
-      rbi << RBI::Module.new("B")
-      rbi << RBI::Module.new("A")
+      rbi = Tree.new
+      rbi << Module.new("C")
+      rbi << Module.new("B")
+      rbi << Module.new("A")
 
       rbi.sort_nodes!
 
@@ -36,10 +36,10 @@ module RBI
     end
 
     def test_sort_classes
-      rbi = RBI::Tree.new
-      rbi << RBI::Class.new("C")
-      rbi << RBI::Class.new("B")
-      rbi << RBI::Class.new("A")
+      rbi = Tree.new
+      rbi << Class.new("C")
+      rbi << Class.new("B")
+      rbi << Class.new("A")
 
       rbi.sort_nodes!
 
@@ -51,10 +51,10 @@ module RBI
     end
 
     def test_sort_structs
-      rbi = RBI::Tree.new
-      rbi << RBI::Struct.new("C")
-      rbi << RBI::Struct.new("B")
-      rbi << RBI::Struct.new("A")
+      rbi = Tree.new
+      rbi << Struct.new("C")
+      rbi << Struct.new("B")
+      rbi << Struct.new("A")
 
       rbi.sort_nodes!
 
@@ -66,13 +66,13 @@ module RBI
     end
 
     def test_sort_constants_and_keeps_original_order_in_case_of_conflicts
-      rbi = RBI::Tree.new
-      rbi << RBI::Class.new("B")
-      rbi << RBI::Module.new("B")
-      rbi << RBI::Const.new("B", "42")
-      rbi << RBI::Const.new("A", "42")
-      rbi << RBI::Module.new("A")
-      rbi << RBI::Class.new("A")
+      rbi = Tree.new
+      rbi << Class.new("B")
+      rbi << Module.new("B")
+      rbi << Const.new("B", "42")
+      rbi << Const.new("A", "42")
+      rbi << Module.new("A")
+      rbi << Class.new("A")
 
       rbi.sort_nodes!
 
@@ -87,11 +87,11 @@ module RBI
     end
 
     def test_sort_methods
-      rbi = RBI::Tree.new
-      rbi << RBI::Method.new("m4")
-      rbi << RBI::Method.new("m3", is_singleton: true)
-      rbi << RBI::Method.new("m2", is_singleton: true)
-      rbi << RBI::Method.new("m1")
+      rbi = Tree.new
+      rbi << Method.new("m4")
+      rbi << Method.new("m3", is_singleton: true)
+      rbi << Method.new("m2", is_singleton: true)
+      rbi << Method.new("m1")
 
       rbi.sort_nodes!
 
@@ -104,12 +104,12 @@ module RBI
     end
 
     def test_sort_does_not_sort_mixins
-      rbi = RBI::Tree.new
-      rbi << RBI::MixesInClassMethods.new("E")
-      rbi << RBI::Extend.new("D")
-      rbi << RBI::Include.new("C")
-      rbi << RBI::Extend.new("B")
-      rbi << RBI::Include.new("A")
+      rbi = Tree.new
+      rbi << MixesInClassMethods.new("E")
+      rbi << Extend.new("D")
+      rbi << Include.new("C")
+      rbi << Extend.new("B")
+      rbi << Include.new("A")
 
       rbi.sort_nodes!
 
@@ -123,11 +123,11 @@ module RBI
     end
 
     def test_does_not_sort_sends
-      rbi = RBI::Tree.new
-      rbi << RBI::Send.new("send4")
-      rbi << RBI::Send.new("send2")
-      rbi << RBI::Send.new("send3")
-      rbi << RBI::Send.new("send1")
+      rbi = Tree.new
+      rbi << Send.new("send4")
+      rbi << Send.new("send2")
+      rbi << Send.new("send3")
+      rbi << Send.new("send1")
 
       rbi.sort_nodes!
 
@@ -140,10 +140,10 @@ module RBI
     end
 
     def test_sort_helpers_test
-      rbi = RBI::Tree.new
-      rbi << RBI::Helper.new("c")
-      rbi << RBI::Helper.new("b")
-      rbi << RBI::Helper.new("a")
+      rbi = Tree.new
+      rbi << Helper.new("c")
+      rbi << Helper.new("b")
+      rbi << Helper.new("a")
 
       rbi.sort_nodes!
 
@@ -155,11 +155,11 @@ module RBI
     end
 
     def test_sort_struct_properties
-      rbi = RBI::Tree.new
-      rbi << RBI::TStructConst.new("d", "T")
-      rbi << RBI::TStructProp.new("c", "T")
-      rbi << RBI::TStructConst.new("b", "T")
-      rbi << RBI::TStructProp.new("a", "T")
+      rbi = Tree.new
+      rbi << TStructConst.new("d", "T")
+      rbi << TStructProp.new("c", "T")
+      rbi << TStructConst.new("b", "T")
+      rbi << TStructProp.new("a", "T")
 
       rbi.sort_nodes!
 
@@ -172,11 +172,11 @@ module RBI
     end
 
     def test_sort_tstructs
-      rbi = RBI::Tree.new
-      rbi << RBI::TStruct.new("D")
-      rbi << RBI::TStruct.new("C")
-      rbi << RBI::TStruct.new("B")
-      rbi << RBI::TStruct.new("A")
+      rbi = Tree.new
+      rbi << TStruct.new("D")
+      rbi << TStruct.new("C")
+      rbi << TStruct.new("B")
+      rbi << TStruct.new("A")
 
       rbi.sort_nodes!
 
@@ -189,11 +189,11 @@ module RBI
     end
 
     def test_sort_enums
-      rbi = RBI::Tree.new
-      rbi << RBI::TEnum.new("D")
-      rbi << RBI::TEnum.new("C")
-      rbi << RBI::TEnum.new("B")
-      rbi << RBI::TEnum.new("A")
+      rbi = Tree.new
+      rbi << TEnum.new("D")
+      rbi << TEnum.new("C")
+      rbi << TEnum.new("B")
+      rbi << TEnum.new("A")
 
       rbi.sort_nodes!
 
@@ -206,25 +206,25 @@ module RBI
     end
 
     def test_sort_does_nothing_if_all_nodes_are_already_sorted
-      rbi = RBI::Tree.new
-      rbi << RBI::Extend.new("M4")
-      rbi << RBI::Include.new("M3")
-      rbi << RBI::Extend.new("M2")
-      rbi << RBI::Include.new("M1")
-      rbi << RBI::Helper.new("h")
-      rbi << RBI::MixesInClassMethods.new("MICM")
-      rbi << RBI::TStructProp.new("SP1", "T")
-      rbi << RBI::TStructConst.new("SP2", "T")
-      rbi << RBI::TStructProp.new("SP3", "T")
-      rbi << RBI::TStructConst.new("SP4", "T")
-      rbi << RBI::Method.new("m1")
-      rbi << RBI::Method.new("m2")
-      rbi << RBI::Method.new("m3", is_singleton: true)
-      rbi << RBI::Const.new("A", "42")
-      rbi << RBI::Module.new("B")
-      rbi << RBI::TEnum.new("C")
-      rbi << RBI::TStruct.new("D")
-      rbi << RBI::Class.new("E")
+      rbi = Tree.new
+      rbi << Extend.new("M4")
+      rbi << Include.new("M3")
+      rbi << Extend.new("M2")
+      rbi << Include.new("M1")
+      rbi << Helper.new("h")
+      rbi << MixesInClassMethods.new("MICM")
+      rbi << TStructProp.new("SP1", "T")
+      rbi << TStructConst.new("SP2", "T")
+      rbi << TStructProp.new("SP3", "T")
+      rbi << TStructConst.new("SP4", "T")
+      rbi << Method.new("m1")
+      rbi << Method.new("m2")
+      rbi << Method.new("m3", is_singleton: true)
+      rbi << Const.new("A", "42")
+      rbi << Module.new("B")
+      rbi << TEnum.new("C")
+      rbi << TStruct.new("D")
+      rbi << Class.new("E")
 
       rbi.sort_nodes!
 
@@ -251,28 +251,28 @@ module RBI
     end
 
     def test_sort_all_nodes_in_tree
-      rbi = RBI::Tree.new
-      rbi << RBI::Const.new("A", "42")
-      rbi << RBI::Extend.new("M4")
-      rbi << RBI::Method.new("m1")
-      rbi << RBI::MixesInClassMethods.new("MICM")
-      rbi << RBI::Module.new("B")
-      rbi << RBI::SingletonClass.new
-      rbi << RBI::Include.new("M3")
-      rbi << RBI::TStructConst.new("SP2", "T")
-      rbi << RBI::Method.new("m2")
-      rbi << RBI::TStruct.new("D")
-      rbi << RBI::TEnum.new("C")
-      rbi << RBI::SingletonClass.new
-      rbi << RBI::Extend.new("M2")
-      rbi << RBI::TStructConst.new("SP4", "T")
-      rbi << RBI::Include.new("M1")
-      rbi << RBI::Helper.new("h")
-      rbi << RBI::SingletonClass.new
-      rbi << RBI::Class.new("E")
-      rbi << RBI::TStructProp.new("SP1", "T")
-      rbi << RBI::Method.new("m3", is_singleton: true)
-      rbi << RBI::TStructProp.new("SP3", "T")
+      rbi = Tree.new
+      rbi << Const.new("A", "42")
+      rbi << Extend.new("M4")
+      rbi << Method.new("m1")
+      rbi << MixesInClassMethods.new("MICM")
+      rbi << Module.new("B")
+      rbi << SingletonClass.new
+      rbi << Include.new("M3")
+      rbi << TStructConst.new("SP2", "T")
+      rbi << Method.new("m2")
+      rbi << TStruct.new("D")
+      rbi << TEnum.new("C")
+      rbi << SingletonClass.new
+      rbi << Extend.new("M2")
+      rbi << TStructConst.new("SP4", "T")
+      rbi << Include.new("M1")
+      rbi << Helper.new("h")
+      rbi << SingletonClass.new
+      rbi << Class.new("E")
+      rbi << TStructProp.new("SP1", "T")
+      rbi << Method.new("m3", is_singleton: true)
+      rbi << TStructProp.new("SP3", "T")
 
       rbi.sort_nodes!
 


### PR DESCRIPTION
In most places, we do not need to qualify the constants. Let's simplify the code.