### PR TITLE
Do not crash on empty sig builders

### DIFF
--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -666,19 +666,25 @@ module RBI
       when :overridable
         @current.is_overridable = true
       when :checked
-        @current.checked = node.children[2].children[0]
+        if node.children.length >= 3
+          @current.checked = node.children[2].children[0]
+        end
       when :type_parameters
         node.children[2..-1].each do |child|
           @current.type_params << child.children[0].to_s
         end
       when :params
-        node.children[2].children.each do |child|
-          name = child.children[0].children[0].to_s
-          type = parse_expr(child.children[1])
-          @current << SigParam.new(name, type)
+        if node.children.length >= 3
+          node.children[2].children.each do |child|
+            name = child.children[0].children[0].to_s
+            type = parse_expr(child.children[1])
+            @current << SigParam.new(name, type)
+          end
         end
       when :returns
-        @current.return_type = parse_expr(node.children[2])
+        if node.children.length >= 3
+          @current.return_type = parse_expr(node.children[2])
+        end
       when :void
         @current.return_type = nil
       else

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -108,10 +108,19 @@ module RBI
         def m1; end
         def self.m2; end
         def m3(a, b = 42, *c, d:, e: "bar", **f, &g); end
+      RBI
 
+      out = Parser.parse_string(rbi)
+      assert_equal(rbi, out.string)
+    end
+
+    def test_parse_sigs
+      rbi = <<~RBI
         sig { void }
         sig(:final) { void }
         sig { returns(String) }
+        sig { params.returns }
+        sig { checked().type_parameters().params().returns() }
         sig { params(a: T.untyped, b: T::Array[String]).returns(T::Hash[String, Integer]) }
         sig { abstract.params(a: Integer).void }
         sig { checked(:never).returns(T::Array[String]) }
@@ -121,11 +130,27 @@ module RBI
         sig { type_parameters(:U).params(step: Integer, _blk: T.proc.returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
         sig { type_parameters(:A, :B).params(a: T::Array[T.type_parameter(:A)], fa: T.proc.params(item: T.type_parameter(:A)).returns(T.untyped), b: T::Array[T.type_parameter(:B)], fb: T.proc.params(item: T.type_parameter(:B)).returns(T.untyped)).returns(T::Array[[T.type_parameter(:A), T.type_parameter(:B)]]) }
         sig { returns({ item_id: String, tax_code: String, name: String, rate: BigDecimal, rate_type: String, amount: BigDecimal, subdivision: String, jurisdiction: String, exempt: T::Boolean, reasons: T::Array[String] }) }
-        def m4; end
+        def foo; end
       RBI
 
       out = Parser.parse_string(rbi)
-      assert_equal(rbi, out.string)
+      assert_equal(<<~RBI, out.string)
+        sig { void }
+        sig(:final) { void }
+        sig { returns(String) }
+        sig { void }
+        sig { void }
+        sig { params(a: T.untyped, b: T::Array[String]).returns(T::Hash[String, Integer]) }
+        sig { abstract.params(a: Integer).void }
+        sig { checked(:never).returns(T::Array[String]) }
+        sig { override.params(printer: Spoom::LSP::SymbolPrinter).void }
+        sig { returns(T.nilable(String)) }
+        sig { params(requested_generators: T::Array[String]).returns(T.proc.params(klass: Class).returns(T::Boolean)) }
+        sig { type_parameters(:U).params(step: Integer, _blk: T.proc.returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
+        sig { type_parameters(:A, :B).params(a: T::Array[T.type_parameter(:A)], fa: T.proc.params(item: T.type_parameter(:A)).returns(T.untyped), b: T::Array[T.type_parameter(:B)], fb: T.proc.params(item: T.type_parameter(:B)).returns(T.untyped)).returns(T::Array[[T.type_parameter(:A), T.type_parameter(:B)]]) }
+        sig { returns({ item_id: String, tax_code: String, name: String, rate: BigDecimal, rate_type: String, amount: BigDecimal, subdivision: String, jurisdiction: String, exempt: T::Boolean, reasons: T::Array[String] }) }
+        def foo; end
+      RBI
     end
 
     def test_parse_methods_with_visibility


### PR DESCRIPTION
Handle:
* `params()`
* `returns()`
* `checked()`
* `type_parameters()`
