### PR TITLE
Rename depends-railgun to depends-isogun

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -22,7 +22,7 @@ commands:
   typecheck:
     desc: 'run Sorbet typechecking'
     aliases: ['tc']
-    depends-railgun: false
+    depends-isogun: false
     run: bundle exec srb tc
   sanity: 'bin/typecheck; bin/test; bin/style'
   rbi:


### PR DESCRIPTION
Otherwise it raises this when `dev up`:

> Invalid value in dev.yml for commands.typecheck: {"desc"=>"run Sorbet typechecking", "aliases"=>["tc"], "depends-railgun"=>false, "run"=>"bundle exec srb tc"}. Unexpected key(s): depends-railgun.

For more information: https://github.com/Shopify/dev/pull/6851#issuecomment-1113313812