### PR TITLE
Allow grouping groups

### DIFF
--- a/lib/rbi/rewriters/group_nodes.rb
+++ b/lib/rbi/rewriters/group_nodes.rb
@@ -47,6 +47,8 @@ module RBI
     sig { returns(Group::Kind) }
     def group_kind
       case self
+      when Group
+        kind
       when Include, Extend
         Group::Kind::Mixins
       when RequiresAncestor

--- a/test/rbi/rewriters/group_nodes_test.rb
+++ b/test/rbi/rewriters/group_nodes_test.rb
@@ -582,5 +582,34 @@ module RBI
         end
       RBI
     end
+
+    def test_group_groups
+      rbi = Tree.new
+      rbi << Method.new("m")
+      rbi << Include.new("I")
+      rbi << AttrWriter.new(:a)
+
+      rbi.group_nodes!
+      rbi.sort_nodes!
+
+      assert_equal(<<~RBI, rbi.string)
+        include I
+
+        attr_writer :a
+
+        def m; end
+      RBI
+
+      rbi.group_nodes!
+      rbi.sort_nodes!
+
+      assert_equal(<<~RBI, rbi.string)
+        include I
+
+        attr_writer :a
+
+        def m; end
+      RBI
+    end
   end
 end


### PR DESCRIPTION
This avoid crashing when we find a group in a tree we're trying to group/sort.