### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.6, 2.7, '3.0', 3.1 ]
+        ruby: [ "2.6", "2.7", "3.0", "3.1" ]
     name: Test Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.6, 2.7, 3.0 ]
+        ruby: [ 2.6, 2.7, '3.0', 3.1 ]
     name: Test Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix.

In addition to adding Ruby 3.1, it quotes the `3.0` entry.  An unquoted `3.0` is truncated to `3` and loads the latest Ruby 3 - at time of writing Ruby 3.1.1.  To ensure a Ruby 3.0.x version is loaded for this entry we simply quote the `3.0`.