### PR TITLE
Bump unparser gem version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,9 +3,9 @@ PATH
   specs:
     rbi (0.0.16)
       ast
-      parser (>= 2.6.4.0)
+      parser (>= 3.0.0)
       sorbet-runtime (>= 0.5.9204)
-      unparser
+      unparser (>= 0.5.6)
 
 GEM
   remote: https://rubygems.org/

--- a/rbi.gemspec
+++ b/rbi.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   ]
 
   spec.add_dependency("ast")
-  spec.add_dependency("parser", ">= 2.6.4.0")
+  spec.add_dependency("parser", ">= 3.0.0")
   spec.add_dependency("sorbet-runtime", ">= 0.5.9204")
-  spec.add_dependency("unparser")
+  spec.add_dependency("unparser", ">= 0.5.6")
 end


### PR DESCRIPTION
Closes #178 

If users attempt to run `tapioca init` with an old version of the `unparser` gem that doesn't yet support Ruby 3 syntax, they'll run into confusing parsing issues. Making a newer version of `unparser` a requirement of the `rbi` gem should fix this issue.