### PR TITLE
Restrict Prism dependency due to breaking changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    rbi (0.1.2)
-      prism (>= 0.15.1)
+    rbi (0.1.3)
+      prism (>= 0.15.1, < 0.17)
       sorbet-runtime (>= 0.5.9204)
 
 GEM

--- a/lib/rbi/version.rb
+++ b/lib/rbi/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module RBI
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/rbi.gemspec
+++ b/rbi.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
     "Rakefile",
   ]
 
-  spec.add_dependency("prism", ">= 0.15.1")
+  spec.add_dependency("prism", ">= 0.15.1", "< 0.17")
   spec.add_dependency("sorbet-runtime", ">= 0.5.9204")
 end


### PR DESCRIPTION
The latest Prism version contains breaking changes that affect RBI. Let's better restrict our requirement to avoid issues.