### PR TITLE
Bump Ruby dependency to 2.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ "2.6", "2.7", "3.0", "3.1" ]
+        ruby: [ "2.7", "3.0", "3.1" ]
     name: Test Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/rbi.gemspec
+++ b/rbi.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "RBI generation framework"
   spec.homepage      = "https://github.com/Shopify/rbi"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 


### PR DESCRIPTION
Ruby 2.6 is [EOL since 2022-03-31](https://www.ruby-lang.org/en/downloads/branches/#:~:text=EOL%20date%3A%202022%2D03%2D31).