### PR TITLE
Do not sort `T::Struct` fields (`prop` and `const` attributes)

### DIFF
--- a/lib/rbi/rewriters/sort_nodes.rb
+++ b/lib/rbi/rewriters/sort_nodes.rb
@@ -81,10 +81,12 @@ module RBI
       sig { params(node: Node).returns(T.nilable(String)) }
       def node_name(node)
         case node
-        when Module, Class, Struct, Const, Method, Helper, TStructField, RequiresAncestor
+        when Module, Class, Struct, Const, Method, Helper, RequiresAncestor
           node.name
         when Attr
           node.names.first.to_s
+        when TStructField, Mixin
+          nil # we never want to sort these nodes by their name
         end
       end
 

--- a/test/rbi/rewriters/group_nodes_test.rb
+++ b/test/rbi/rewriters/group_nodes_test.rb
@@ -280,8 +280,8 @@ module RBI
           send2
           send1
 
-          const :SC, Type
           prop :SP, Type
+          const :SC, Type
 
           def m1; end
           def self.m2; end
@@ -350,10 +350,10 @@ module RBI
         mixes_in_class_methods MICM2
         mixes_in_class_methods MICM1
 
-        const :SC1, Type
+        prop :SP2, Type
         const :SC2, Type
         prop :SP1, Type
-        prop :SP2, Type
+        const :SC1, Type
 
         def m1; end
         def m2; end
@@ -487,10 +487,10 @@ module RBI
           mixes_in_class_methods MICM2
           mixes_in_class_methods MICM1
 
-          const :SC1, Type
+          prop :SP2, Type
           const :SC2, Type
           prop :SP1, Type
-          prop :SP2, Type
+          const :SC1, Type
 
           def m1; end
           def m2; end
@@ -524,10 +524,10 @@ module RBI
           mixes_in_class_methods MICM2
           mixes_in_class_methods MICM1
 
-          const :SC1, Type
+          prop :SP2, Type
           const :SC2, Type
           prop :SP1, Type
-          prop :SP2, Type
+          const :SC1, Type
 
           def m1; end
           def m2; end
@@ -556,10 +556,10 @@ module RBI
             mixes_in_class_methods MICM2
             mixes_in_class_methods MICM1
 
-            const :SC1, Type
+            prop :SP2, Type
             const :SC2, Type
             prop :SP1, Type
-            prop :SP2, Type
+            const :SC1, Type
 
             def m1; end
             def m2; end

--- a/test/rbi/rewriters/sort_nodes_test.rb
+++ b/test/rbi/rewriters/sort_nodes_test.rb
@@ -166,10 +166,10 @@ module RBI
       rbi.sort_nodes!
 
       assert_equal(<<~RBI, rbi.string)
-        prop :a, T
-        const :b, T
-        prop :c, T
         const :d, T
+        prop :c, T
+        const :b, T
+        prop :a, T
       RBI
     end
 
@@ -290,10 +290,10 @@ module RBI
         requires_ancestor { RA }
         h!
         mixes_in_class_methods MICM
-        prop :SP1, T
         const :SP2, T
-        prop :SP3, T
         const :SP4, T
+        prop :SP1, T
+        prop :SP3, T
         attr_accessor :a, :foo, :z
         attr_writer :b, :baz
         attr_reader :bar


### PR DESCRIPTION
Related to: https://github.com/Shopify/hedwig/pull/521

Sorbet defines the initializer depending on the declaration order of the fields. When we sort the fields, the initializer ends up not matching the declaration expected by Sorbet.

This is especially problematic if the initializer of the struct subclass is overriden, since the static type checker will raise an error if the order of the parameters in the initializer does not match the order that the props were declared, which is file order. An example can be seen
[here](https://sorbet.run/#%23%20typed%3A%20true%0A%0Aclass%20Foo%20%3C%20T%3A%3AStruct%0A%20%20const%20%3Abar%2C%20Integer%0A%20%20const%20%3Afoo%2C%20String%0A%0A%20%20sig%20%7B%20params%28foo%3A%20String%2C%20bar%3A%20Integer%29.void%20%7D%0A%20%20def%20initialize%28foo%3A%2C%20bar%3A%29%0A%20%20end%0Aend%0A%0A). Since we generate the initializer params in document order, we should also generate props in document order as well.

**Note:** As I was removing `TStructField` from the `node_name` method case statement, I realized that we never really explicitly show which nodes should not be sorted by name, so I added an explicit `nil` returning case for those.