### PR TITLE
Enable dependency updates with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "Shopify/sorbet"
+    labels:
+      - "dependencies"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "Shopify/sorbet"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
The `.github/dependabot.yml` file is directly [copied from spoom](https://github.com/Shopify/spoom/blob/main/.github/dependabot.yml).