### PR TITLE
Add support for `requires_ancestor` nodes

### DIFF
--- a/lib/rbi/index.rb
+++ b/lib/rbi/index.rb
@@ -151,6 +151,16 @@ module RBI
     end
   end
 
+  class RequiresAncestor
+    extend T::Sig
+    include Indexable
+
+    sig { override.returns(T::Array[String]) }
+    def index_ids
+      [to_s]
+    end
+  end
+
   class Helper
     extend T::Sig
     include Indexable

--- a/lib/rbi/model.rb
+++ b/lib/rbi/model.rb
@@ -1361,4 +1361,28 @@ module RBI
       "#{parent_scope&.fully_qualified_name}.mixes_in_class_methods(#{names.join(", ")})"
     end
   end
+
+  class RequiresAncestor < NodeWithComments
+    extend T::Sig
+
+    sig { returns(String) }
+    attr_reader :name
+
+    sig do
+      params(
+        name: String,
+        loc: T.nilable(Loc),
+        comments: T::Array[Comment]
+      ).void
+    end
+    def initialize(name, loc: nil, comments: [])
+      super(loc: loc, comments: comments)
+      @name = name
+    end
+
+    sig { override.returns(String) }
+    def to_s
+      "#{parent_scope&.fully_qualified_name}.requires_ancestor(#{name})"
+    end
+  end
 end

--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -344,6 +344,8 @@ module RBI
         parse_sig(node)
       when :enums
         parse_enum(node)
+      when :requires_ancestor
+        parse_requires_ancestor(node)
       else
         raise ParseError.new("Unsupported block node type `#{name}`", node_loc(node))
       end
@@ -425,6 +427,14 @@ module RBI
       end
       enum.loc = node_loc(node)
       enum
+    end
+
+    sig { params(node: AST::Node).returns(RequiresAncestor) }
+    def parse_requires_ancestor(node)
+      name = parse_name(node.children[2])
+      ra = RequiresAncestor.new(name)
+      ra.loc = node_loc(node)
+      ra
     end
 
     sig { params(node: AST::Node).returns(Loc) }

--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -851,4 +851,17 @@ module RBI
       false
     end
   end
+
+  class RequiresAncestor
+    extend T::Sig
+
+    sig { override.params(v: Printer).void }
+    def accept_printer(v)
+      print_blank_line_before(v)
+
+      v.printl("# #{loc}") if loc && v.print_locs
+      v.visit_all(comments)
+      v.printl("requires_ancestor { #{name} }")
+    end
+  end
 end

--- a/lib/rbi/rewriters/group_nodes.rb
+++ b/lib/rbi/rewriters/group_nodes.rb
@@ -49,6 +49,8 @@ module RBI
       case self
       when Include, Extend
         Group::Kind::Mixins
+      when RequiresAncestor
+        Group::Kind::RequiredAncestors
       when Helper
         Group::Kind::Helpers
       when TypeMember
@@ -96,6 +98,7 @@ module RBI
     class Kind < T::Enum
       enums do
         Mixins              = new
+        RequiredAncestors   = new
         Helpers             = new
         TypeMembers         = new
         MixesInClassMethods = new

--- a/lib/rbi/rewriters/sort_nodes.rb
+++ b/lib/rbi/rewriters/sort_nodes.rb
@@ -34,6 +34,7 @@ module RBI
         case node
         when Group                then group_rank(node.kind)
         when Include, Extend      then 10
+        when RequiresAncestor     then 15
         when Helper               then 20
         when TypeMember           then 30
         when MixesInClassMethods  then 40
@@ -60,9 +61,10 @@ module RBI
       def group_rank(kind)
         case kind
         when Group::Kind::Mixins              then 0
-        when Group::Kind::Helpers             then 1
-        when Group::Kind::TypeMembers         then 2
-        when Group::Kind::MixesInClassMethods then 3
+        when Group::Kind::RequiredAncestors   then 1
+        when Group::Kind::Helpers             then 2
+        when Group::Kind::TypeMembers         then 3
+        when Group::Kind::MixesInClassMethods then 4
         when Group::Kind::Sends               then 5
         when Group::Kind::TStructFields       then 6
         when Group::Kind::TEnums              then 7
@@ -79,7 +81,7 @@ module RBI
       sig { params(node: Node).returns(T.nilable(String)) }
       def node_name(node)
         case node
-        when Module, Class, Struct, Const, Method, Helper, TStructField
+        when Module, Class, Struct, Const, Method, Helper, TStructField, RequiresAncestor
           node.name
         when Attr
           node.names.first.to_s

--- a/test/rbi/index_test.rb
+++ b/test/rbi/index_test.rb
@@ -84,6 +84,7 @@ module RBI
         end
 
         mixes_in_class_methods A
+        requires_ancestor { A }
         C = type_member
         D = type_template
       RBI
@@ -91,14 +92,15 @@ module RBI
       index_string = index_string(rbi.index)
       assert_equal(<<~IDX, index_string)
         .mixes_in_class_method(A): -:13:0-13:24
+        .requires_ancestor(A): -:14:0-14:23
         ::A: -:1:0-4:3
         ::A#a: -:2:2-2:19
         ::A#b: -:3:2-3:17
         ::A#b=: -:3:2-3:17
         ::B: -:6:0-11:3
         ::B.enums: -:7:2-10:5
-        ::C: -:14:0-14:15
-        ::D: -:15:0-15:17
+        ::C: -:15:0-15:15
+        ::D: -:16:0-16:17
       IDX
     end
 

--- a/test/rbi/model_test.rb
+++ b/test/rbi/model_test.rb
@@ -370,6 +370,10 @@ module RBI
       mod << micm
       assert_equal("::Foo.mixes_in_class_methods(A)", micm.to_s)
 
+      ra = RequiresAncestor.new("A")
+      mod << ra
+      assert_equal("::Foo.requires_ancestor(A)", ra.to_s)
+
       helper = Helper.new("foo")
       mod << helper
       assert_equal("::Foo.foo!", helper.to_s)

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -210,6 +210,7 @@ module RBI
           sealed!
           interface!
           mixes_in_class_methods A
+          requires_ancestor { A }
         end
       RBI
 
@@ -527,12 +528,13 @@ module RBI
           sealed!
           interface!
           mixes_in_class_methods A
+          requires_ancestor { A }
         end
       RBI
 
       out = Parser.parse_string(rbi)
       assert_equal(<<~RBI, out.string(print_locs: true))
-        # -:1:0-6:3
+        # -:1:0-7:3
         class Foo
           # -:2:2-2:11
           abstract!
@@ -542,6 +544,8 @@ module RBI
           interface!
           # -:5:2-5:26
           mixes_in_class_methods A
+          # -:6:2-6:25
+          requires_ancestor { A }
         end
       RBI
     end

--- a/test/rbi/printer_test.rb
+++ b/test/rbi/printer_test.rb
@@ -317,6 +317,7 @@ module RBI
       rbi << Helper.new("sealed")
       rbi << Helper.new("interface")
       rbi << MixesInClassMethods.new("A")
+      rbi << RequiresAncestor.new("A")
 
       assert_equal(<<~RBI, rbi.string)
         class Foo
@@ -324,6 +325,7 @@ module RBI
           sealed!
           interface!
           mixes_in_class_methods A
+          requires_ancestor { A }
         end
       RBI
     end

--- a/test/rbi/rewriters/group_nodes_test.rb
+++ b/test/rbi/rewriters/group_nodes_test.rb
@@ -27,6 +27,7 @@ module RBI
       rbi << AttrWriter.new(:baz, :b)
       rbi << AttrReader.new(:bar)
       rbi << AttrAccessor.new(:foo, :a, :z)
+      rbi << RequiresAncestor.new("RA")
 
       rbi.group_nodes!
       rbi.sort_nodes!
@@ -34,6 +35,8 @@ module RBI
       assert_equal(<<~RBI, rbi.string)
         extend E
         include I
+
+        requires_ancestor { RA }
 
         h!
 
@@ -83,6 +86,7 @@ module RBI
       scope3 << Extend.new("E1")
       scope3 << Extend.new("E2")
       scope3 << MixesInClassMethods.new("MICM1")
+      scope3 << RequiresAncestor.new("RA1")
 
       rbi << scope1
       scope1 << scope2
@@ -111,6 +115,8 @@ module RBI
               extend E1
               extend E2
 
+              requires_ancestor { RA1 }
+
               mixes_in_class_methods MICM1
             end
           end
@@ -130,6 +136,7 @@ module RBI
       rbi << Extend.new("E")
       rbi << Include.new("I")
       rbi << MixesInClassMethods.new("MICM")
+      rbi << RequiresAncestor.new("RA")
       rbi << Helper.new("h")
       rbi << TStructConst.new("SC", "Type")
       rbi << TStructProp.new("SP", "Type")
@@ -143,6 +150,8 @@ module RBI
       assert_equal(<<~RBI, rbi.string)
         extend E
         include I
+
+        requires_ancestor { RA }
 
         h!
 
@@ -239,6 +248,7 @@ module RBI
       scope << Include.new("I")
       scope << Extend.new("E")
       scope << MixesInClassMethods.new("MICM")
+      scope << RequiresAncestor.new("RA")
       scope << Helper.new("h")
       scope << TStructProp.new("SP", "Type")
       scope << TStructConst.new("SC", "Type")
@@ -257,6 +267,8 @@ module RBI
         module Scope
           include I
           extend E
+
+          requires_ancestor { RA }
 
           h!
 
@@ -295,6 +307,7 @@ module RBI
       rbi << Include.new("I2")
       rbi << Extend.new("E2")
       rbi << MixesInClassMethods.new("MICM2")
+      rbi << RequiresAncestor.new("RA2")
       rbi << Helper.new("h2")
       rbi << TStructProp.new("SP2", "Type")
       rbi << TStructConst.new("SC2", "Type")
@@ -306,6 +319,7 @@ module RBI
       rbi << Include.new("I1")
       rbi << Extend.new("E1")
       rbi << MixesInClassMethods.new("MICM1")
+      rbi << RequiresAncestor.new("RA1")
       rbi << Helper.new("h1")
       rbi << TStructProp.new("SP1", "Type")
       rbi << TStructConst.new("SC1", "Type")
@@ -323,6 +337,9 @@ module RBI
         extend E2
         include I1
         extend E1
+
+        requires_ancestor { RA1 }
+        requires_ancestor { RA2 }
 
         h1!
         h2!
@@ -365,6 +382,7 @@ module RBI
       sscope << Include.new("I2")
       sscope << Extend.new("E2")
       sscope << MixesInClassMethods.new("MICM2")
+      sscope << RequiresAncestor.new("RA2")
       sscope << Helper.new("h2")
       sscope << TStructProp.new("SP2", "Type")
       sscope << TStructConst.new("SC2", "Type")
@@ -376,6 +394,7 @@ module RBI
       sscope << Include.new("I1")
       sscope << Extend.new("E1")
       sscope << MixesInClassMethods.new("MICM1")
+      sscope << RequiresAncestor.new("RA1")
       sscope << Helper.new("h1")
       sscope << TStructProp.new("SP1", "Type")
       sscope << TStructConst.new("SC1", "Type")
@@ -393,6 +412,7 @@ module RBI
       scope << Include.new("I2")
       scope << Extend.new("E2")
       scope << MixesInClassMethods.new("MICM2")
+      scope << RequiresAncestor.new("RA2")
       scope << Helper.new("h2")
       scope << TStructProp.new("SP2", "Type")
       scope << TStructConst.new("SC2", "Type")
@@ -404,6 +424,7 @@ module RBI
       scope << Include.new("I1")
       scope << Extend.new("E1")
       scope << MixesInClassMethods.new("MICM1")
+      scope << RequiresAncestor.new("RA1")
       scope << Helper.new("h1")
       scope << TStructProp.new("SP1", "Type")
       scope << TStructConst.new("SC1", "Type")
@@ -421,6 +442,7 @@ module RBI
       scope << Include.new("I2")
       scope << Extend.new("E2")
       scope << MixesInClassMethods.new("MICM2")
+      scope << RequiresAncestor.new("RA2")
       scope << Helper.new("h2")
       scope << TStructProp.new("SP2", "Type")
       scope << TStructConst.new("SC2", "Type")
@@ -432,6 +454,7 @@ module RBI
       scope << Include.new("I1")
       scope << Extend.new("E1")
       scope << MixesInClassMethods.new("MICM1")
+      scope << RequiresAncestor.new("RA1")
       scope << Helper.new("h1")
       scope << TStructProp.new("SP1", "Type")
       scope << TStructConst.new("SC1", "Type")
@@ -451,6 +474,9 @@ module RBI
           extend E2
           include I1
           extend E1
+
+          requires_ancestor { RA1 }
+          requires_ancestor { RA2 }
 
           h1!
           h2!
@@ -486,6 +512,9 @@ module RBI
           include I1
           extend E1
 
+          requires_ancestor { RA1 }
+          requires_ancestor { RA2 }
+
           h1!
           h2!
 
@@ -514,6 +543,9 @@ module RBI
             extend E2
             include I1
             extend E1
+
+            requires_ancestor { RA1 }
+            requires_ancestor { RA2 }
 
             h1!
             h2!

--- a/test/rbi/rewriters/sort_nodes_test.rb
+++ b/test/rbi/rewriters/sort_nodes_test.rb
@@ -110,6 +110,7 @@ module RBI
       rbi << Include.new("C")
       rbi << Extend.new("B")
       rbi << Include.new("A")
+      rbi << RequiresAncestor.new("A")
 
       rbi.sort_nodes!
 
@@ -118,6 +119,7 @@ module RBI
         include C
         extend B
         include A
+        requires_ancestor { A }
         mixes_in_class_methods E
       RBI
     end
@@ -276,6 +278,7 @@ module RBI
       rbi << AttrWriter.new(:baz, :b)
       rbi << AttrReader.new(:bar)
       rbi << AttrAccessor.new(:foo, :a, :z)
+      rbi << RequiresAncestor.new("RA")
 
       rbi.sort_nodes!
 
@@ -284,6 +287,7 @@ module RBI
         include M3
         extend M2
         include M1
+        requires_ancestor { RA }
         h!
         mixes_in_class_methods MICM
         prop :SP1, T


### PR DESCRIPTION
So they can be used in shims or generated by Tapioca.