### PR TITLE
Schedule monthly dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     reviewers:
       - "Shopify/sorbet"
     labels:


### PR DESCRIPTION
`rbi` is a library so we can be more lenient with the number of PRs and reduce the noise.