### PR TITLE
Restrict Whitequark version to >= 2.6.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     rbi (0.0.13)
       ast
-      parser
+      parser (>= 2.6.4.0)
       sorbet-runtime (>= 0.5.9204)
       unparser
 

--- a/rbi.gemspec
+++ b/rbi.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   )
 
   spec.add_dependency("ast")
-  spec.add_dependency("parser")
+  spec.add_dependency("parser", ">= 2.6.4.0")
   spec.add_dependency("sorbet-runtime", ">= 0.5.9204")
   spec.add_dependency("unparser")
 end


### PR DESCRIPTION
When initializing the `Parser`, we call `emit_arg_inside_procarg0 = true` (https://github.com/Shopify/rbi/blob/main/lib/rbi/parser.rb#L25) but this method was added in v2.6.4.0 (https://github.com/whitequark/parser/commit/17a66bdf5712686fa8eca4a7bd10ffab45c1d754).

With the wrong version of the `parser` gem, running Tapioca results in a stack trace:

```
vendor/bundle/ruby/2.6.0/gems/rbi-0.0.13/lib/rbi/parser.rb:28:in `<class:Parser>': undefined method `emit_arg_inside_procarg0=' for Parser::Builders::Default:Class (NoMethodError)
Did you mean?  emit_procarg0=
	from vendor/bundle/ruby/2.6.0/gems/rbi-0.0.13/lib/rbi/parser.rb:20:in `<module:RBI>'
```