### PR TITLE
Fix merging of type variables

### DIFF
--- a/lib/rbi/index.rb
+++ b/lib/rbi/index.rb
@@ -175,6 +175,16 @@ module RBI
     end
   end
 
+  class TypeMember
+    extend T::Sig
+    include Indexable
+
+    sig { override.returns(T::Array[String]) }
+    def index_ids
+      [to_s]
+    end
+  end
+
   class Send
     extend T::Sig
     include Indexable

--- a/test/rbi/rewriters/merge_trees_test.rb
+++ b/test/rbi/rewriters/merge_trees_test.rb
@@ -285,6 +285,49 @@ module RBI
       RBI
     end
 
+    def test_merge_type_members_together
+      rbi1 = Parser.parse_string(<<~RBI)
+        class A
+          Foo = type_member {{ fixed: Integer }}
+          Bar = type_template {{ upper: String }}
+        end
+      RBI
+
+      rbi2 = Parser.parse_string(<<~RBI)
+        class A
+          Foo = type_member {
+            { fixed: Integer }
+          }
+          Bar = type_template {
+            { upper: String }
+          }
+          Baz = type_template
+        end
+      RBI
+
+      res = rbi1.merge(rbi2)
+      assert_equal(<<~RBI, res.string)
+        class A
+          Foo = type_member {{ fixed: Integer }}
+          Bar = type_template {{ upper: String }}
+          Baz = type_template
+        end
+      RBI
+
+      res = rbi2.merge(rbi1)
+      assert_equal(<<~RBI, res.string)
+        class A
+          Foo = type_member {
+            { fixed: Integer }
+          }
+          Bar = type_template {
+            { upper: String }
+          }
+          Baz = type_template
+        end
+      RBI
+    end
+
     def test_merge_structs_together
       rbi1 = Parser.parse_string(<<~RBI)
         class A < T::Struct


### PR DESCRIPTION
As [reported by @searls on Sorbet Slack](https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1686419185397299) when RBI does a merge, it completely drops nodes of type `RBI::TypeMember` since they were never marked indexable. The reported example commit can be seen [here](https://github.com/testdouble/mocktail/pull/22/commits/efbfd14e080d5ea6edaf5097f8c793e6474e24a0#diff-ddd1adf70b87dd273df33ac34ca68b75278b7be9ec334a55719b4656153e2c32R7).

Moreover, we'd never added proper support for parsing type variable definitions as `RBI::TypeMember` nodes, which was also making it really hard to test this based on nodes generated from parsed source.

This PR:
1. Adds parsing support for `type_member` and `type_template` declarations.
2. Adds a failing test for merging type variable nodes.
3. Marks `RBI::TypeMember` nodes as `Indexable` so that they get merged properly and pass the test added in the previous commit.