### PR TITLE
Add support for final sigs

### DIFF
--- a/lib/rbi/model.rb
+++ b/lib/rbi/model.rb
@@ -1026,7 +1026,7 @@ module RBI
     attr_accessor :return_type
 
     sig { returns(T::Boolean) }
-    attr_accessor :is_abstract, :is_override, :is_overridable
+    attr_accessor :is_abstract, :is_override, :is_overridable, :is_final
 
     sig { returns(T::Array[String]) }
     attr_reader :type_params
@@ -1041,6 +1041,7 @@ module RBI
         is_abstract: T::Boolean,
         is_override: T::Boolean,
         is_overridable: T::Boolean,
+        is_final: T::Boolean,
         type_params: T::Array[String],
         checked: T.nilable(Symbol),
         loc: T.nilable(Loc),
@@ -1053,6 +1054,7 @@ module RBI
       is_abstract: false,
       is_override: false,
       is_overridable: false,
+      is_final: false,
       type_params: [],
       checked: nil,
       loc: nil,
@@ -1064,6 +1066,7 @@ module RBI
       @is_abstract = is_abstract
       @is_override = is_override
       @is_overridable = is_overridable
+      @is_final = is_final
       @type_params = type_params
       @checked = checked
       block&.call(self)
@@ -1078,7 +1081,7 @@ module RBI
     def ==(other)
       return false unless other.is_a?(Sig)
       params == other.params && return_type == other.return_type && is_abstract == other.is_abstract &&
-        is_override == other.is_override && is_overridable == other.is_overridable &&
+        is_override == other.is_override && is_overridable == other.is_overridable && is_final == other.is_final &&
         type_params == other.type_params && checked == other.checked
     end
   end

--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -568,7 +568,7 @@ module RBI
     sig { params(node: AST::Node).returns(Sig) }
     def self.build(node)
       v = SigBuilder.new
-      v.visit_all(node.children[2..-1])
+      v.visit_all(node.children)
       v.current
     end
 
@@ -595,6 +595,9 @@ module RBI
       visit(node.children[0]) if node.children[0]
       name = node.children[1]
       case name
+      when :sig
+        arg = node.children[2]
+        @current.is_final = arg && arg.children[0] == :final
       when :abstract
         @current.is_abstract = true
       when :override

--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -670,7 +670,9 @@ module RBI
 
     sig { params(v: Printer).void }
     def print_as_line(v)
-      v.printt("sig { ")
+      v.printt("sig")
+      v.print("(:final)") if is_final
+      v.print(" { ")
       sig_modifiers.each do |modifier|
         v.print("#{modifier}.")
       end

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -110,6 +110,7 @@ module RBI
         def m3(a, b = 42, *c, d:, e: "bar", **f, &g); end
 
         sig { void }
+        sig(:final) { void }
         sig { returns(String) }
         sig { params(a: T.untyped, b: T::Array[String]).returns(T::Hash[String, Integer]) }
         sig { abstract.params(a: Integer).void }


### PR DESCRIPTION
Add support for parsing and writing `sig(:final)` calls which represent final methods: https://sorbet.org/docs/final#final-methods