### PR TITLE
Associate sigs comments with method/attr nodes

### DIFF
--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -727,6 +727,41 @@ module RBI
       assert_equal(rbi, out.string)
     end
 
+    def test_parse_comments_with_sigs
+      rbi = <<~RBI
+        module A
+          # foo comment
+          sig { void }
+          def foo; end
+
+          # bar comment
+          sig { returns(String) }
+          attr_reader :bar
+
+          sig { void }
+          # baz comment
+          def baz; end
+        end
+      RBI
+
+      out = Parser.parse_string(rbi)
+      assert_equal(<<~RBI, out.string)
+        module A
+          # foo comment
+          sig { void }
+          def foo; end
+
+          # bar comment
+          sig { returns(String) }
+          attr_reader :bar
+
+          # baz comment
+          sig { void }
+          def baz; end
+        end
+      RBI
+    end
+
     def test_parse_multiline_comments
       rbi = <<~RBI
         # Foo 1


### PR DESCRIPTION
So we actually associate the comments on top of a sig to the following method:

```rb
# This comment was lost
sig { returns(String) }
attr_reader :bar

# This one as well
sig { void }
def foo; end
```