### PR TITLE
Do not strip leading spaces in comments

### DIFF
--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -200,7 +200,7 @@ module RBI
       end
 
       lines.each do |line|
-        text = line.strip
+        text = line.rstrip
         v.printt("#")
         v.print(" #{text}") unless text.empty?
         v.printn
@@ -455,7 +455,7 @@ module RBI
 
     sig { returns(T::Array[String]) }
     def comments_lines
-      comments.flat_map { |comment| comment.text.lines.map(&:strip) }
+      comments.flat_map { |comment| comment.text.lines.map(&:rstrip) }
     end
   end
 
@@ -760,7 +760,7 @@ module RBI
 
     sig { returns(T::Array[String]) }
     def comments_lines
-      comments.flat_map { |comment| comment.text.lines.map(&:strip) }
+      comments.flat_map { |comment| comment.text.lines.map(&:rstrip) }
     end
   end
 

--- a/test/rbi/printer_test.rb
+++ b/test/rbi/printer_test.rb
@@ -486,7 +486,7 @@ module RBI
     end
 
     def test_print_nodes_with_multiline_comments
-      comments = [Comment.new("This is a\nmultiline comment")]
+      comments = [Comment.new("This is a\nmultiline\n  comment")]
 
       rbi = Tree.new do |tree|
         tree << Module.new("Foo", comments: comments) do |mod|
@@ -513,44 +513,58 @@ module RBI
 
       assert_equal(<<~RBI, rbi.string)
         # This is a
-        # multiline comment
+        # multiline
+        #   comment
         module Foo
           # This is a
-          # multiline comment
+          # multiline
+          #   comment
           A = type_member
 
           # This is a
-          # multiline comment
+          # multiline
+          #   comment
           def foo; end
         end
 
         # This is a
-        # multiline comment
+        # multiline
+        #   comment
         sig do
           params(
             a: Integer, # This is a
-                        # multiline comment
+                        # multiline
+                        #   comment
             b: String, # This is a
-                       # multiline comment
+                       # multiline
+                       #   comment
             c: T.untyped # This is a
-                         # multiline comment
+                         # multiline
+                         #   comment
           ).void
         end
         def foo(
           a, # This is a
-             # multiline comment
+             # multiline
+             #   comment
           b = 42, # This is a
-                  # multiline comment
+                  # multiline
+                  #   comment
           *c, # This is a
-              # multiline comment
+              # multiline
+              #   comment
           d:, # This is a
-              # multiline comment
+              # multiline
+              #   comment
           e: 'bar', # This is a
-                    # multiline comment
+                    # multiline
+                    #   comment
           **f, # This is a
-               # multiline comment
+               # multiline
+               #   comment
           &g # This is a
-             # multiline comment
+             # multiline
+             #   comment
         ); end
       RBI
     end


### PR DESCRIPTION
So one can actually print this kind of comments:

```rb
# @deprecated Reason
#   Some long description of why
#   That might span on multiple lines
def foo; end
```

Required to fix https://github.com/Shopify/tapioca/issues/649.