### PR TITLE
Handle AttrAccessor/Reader/Writer in GroupNodes

### DIFF
--- a/lib/rbi/rewriters/group_nodes.rb
+++ b/lib/rbi/rewriters/group_nodes.rb
@@ -57,6 +57,8 @@ module RBI
         Group::Kind::MixesInClassMethods
       when Send
         Group::Kind::Sends
+      when AttrAccessor, AttrReader, AttrWriter
+        Group::Kind::Attrs
       when TStructField
         Group::Kind::TStructFields
       when TEnumBlock
@@ -98,6 +100,7 @@ module RBI
         TypeMembers         = new
         MixesInClassMethods = new
         Sends               = new
+        Attrs               = new
         TStructFields       = new
         TEnums              = new
         Inits               = new

--- a/lib/rbi/rewriters/group_nodes.rb
+++ b/lib/rbi/rewriters/group_nodes.rb
@@ -57,7 +57,7 @@ module RBI
         Group::Kind::MixesInClassMethods
       when Send
         Group::Kind::Sends
-      when AttrAccessor, AttrReader, AttrWriter
+      when Attr
         Group::Kind::Attrs
       when TStructField
         Group::Kind::TStructFields

--- a/lib/rbi/rewriters/sort_nodes.rb
+++ b/lib/rbi/rewriters/sort_nodes.rb
@@ -8,6 +8,7 @@ module RBI
 
       sig { override.params(node: T.nilable(Node)).void }
       def visit(node)
+        sort_node!(node) if node
         return unless node.is_a?(Tree)
         visit_all(node.nodes)
         original_order = node.nodes.map.with_index.to_h
@@ -38,9 +39,7 @@ module RBI
         when Send                 then 50
         when TStructField         then 60
         when TEnumBlock           then 70
-        when AttrAccessor         then 71
-        when AttrReader           then 72
-        when AttrWriter           then 73
+        when Attr                 then 75
         when Method
           if node.name == "initialize"
             81
@@ -81,6 +80,16 @@ module RBI
         case node
         when Module, Class, Struct, Const, Method, Helper, TStructField
           node.name
+        when Attr
+          node.names.first.to_s
+        end
+      end
+
+      sig { params(node: Node).void }
+      def sort_node!(node)
+        case node
+        when Attr
+          node.names.sort!
         end
       end
     end

--- a/lib/rbi/rewriters/sort_nodes.rb
+++ b/lib/rbi/rewriters/sort_nodes.rb
@@ -38,6 +38,9 @@ module RBI
         when Send                 then 50
         when TStructField         then 60
         when TEnumBlock           then 70
+        when AttrAccessor         then 71
+        when AttrReader           then 72
+        when AttrWriter           then 73
         when Method
           if node.name == "initialize"
             81
@@ -63,10 +66,11 @@ module RBI
         when Group::Kind::Sends               then 5
         when Group::Kind::TStructFields       then 6
         when Group::Kind::TEnums              then 7
-        when Group::Kind::Inits               then 8
-        when Group::Kind::Methods             then 9
-        when Group::Kind::SingletonClasses    then 10
-        when Group::Kind::Consts              then 11
+        when Group::Kind::Attrs               then 8
+        when Group::Kind::Inits               then 9
+        when Group::Kind::Methods             then 10
+        when Group::Kind::SingletonClasses    then 11
+        when Group::Kind::Consts              then 12
         else
           T.absurd(kind)
         end

--- a/lib/rbi/rewriters/sort_nodes.rb
+++ b/lib/rbi/rewriters/sort_nodes.rb
@@ -8,7 +8,8 @@ module RBI
 
       sig { override.params(node: T.nilable(Node)).void }
       def visit(node)
-        sort_node!(node) if node
+        sort_node_names!(node) if node
+
         return unless node.is_a?(Tree)
         visit_all(node.nodes)
         original_order = node.nodes.map.with_index.to_h
@@ -86,7 +87,7 @@ module RBI
       end
 
       sig { params(node: Node).void }
-      def sort_node!(node)
+      def sort_node_names!(node)
         case node
         when Attr
           node.names.sort!

--- a/test/rbi/rewriters/group_nodes_test.rb
+++ b/test/rbi/rewriters/group_nodes_test.rb
@@ -24,9 +24,9 @@ module RBI
       rbi << SingletonClass.new
       rbi << TStruct.new("TS")
       rbi << Send.new("foo")
-      rbi << AttrWriter.new(:baz)
+      rbi << AttrWriter.new(:baz, :b)
       rbi << AttrReader.new(:bar)
-      rbi << AttrAccessor.new(:foo)
+      rbi << AttrAccessor.new(:foo, :a, :z)
 
       rbi.group_nodes!
       rbi.sort_nodes!
@@ -44,9 +44,9 @@ module RBI
         const :SC, Type
         prop :SP, Type
 
-        attr_accessor :foo
+        attr_accessor :a, :foo, :z
+        attr_writer :b, :baz
         attr_reader :bar
-        attr_writer :baz
 
         def initialize; end
 

--- a/test/rbi/rewriters/group_nodes_test.rb
+++ b/test/rbi/rewriters/group_nodes_test.rb
@@ -13,6 +13,7 @@ module RBI
       rbi << Struct.new("S3")
       rbi << Method.new("m1")
       rbi << Method.new("m2", is_singleton: true)
+      rbi << Method.new("initialize")
       rbi << Extend.new("E")
       rbi << Include.new("I")
       rbi << MixesInClassMethods.new("MICM")
@@ -23,6 +24,9 @@ module RBI
       rbi << SingletonClass.new
       rbi << TStruct.new("TS")
       rbi << Send.new("foo")
+      rbi << AttrWriter.new(:baz)
+      rbi << AttrReader.new(:bar)
+      rbi << AttrAccessor.new(:foo)
 
       rbi.group_nodes!
       rbi.sort_nodes!
@@ -39,6 +43,12 @@ module RBI
 
         const :SC, Type
         prop :SP, Type
+
+        attr_accessor :foo
+        attr_reader :bar
+        attr_writer :baz
+
+        def initialize; end
 
         def m1; end
         def self.m2; end

--- a/test/rbi/rewriters/sort_nodes_test.rb
+++ b/test/rbi/rewriters/sort_nodes_test.rb
@@ -273,6 +273,9 @@ module RBI
       rbi << TStructProp.new("SP1", "T")
       rbi << Method.new("m3", is_singleton: true)
       rbi << TStructProp.new("SP3", "T")
+      rbi << AttrWriter.new(:baz, :b)
+      rbi << AttrReader.new(:bar)
+      rbi << AttrAccessor.new(:foo, :a, :z)
 
       rbi.sort_nodes!
 
@@ -287,6 +290,9 @@ module RBI
         const :SP2, T
         prop :SP3, T
         const :SP4, T
+        attr_accessor :a, :foo, :z
+        attr_writer :b, :baz
+        attr_reader :bar
         def m1; end
         def m2; end
         def self.m3; end


### PR DESCRIPTION
Came across a runtime error trying to use `AttrReader` in a custom DSL generator:
> RuntimeError: Unknown group for .attr_reader(:foo)

This PR handles attrs in GroupNodes. For now I've just added them to the `Sends` group but open question:
- Should these be in their own "kind" - e.g. `Group::Kind::Attrs`
- If so, where should they go inside `SortNodes`? I would think maybe right below Sends?