### PR TITLE
Missing T::Struct options that impact type checking

### DIFF
--- a/lib/rbi/model.rb
+++ b/lib/rbi/model.rb
@@ -1142,23 +1142,23 @@ module RBI
     sig { returns(String) }
     attr_accessor :name, :type
 
-    sig { returns(T.nilable(String)) }
-    attr_accessor :default
+    sig { returns(T::Hash[Symbol, String]) }
+    attr_accessor :options
 
     sig do
       params(
         name: String,
         type: String,
-        default: T.nilable(String),
+        options: T::Hash[Symbol, String],
         loc: T.nilable(Loc),
         comments: T::Array[Comment]
       ).void
     end
-    def initialize(name, type, default: nil, loc: nil, comments: [])
+    def initialize(name, type, options: {}, loc: nil, comments: [])
       super(loc: loc, comments: comments)
       @name = name
       @type = type
-      @default = default
+      @options = options
     end
 
     sig { abstract.returns(T::Array[String]) }
@@ -1172,14 +1172,14 @@ module RBI
       params(
         name: String,
         type: String,
-        default: T.nilable(String),
+        options: T::Hash[Symbol, String],
         loc: T.nilable(Loc),
         comments: T::Array[Comment],
         block: T.nilable(T.proc.params(node: TStructConst).void)
       ).void
     end
-    def initialize(name, type, default: nil, loc: nil, comments: [], &block)
-      super(name, type, default: default, loc: loc, comments: comments)
+    def initialize(name, type, options: {}, loc: nil, comments: [], &block)
+      super(name, type, options: options, loc: loc, comments: comments)
       block&.call(self)
     end
 
@@ -1202,14 +1202,14 @@ module RBI
       params(
         name: String,
         type: String,
-        default: T.nilable(String),
+        options: T::Hash[Symbol, String],
         loc: T.nilable(Loc),
         comments: T::Array[Comment],
         block: T.nilable(T.proc.params(node: TStructProp).void)
       ).void
     end
-    def initialize(name, type, default: nil, loc: nil, comments: [], &block)
-      super(name, type, default: default, loc: loc, comments: comments)
+    def initialize(name, type, options: {}, loc: nil, comments: [], &block)
+      super(name, type, options: options, loc: loc, comments: comments)
       block&.call(self)
     end
 

--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -780,8 +780,9 @@ module RBI
         v.printt("const")
       end
       v.print(" :#{name}, #{type}")
-      default = self.default
-      v.print(", default: #{default}") if default
+      options.each do |key, value|
+        v.print(", #{key}: #{value}")
+      end
       v.printn
     end
   end

--- a/lib/rbi/rewriters/merge_trees.rb
+++ b/lib/rbi/rewriters/merge_trees.rb
@@ -526,7 +526,7 @@ module RBI
 
     sig { override.params(other: Node).returns(T::Boolean) }
     def compatible_with?(other)
-      other.is_a?(TStructField) && name == other.name && type == other.type && default == other.default
+      other.is_a?(TStructField) && name == other.name && type == other.type && options == other.options
     end
   end
 

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -180,6 +180,10 @@ module RBI
           const :b, B, default: B.new
           prop :c, C
           prop :d, D, default: D.new
+          const :e, E, factory: -> { 1 }
+          prop :f, F, factory: -> { 1 }
+          const :g, G, immutable: true, default: G.new, some_other_option: true
+          prop :h, H, immutable: true, default: H.new, some_other_option: true
           def foo; end
         end
         RBI

--- a/test/rbi/printer_test.rb
+++ b/test/rbi/printer_test.rb
@@ -276,9 +276,9 @@ module RBI
     def test_print_t_structs
       struct = TStruct.new("Foo")
       struct << TStructConst.new("a", "A")
-      struct << TStructConst.new("b", "B", default: "B.new")
+      struct << TStructConst.new("b", "B", options: { default: "B.new" })
       struct << TStructProp.new("c", "C")
-      struct << TStructProp.new("d", "D", default: "D.new")
+      struct << TStructProp.new("d", "D", options: { default: "D.new" })
       struct << Method.new("foo")
 
       assert_equal(<<~RBI, struct.string)


### PR DESCRIPTION
We started using the `factory` option for a field in one of our T::Structs and noticed it didn't come through the RBI that tapioca generated. `factory` is basically the same as `default` but takes a proc so the value can be set dynamically. Like default, if a prop/const has a factory set you don't have to pass a value in the initializer so its absence from the RBI meaningfully impacts type-checking. Given that tapioca uses the `RBI::TStructConst/Prop` models, support needs to be added here first.

I started down the path of a fix, adding handling for `factory` where there's handling for `default`, when I realized that there's at least one more option that affects type checking: `immutable`. If you set `prop :x, Integer, immutable: true` it basically acts like `const` where it will show a type error if you try to use the setter. I also realized that the current parsing logic expects `default` (if present at all) to be the first option so if you have `immutable: true, default: 1` the parser will currently drop both on the floor.

Here's a [sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0Aclass%20Foo%20%3C%20T%3A%3AStruct%0A%20%20const%20%3Ax%2C%20Integer%2C%20factory%3A%20-%3E%20%7B%7D%0A%20%20const%20%3Ay%2C%20Integer%2C%20factory%3A%20T.unsafe%28nil%29%0A%20%20prop%20%3Az%2C%20Integer%2C%20immutable%3A%20true%2C%20some_other_prop%3A%20'hey'%0Aend%0A%0AFoo.new%28z%3A%201%29.z%20%3D%202) to showing these examples.

There are [many more options](https://github.com/sorbet/sorbet/blob/c3365c5fbc4f652b30cc45428792f4646783c3a8/gems/sorbet-runtime/lib/types/props/_props.rb#L54-L109) (although many seem to be internal to stripe) and technically you can pass arbitrary options.

Before I went further I wanted to get your thoughts. I think we at least need to handle `factory` and `immutable` since those impact type checking, so there are a few options:
- add `factory` and `immutable` attrs to `TStructField` (and const/prop) and handle them whenever we currently handle `default`.
  - Slightly more verbose but very explicit
  - We'll drop other options on the floor. This is probably fine but it would mean that `input == (parse(input).out)` is no longer necessarily true.
- remove `default` from `TStructField` and replace it with `options` which would capture all options
  - More flexible but less explicit
- just add factory, and when we see “immutable: true” parse it as a Const instead of a Prop.

There's also a middle ground where the constructor for `TStructField` and friends still only take `default` (and maybe `factory` and `immutable` as well?) as an explicit option since it's the most common but also take an `options` hash. The initializer would join the two so you'd only ever operate on the hash. This would be similar to how `Attr` takes (name, names) and then joins them together in the initializer.

I'm happy to take this on here and in tapioca so let me know what you think.