### PR TITLE
Do not change visibility when sorting

### DIFF
--- a/test/rbi/rewriters/sort_nodes_test.rb
+++ b/test/rbi/rewriters/sort_nodes_test.rb
@@ -310,5 +310,30 @@ module RBI
         class E; end
       RBI
     end
+
+    def test_sort_doesnt_change_privacy
+      rbi = Tree.new
+      rbi << Public.new
+      rbi << Method.new("c") # 0
+      rbi << Private.new     # 1
+      rbi << Method.new("a") # 2
+      rbi << Protected.new   # 3
+      rbi << Method.new("b") # 4
+      rbi << Public.new
+      rbi << Method.new("aa")
+
+      rbi.sort_nodes!
+
+      assert_equal(<<~RBI, rbi.string)
+        public
+        def c; end
+        private
+        def a; end
+        protected
+        def b; end
+        public
+        def aa; end
+      RBI
+    end
   end
 end


### PR DESCRIPTION
Hopefully fixes #141 . Updates the `SortNodes` visitor to preserve visibility of nodes. So, a file that looks like

```ruby
class MyClass
def zethod2; end
def zethod1; end
private
def c; end
def b; end
end
```

will get sorted as
```ruby
class MyClass
def zethod1; end
def zethod2; end
private
def b; end
def c; end
end
```

rather than as

```ruby
class MyClass
def b; end
def c; end
private
def zethod1; end
def zethod2; end
end
```