### PR TITLE
Update supported versions to remove Ruby 2.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ "2.7", "3.0", "3.1" ]
+        ruby: [ "3.0", "3.1", "3.2" ]
     name: Test Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   SuggestExtensions: false
   Exclude:
   - 'vendor/**/*'

--- a/rbi.gemspec
+++ b/rbi.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "RBI generation framework"
   spec.homepage      = "https://github.com/Shopify/rbi"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.0.0")
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 


### PR DESCRIPTION
Ruby 2.7 is now in [end of life](https://endoflife.date/ruby).