### PR TITLE
Pass max_line_length to printer

### DIFF
--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -117,16 +117,23 @@ module RBI
       end
     end
 
-    sig { params(out: T.any(IO, StringIO), indent: Integer, print_locs: T::Boolean).void }
-    def print(out: $stdout, indent: 0, print_locs: false)
-      p = Printer.new(out: out, indent: indent, print_locs: print_locs)
+    sig do
+      params(
+        out: T.any(IO, StringIO),
+        indent: Integer,
+        print_locs: T::Boolean,
+        max_line_length: T.nilable(Integer)
+      ).void
+    end
+    def print(out: $stdout, indent: 0, print_locs: false, max_line_length: nil)
+      p = Printer.new(out: out, indent: indent, print_locs: print_locs, max_line_length: max_line_length)
       p.visit_file(self)
     end
 
-    sig { params(indent: Integer, print_locs: T::Boolean).returns(String) }
-    def string(indent: 0, print_locs: false)
+    sig { params(indent: Integer, print_locs: T::Boolean, max_line_length: T.nilable(Integer)).returns(String) }
+    def string(indent: 0, print_locs: false, max_line_length: nil)
       out = StringIO.new
-      print(out: out, indent: indent, print_locs: print_locs)
+      print(out: out, indent: indent, print_locs: print_locs, max_line_length: max_line_length)
       out.string
     end
   end

--- a/test/rbi/printer_test.rb
+++ b/test/rbi/printer_test.rb
@@ -828,8 +828,8 @@ module RBI
     end
 
     def test_print_sig_over_max_line_length
-      rbi = Tree.new do |tree|
-        tree << Class.new("Foo") do |cls|
+      rbi = File.new do |file|
+        file << Class.new("Foo") do |cls|
           cls << Sig.new(is_abstract: true, is_overridable: true) do |sig|
             sig << SigParam.new("a", "Integer")
             sig << SigParam.new("b", "Integer")


### PR DESCRIPTION
This option is available on `Node#print` it should also be on `File#print`.