### PR TITLE
Remove Ruby 3.0 from CI matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ "3.0", "3.1", "3.2", "3.3" ]
+        ruby: [ "3.1", "3.2", "3.3" ]
     name: Test Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v4

--- a/rbi.gemspec
+++ b/rbi.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |spec|
   spec.summary       = "RBI generation framework"
   spec.homepage      = "https://github.com/Shopify/rbi"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 3.0.0")
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
@@ -26,4 +25,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("prism", ">= 0.18.0", "< 0.28")
   spec.add_dependency("sorbet-runtime", ">= 0.5.9204")
+
+  spec.required_ruby_version = ">= 3.1"
 end


### PR DESCRIPTION
Ruby 3.0 is EOL since 2024-04-23.

See https://www.ruby-lang.org/en/downloads/branches/.