### PR TITLE
index.rb: fix minor typo

### DIFF
--- a/lib/rbi/index.rb
+++ b/lib/rbi/index.rb
@@ -70,7 +70,7 @@ module RBI
     end
   end
 
-  # A Node that can be refered to by a unique ID inside an index
+  # A Node that can be referred to by a unique ID inside an index
   module Indexable
     extend T::Sig
     extend T::Helpers


### PR DESCRIPTION
This PR aims to fix various minor typos across the codebase. I noticed some of these when doing the same review on our Homebrew/brew repo, since we use rbi.