### PR TITLE
Method nodes fail tree merge if their default values are not exactly the same

### DIFF
--- a/lib/rbi/model.rb
+++ b/lib/rbi/model.rb
@@ -621,7 +621,7 @@ module RBI
 
     sig { params(other: T.nilable(Object)).returns(T::Boolean) }
     def ==(other)
-      OptParam === other && name == other.name && value == other.value
+      OptParam === other && name == other.name
     end
   end
 
@@ -707,7 +707,7 @@ module RBI
 
     sig { params(other: T.nilable(Object)).returns(T::Boolean) }
     def ==(other)
-      KwOptParam === other && name == other.name && value == other.value
+      KwOptParam === other && name == other.name
     end
   end
 

--- a/test/rbi/rewriters/merge_trees_test.rb
+++ b/test/rbi/rewriters/merge_trees_test.rb
@@ -731,7 +731,6 @@ module RBI
           def m5(a = 10); end
           def m6(a); end
           def m7(&a); end
-          def m8(a: nil); end
           =======
           def m1(a); end
           def m2; end
@@ -740,8 +739,32 @@ module RBI
           def m5(a); end
           def m6(a:); end
           def m7(a); end
-          def m8(a: 10); end
           >>>>>>> right
+          def m8(a: nil); end
+        end
+      RBI
+
+      res = rbi2.merge(rbi1)
+      assert_equal(<<~RBI, res.string)
+        class Foo
+          <<<<<<< left
+          def m1(a); end
+          def m2; end
+          def m3(b); end
+          def m4(c, b, a); end
+          def m5(a); end
+          def m6(a:); end
+          def m7(a); end
+          =======
+          def m1; end
+          def m2(a); end
+          def m3(a); end
+          def m4(a, b, c); end
+          def m5(a = 10); end
+          def m6(a); end
+          def m7(&a); end
+          >>>>>>> right
+          def m8(a: 10); end
         end
       RBI
     end

--- a/test/rbi/rewriters/merge_trees_test.rb
+++ b/test/rbi/rewriters/merge_trees_test.rb
@@ -174,6 +174,7 @@ module RBI
           def b; end
           def c(a, b:, &d); end
           def d(a); end
+          def x(a = T.unsafe(nil), b: T.unsafe(nil)); end
         end
       RBI
 
@@ -183,6 +184,7 @@ module RBI
           def b; end
           def c(a, b:, &d); end
           def e(a); end
+          def x(a = false, b: "foo"); end
         end
       RBI
 
@@ -193,6 +195,7 @@ module RBI
           def b; end
           def c(a, b:, &d); end
           def d(a); end
+          def x(a = T.unsafe(nil), b: T.unsafe(nil)); end
           def e(a); end
         end
       RBI


### PR DESCRIPTION
@searls reported that Tapioca would (silently) fail to merge the generated signatures and the bundled signatures of a method defined like the following:
```ruby
sig { params(a: T::Boolean).void }
def foo(a: false)
end
```

This happens because when Tapioca generates the RBI for the `foo` method it generates it as:
```ruby
sig { params(a: T::Boolean).void } 
def foo(a: T.unsafe(nil); end
```

Note that the default value in the generated RBI file does not match the default value in the bundled RBI file, so the merge fails [this check](https://github.com/Shopify/rbi/blob/da5e30e95f290aa26fbdcf5fc9fcace5c5a291aa/lib/rbi/rewriters/merge_trees.rb#L464), which itself fails because of [this comparison](https://github.com/Shopify/rbi/blob/36de54c34409292f9fab8e7c4a3a482adfc756ab/lib/rbi/model.rb#L708-L711).

This PR adds a test case to exhibit the behaviour and adds a hacky fix that considers `T.unsafe(nil)` to be equivalent as a default value to any other value. We probably need a more general fix for this though.