### PR TITLE
Transform all visitors in double-dispatch visitors

### DIFF
--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -74,18 +74,6 @@ module RBI
       printn(string)
     end
 
-    sig { params(file: File).void }
-    def visit_file(file)
-      file.accept_printer(self)
-    end
-
-    sig { override.params(node: T.nilable(Node)).void }
-    def visit(node)
-      return unless node
-
-      node.accept_printer(self)
-    end
-
     sig { override.params(nodes: T::Array[Node]).void }
     def visit_all(nodes)
       previous_node = @previous_node
@@ -96,27 +84,650 @@ module RBI
       end
       @previous_node = previous_node
     end
+
+    sig { override.params(file: File).void }
+    def visit_file(file)
+      strictness = file.strictness
+      if strictness
+        printl("# typed: #{strictness}")
+      end
+      unless file.comments.empty?
+        printn if strictness
+        visit_all(file.comments)
+      end
+
+      unless file.root.empty? && file.root.comments.empty?
+        printn if strictness || !file.comments.empty?
+        visit(file.root)
+      end
+    end
+
+    private
+
+    sig { override.params(node: Comment).void }
+    def visit_comment(node)
+      lines = node.text.lines
+
+      if lines.empty?
+        printl("#")
+      end
+
+      lines.each do |line|
+        text = line.rstrip
+        printt("#")
+        print(" #{text}") unless text.empty?
+        printn
+      end
+    end
+
+    sig { override.params(node: BlankLine).void }
+    def visit_blank_line(node)
+      printn
+    end
+
+    sig { override.params(node: Tree).void }
+    def visit_tree(node)
+      visit_all(node.comments)
+      printn if !node.comments.empty? && !node.empty?
+      visit_all(node.nodes)
+    end
+
+    sig { override.params(node: Module).void }
+    def visit_module(node)
+      visit_scope(node)
+    end
+
+    sig { override.params(node: Class).void }
+    def visit_class(node)
+      visit_scope(node)
+    end
+
+    sig { override.params(node: Struct).void }
+    def visit_struct(node)
+      visit_scope(node)
+    end
+
+    sig { override.params(node: SingletonClass).void }
+    def visit_singleton_class(node)
+      visit_scope(node)
+    end
+
+    sig { params(node: Scope).void }
+    def visit_scope(node)
+      print_blank_line_before(node)
+      print_loc(node)
+      visit_all(node.comments)
+
+      visit_scope_header(node)
+      visit_scope_body(node)
+    end
+
+    sig { params(node: Scope).void }
+    def visit_scope_header(node)
+      case node
+      when Module
+        printt("module #{node.name}")
+      when Class
+        printt("class #{node.name}")
+        superclass = node.superclass_name
+        print(" < #{superclass}") if superclass
+      when Struct
+        printt("#{node.name} = ::Struct.new")
+        if !node.members.empty? || node.keyword_init
+          print("(")
+          args = node.members.map { |member| ":#{member}" }
+          args << "keyword_init: true" if node.keyword_init
+          print(args.join(", "))
+          print(")")
+        end
+      when SingletonClass
+        printt("class << self")
+      when TStruct
+        printt("class #{node.name} < T::Struct")
+      when TEnum
+        printt("class #{node.name} < T::Enum")
+      else
+        raise "Unhandled node: #{node.class}"
+      end
+      if node.empty? && !node.is_a?(Struct)
+        print("; end")
+      elsif !node.empty? && node.is_a?(Struct)
+        print(" do")
+      end
+      printn
+    end
+
+    sig { params(node: Scope).void }
+    def visit_scope_body(node)
+      return if node.empty?
+
+      indent
+      visit_all(node.nodes)
+      dedent
+      printl("end")
+    end
+
+    sig { override.params(node: Const).void }
+    def visit_const(node)
+      print_blank_line_before(node)
+      print_loc(node)
+      visit_all(node.comments)
+
+      printl("#{node.name} = #{node.value}")
+    end
+
+    sig { override.params(node: AttrAccessor).void }
+    def visit_attr_accessor(node)
+      visit_attr(node)
+    end
+
+    sig { override.params(node: AttrReader).void }
+    def visit_attr_reader(node)
+      visit_attr(node)
+    end
+
+    sig { override.params(node: AttrWriter).void }
+    def visit_attr_writer(node)
+      visit_attr(node)
+    end
+
+    sig { params(node: Attr).void }
+    def visit_attr(node)
+      print_blank_line_before(node)
+
+      visit_all(node.comments)
+      node.sigs.each { |sig| visit(sig) }
+
+      print_loc(node)
+      printt
+      unless in_visibility_group || node.visibility.public?
+        self.print(node.visibility.visibility.to_s)
+        print(" ")
+      end
+      case node
+      when AttrAccessor
+        print("attr_accessor")
+      when AttrReader
+        print("attr_reader")
+      when AttrWriter
+        print("attr_writer")
+      end
+      unless node.names.empty?
+        print(" ")
+        print(node.names.map { |name| ":#{name}" }.join(", "))
+      end
+      printn
+    end
+
+    sig { override.params(node: Method).void }
+    def visit_method(node)
+      print_blank_line_before(node)
+      visit_all(node.comments)
+      visit_all(node.sigs)
+
+      print_loc(node)
+      printt
+      unless in_visibility_group || node.visibility.public?
+        self.print(node.visibility.visibility.to_s)
+        print(" ")
+      end
+      print("def ")
+      print("self.") if node.is_singleton
+      print(node.name)
+      unless node.params.empty?
+        print("(")
+        if node.params.all? { |p| p.comments.empty? }
+          node.params.each_with_index do |param, index|
+            print(", ") if index > 0
+            visit(param)
+          end
+        else
+          printn
+          indent
+          node.params.each_with_index do |param, pindex|
+            printt
+            visit(param)
+            print(",") if pindex < node.params.size - 1
+
+            comment_lines = param.comments.flat_map { |comment| comment.text.lines.map(&:rstrip) }
+            comment_lines.each_with_index do |comment, cindex|
+              if cindex > 0
+                print_param_comment_leading_space(param, last: pindex == node.params.size - 1)
+              else
+                print(" ")
+              end
+              print("# #{comment}")
+            end
+            printn
+          end
+          dedent
+        end
+        print(")")
+      end
+      print("; end")
+      printn
+    end
+
+    sig { override.params(node: ReqParam).void }
+    def visit_req_param(node)
+      print(node.name)
+    end
+
+    sig { override.params(node: OptParam).void }
+    def visit_opt_param(node)
+      print("#{node.name} = #{node.value}")
+    end
+
+    sig { override.params(node: RestParam).void }
+    def visit_rest_param(node)
+      print("*#{node.name}")
+    end
+
+    sig { override.params(node: KwParam).void }
+    def visit_kw_param(node)
+      print("#{node.name}:")
+    end
+
+    sig { override.params(node: KwOptParam).void }
+    def visit_kw_opt_param(node)
+      print("#{node.name}: #{node.value}")
+    end
+
+    sig { override.params(node: KwRestParam).void }
+    def visit_kw_rest_param(node)
+      print("**#{node.name}")
+    end
+
+    sig { override.params(node: BlockParam).void }
+    def visit_block_param(node)
+      print("&#{node.name}")
+    end
+
+    sig { override.params(node: Include).void }
+    def visit_include(node)
+      visit_mixin(node)
+    end
+
+    sig { override.params(node: Extend).void }
+    def visit_extend(node)
+      visit_mixin(node)
+    end
+
+    sig { params(node: Mixin).void }
+    def visit_mixin(node)
+      print_blank_line_before(node)
+      print_loc(node)
+      visit_all(node.comments)
+
+      case node
+      when Include
+        printt("include")
+      when Extend
+        printt("extend")
+      when MixesInClassMethods
+        printt("mixes_in_class_methods")
+      end
+      printn(" #{node.names.join(", ")}")
+    end
+
+    sig { override.params(node: Public).void }
+    def visit_public(node)
+      visit_visibility(node)
+    end
+
+    sig { override.params(node: Protected).void }
+    def visit_protected(node)
+      visit_visibility(node)
+    end
+
+    sig { override.params(node: Private).void }
+    def visit_private(node)
+      visit_visibility(node)
+    end
+
+    sig { params(node: Visibility).void }
+    def visit_visibility(node)
+      print_blank_line_before(node)
+      print_loc(node)
+      visit_all(node.comments)
+
+      printl(node.visibility.to_s)
+    end
+
+    sig { override.params(node: Send).void }
+    def visit_send(node)
+      print_blank_line_before(node)
+      print_loc(node)
+      visit_all(node.comments)
+
+      printt(node.method)
+      unless node.args.empty?
+        print(" ")
+        node.args.each_with_index do |arg, index|
+          visit(arg)
+          print(", ") if index < node.args.size - 1
+        end
+      end
+      printn
+    end
+
+    sig { override.params(node: Arg).void }
+    def visit_arg(node)
+      print(node.value)
+    end
+
+    sig { override.params(node: KwArg).void }
+    def visit_kw_arg(node)
+      print("#{node.keyword}: #{node.value}")
+    end
+
+    sig { override.params(node: Sig).void }
+    def visit_sig(node)
+      print_loc(node)
+
+      max_line_length = self.max_line_length
+      if oneline?(node) && max_line_length.nil?
+        print_sig_as_line(node)
+      elsif max_line_length
+        line = node.string(indent: current_indent)
+        if line.length <= max_line_length
+          print(line)
+        else
+          print_sig_as_block(node)
+        end
+      else
+        print_sig_as_block(node)
+      end
+    end
+
+    sig { override.params(node: SigParam).void }
+    def visit_sig_param(node)
+      print("#{node.name}: #{node.type}")
+    end
+
+    sig { override.params(node: TStruct).void }
+    def visit_tstruct(node)
+      visit_scope(node)
+    end
+
+    sig { override.params(node: TStructConst).void }
+    def visit_tstruct_const(node)
+      visit_t_struct_field(node)
+    end
+
+    sig { override.params(node: TStructProp).void }
+    def visit_tstruct_prop(node)
+      visit_t_struct_field(node)
+    end
+
+    sig { params(node: TStructField).void }
+    def visit_t_struct_field(node)
+      print_blank_line_before(node)
+      print_loc(node)
+      visit_all(node.comments)
+
+      case node
+      when TStructProp
+        printt("prop")
+      when TStructConst
+        printt("const")
+      end
+      print(" :#{node.name}, #{node.type}")
+      default = node.default
+      print(", default: #{default}") if default
+      printn
+    end
+
+    sig { override.params(node: TEnum).void }
+    def visit_tenum(node)
+      visit_scope(node)
+    end
+
+    sig { override.params(node: TEnumBlock).void }
+    def visit_tenum_block(node)
+      print_loc(node)
+      visit_all(node.comments)
+
+      printl("enums do")
+      indent
+      node.names.each do |name|
+        printl("#{name} = new")
+      end
+      dedent
+      printl("end")
+    end
+
+    sig { override.params(node: TypeMember).void }
+    def visit_type_member(node)
+      print_blank_line_before(node)
+      print_loc(node)
+      visit_all(node.comments)
+
+      printl("#{node.name} = #{node.value}")
+    end
+
+    sig { override.params(node: Helper).void }
+    def visit_helper(node)
+      print_blank_line_before(node)
+      print_loc(node)
+      visit_all(node.comments)
+
+      printl("#{node.name}!")
+    end
+
+    sig { override.params(node: MixesInClassMethods).void }
+    def visit_mixes_in_class_methods(node)
+      visit_mixin(node)
+    end
+
+    sig { override.params(node: Group).void }
+    def visit_group(node)
+      printn unless previous_node.nil?
+      visit_all(node.nodes)
+    end
+
+    sig { override.params(node: VisibilityGroup).void }
+    def visit_visibility_group(node)
+      self.in_visibility_group = true
+      if node.visibility.public?
+        printn unless previous_node.nil?
+      else
+        visit(node.visibility)
+        printn
+      end
+      visit_all(node.nodes)
+      self.in_visibility_group = false
+    end
+
+    sig { override.params(node: RequiresAncestor).void }
+    def visit_requires_ancestor(node)
+      print_blank_line_before(node)
+      print_loc(node)
+      visit_all(node.comments)
+
+      printl("requires_ancestor { #{node.name} }")
+    end
+
+    sig { override.params(node: ConflictTree).void }
+    def visit_conflict_tree(node)
+      printl("<<<<<<< #{node.left_name}")
+      visit(node.left)
+      printl("=======")
+      visit(node.right)
+      printl(">>>>>>> #{node.right_name}")
+    end
+
+    sig { override.params(node: ScopeConflict).void }
+    def visit_scope_conflict(node)
+      print_blank_line_before(node)
+      print_loc(node)
+      visit_all(node.comments)
+
+      printl("<<<<<<< #{node.left_name}")
+      visit_scope_header(node.left)
+      printl("=======")
+      visit_scope_header(node.right)
+      printl(">>>>>>> #{node.right_name}")
+      visit_scope_body(node.left)
+    end
+
+    sig { params(node: Node).void }
+    def print_blank_line_before(node)
+      previous_node = self.previous_node
+      return unless previous_node
+      return if previous_node.is_a?(BlankLine)
+      return if oneline?(previous_node) && oneline?(node)
+
+      printn
+    end
+
+    sig { params(node: Node).void }
+    def print_loc(node)
+      loc = node.loc
+      printl("# #{loc}") if loc && print_locs
+    end
+
+    sig { params(node: Param, last: T::Boolean).void }
+    def print_param_comment_leading_space(node, last:)
+      printn
+      printt
+      print(" " * (node.name.size + 1))
+      print(" ") unless last
+      case node
+      when OptParam
+        print(" " * (node.value.size + 3))
+      when RestParam, KwParam, BlockParam
+        print(" ")
+      when KwRestParam
+        print("  ")
+      when KwOptParam
+        print(" " * (node.value.size + 2))
+      end
+    end
+
+    sig { params(node: SigParam, last: T::Boolean).void }
+    def print_sig_param_comment_leading_space(node, last:)
+      printn
+      printt
+      print(" " * (node.name.size + node.type.size + 3))
+      print(" ") unless last
+    end
+
+    sig { params(node: Node).returns(T::Boolean) }
+    def oneline?(node)
+      case node
+      when ScopeConflict
+        oneline?(node.left)
+      when Tree
+        node.comments.empty? && node.empty?
+      when Attr
+        node.comments.empty? && node.sigs.empty?
+      when Method
+        node.comments.empty? && node.sigs.empty? && node.params.all? { |p| p.comments.empty? }
+      when Sig
+        node.params.all? { |p| p.comments.empty? }
+      when NodeWithComments
+        node.comments.empty?
+      when VisibilityGroup
+        false
+      else
+        true
+      end
+    end
+
+    sig { params(node: Sig).void }
+    def print_sig_as_line(node)
+      printt("sig")
+      print("(:final)") if node.is_final
+      print(" { ")
+      sig_modifiers(node).each do |modifier|
+        print("#{modifier}.")
+      end
+      unless node.params.empty?
+        print("params(")
+        node.params.each_with_index do |param, index|
+          print(", ") if index > 0
+          visit(param)
+        end
+        print(").")
+      end
+      return_type = node.return_type
+      if node.return_type && node.return_type != "void"
+        print("returns(#{return_type})")
+      else
+        print("void")
+      end
+      printn(" }")
+    end
+
+    sig { params(node: Sig).void }
+    def print_sig_as_block(node)
+      modifiers = sig_modifiers(node)
+
+      printl("sig do")
+      indent
+      if modifiers.any?
+        printl(T.must(modifiers.first))
+        indent
+        modifiers[1..]&.each do |modifier|
+          printl(".#{modifier}")
+        end
+      end
+
+      params = node.params
+      if params.any?
+        printt
+        print(".") if modifiers.any?
+        printn("params(")
+        indent
+        params.each_with_index do |param, pindex|
+          printt
+          visit(param)
+          print(",") if pindex < params.size - 1
+
+          comment_lines = param.comments.flat_map { |comment| comment.text.lines.map(&:rstrip) }
+          comment_lines.each_with_index do |comment, cindex|
+            if cindex == 0
+              print(" ")
+            else
+              print_sig_param_comment_leading_space(param, last: pindex == params.size - 1)
+            end
+            print("# #{comment}")
+          end
+          printn
+        end
+        dedent
+        printt(")")
+      end
+      printt if params.empty?
+      print(".") if modifiers.any? || params.any?
+
+      return_type = node.return_type
+      if return_type && return_type != "void"
+        print("returns(#{return_type})")
+      else
+        print("void")
+      end
+      printn
+      dedent
+      dedent if modifiers.any?
+      printl("end")
+    end
+
+    sig { params(node: Sig).returns(T::Array[String]) }
+    def sig_modifiers(node)
+      modifiers = T.let([], T::Array[String])
+      modifiers << "abstract" if node.is_abstract
+      modifiers << "override" if node.is_override
+      modifiers << "overridable" if node.is_overridable
+      modifiers << "type_parameters(#{node.type_params.map { |type| ":#{type}" }.join(", ")})" if node.type_params.any?
+      modifiers << "checked(:#{node.checked})" if node.checked
+      modifiers
+    end
   end
 
   class File
     extend T::Sig
-
-    sig { params(v: Printer).void }
-    def accept_printer(v)
-      strictness = self.strictness
-      if strictness
-        v.printl("# typed: #{strictness}")
-      end
-      unless comments.empty?
-        v.printn if strictness
-        v.visit_all(comments)
-      end
-
-      unless root.empty? && root.comments.empty?
-        v.printn if strictness || !comments.empty?
-        v.visit(root)
-      end
-    end
 
     sig do
       params(
@@ -142,9 +753,6 @@ module RBI
   class Node
     extend T::Sig
 
-    sig { abstract.params(v: Printer).void }
-    def accept_printer(v); end
-
     sig do
       params(
         out: T.any(IO, StringIO),
@@ -163,716 +771,6 @@ module RBI
       out = StringIO.new
       print(out: out, indent: indent, print_locs: print_locs, max_line_length: max_line_length)
       out.string
-    end
-
-    sig { params(v: Printer).void }
-    def print_blank_line_before(v)
-      previous_node = v.previous_node
-      return unless previous_node
-      return if previous_node.is_a?(BlankLine)
-      return if previous_node.oneline? && oneline?
-
-      v.printn
-    end
-
-    sig { returns(T::Boolean) }
-    def oneline?
-      true
-    end
-  end
-
-  class NodeWithComments
-    extend T::Sig
-
-    sig { override.returns(T::Boolean) }
-    def oneline?
-      comments.empty?
-    end
-  end
-
-  class Comment
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      lines = text.lines
-
-      if lines.empty?
-        v.printl("#")
-      end
-
-      lines.each do |line|
-        text = line.rstrip
-        v.printt("#")
-        v.print(" #{text}") unless text.empty?
-        v.printn
-      end
-    end
-  end
-
-  class BlankLine
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      v.printn
-    end
-  end
-
-  class Tree
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      v.visit_all(comments)
-      v.printn if !comments.empty? && !empty?
-      v.visit_all(nodes)
-    end
-
-    sig { override.returns(T::Boolean) }
-    def oneline?
-      comments.empty? && empty?
-    end
-  end
-
-  class Scope
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      print_blank_line_before(v)
-
-      v.printl("# #{loc}") if loc && v.print_locs
-      v.visit_all(comments)
-
-      print_header(v)
-      print_body(v)
-    end
-
-    sig { abstract.params(v: Printer).void }
-    def print_header(v); end
-
-    sig { params(v: Printer).void }
-    def print_body(v)
-      unless empty?
-        v.indent
-        v.visit_all(nodes)
-        v.dedent
-        v.printl("end")
-      end
-    end
-  end
-
-  class Module
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def print_header(v)
-      v.printt("module #{name}")
-      if empty?
-        v.printn("; end")
-      else
-        v.printn
-      end
-    end
-  end
-
-  class Class
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def print_header(v)
-      v.printt("class #{name}")
-      superclass = superclass_name
-      v.print(" < #{superclass}") if superclass
-      if empty?
-        v.printn("; end")
-      else
-        v.printn
-      end
-    end
-  end
-
-  class Struct
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def print_header(v)
-      v.printt("#{name} = ::Struct.new")
-      if !members.empty? || keyword_init
-        v.print("(")
-        args = members.map { |member| ":#{member}" }
-        args << "keyword_init: true" if keyword_init
-        v.print(args.join(", "))
-        v.print(")")
-      end
-      if empty?
-        v.printn
-      else
-        v.printn(" do")
-      end
-    end
-  end
-
-  class SingletonClass
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def print_header(v)
-      v.printt("class << self")
-      if empty?
-        v.printn("; end")
-      else
-        v.printn
-      end
-    end
-  end
-
-  class Const
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      print_blank_line_before(v)
-
-      v.printl("# #{loc}") if loc && v.print_locs
-      v.visit_all(comments)
-      v.printl("#{name} = #{value}")
-    end
-  end
-
-  class Attr
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      print_blank_line_before(v)
-
-      v.visit_all(comments)
-      sigs.each { |sig| v.visit(sig) }
-      v.printl("# #{loc}") if loc && v.print_locs
-      v.printt
-      unless v.in_visibility_group || visibility.public?
-        v.print(visibility.visibility.to_s)
-        v.print(" ")
-      end
-      case self
-      when AttrAccessor
-        v.print("attr_accessor")
-      when AttrReader
-        v.print("attr_reader")
-      when AttrWriter
-        v.print("attr_writer")
-      end
-      unless names.empty?
-        v.print(" ")
-        v.print(names.map { |name| ":#{name}" }.join(", "))
-      end
-      v.printn
-    end
-
-    sig { override.returns(T::Boolean) }
-    def oneline?
-      comments.empty? && sigs.empty?
-    end
-  end
-
-  class Method
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      print_blank_line_before(v)
-
-      v.visit_all(comments)
-      v.visit_all(sigs)
-      v.printl("# #{loc}") if loc && v.print_locs
-      v.printt
-      unless v.in_visibility_group || visibility.public?
-        v.print(visibility.visibility.to_s)
-        v.print(" ")
-      end
-      v.print("def ")
-      v.print("self.") if is_singleton
-      v.print(name)
-      unless params.empty?
-        v.print("(")
-        if inline_params?
-          params.each_with_index do |param, index|
-            v.print(", ") if index > 0
-            v.visit(param)
-          end
-        else
-          v.printn
-          v.indent
-          params.each_with_index do |param, pindex|
-            v.printt
-            v.visit(param)
-            v.print(",") if pindex < params.size - 1
-
-            param.comments_lines.each_with_index do |comment, cindex|
-              if cindex > 0
-                param.print_comment_leading_space(v, last: pindex == params.size - 1)
-              else
-                v.print(" ")
-              end
-              v.print("# #{comment}")
-            end
-            v.printn
-          end
-          v.dedent
-        end
-        v.print(")")
-      end
-      v.print("; end")
-      v.printn
-    end
-
-    sig { override.returns(T::Boolean) }
-    def oneline?
-      comments.empty? && sigs.empty? && inline_params?
-    end
-
-    sig { returns(T::Boolean) }
-    def inline_params?
-      params.all? { |p| p.comments.empty? }
-    end
-  end
-
-  class Param
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      v.print(name.to_s)
-    end
-
-    sig { params(v: Printer, last: T::Boolean).void }
-    def print_comment_leading_space(v, last:)
-      v.printn
-      v.printt
-      v.print(" " * (name.size + 1))
-      v.print(" ") unless last
-    end
-
-    sig { returns(T::Array[String]) }
-    def comments_lines
-      comments.flat_map { |comment| comment.text.lines.map(&:rstrip) }
-    end
-  end
-
-  class OptParam
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      v.print("#{name} = #{value}")
-    end
-
-    sig { override.params(v: Printer, last: T::Boolean).void }
-    def print_comment_leading_space(v, last:)
-      super
-      v.print(" " * (value.size + 3))
-    end
-  end
-
-  class RestParam
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      v.print("*#{name}")
-    end
-
-    sig { override.params(v: Printer, last: T::Boolean).void }
-    def print_comment_leading_space(v, last:)
-      super
-      v.print(" ")
-    end
-  end
-
-  class KwParam
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      v.print("#{name}:")
-    end
-
-    sig { override.params(v: Printer, last: T::Boolean).void }
-    def print_comment_leading_space(v, last:)
-      super
-      v.print(" ")
-    end
-  end
-
-  class KwOptParam
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      v.print("#{name}: #{value}")
-    end
-
-    sig { override.params(v: Printer, last: T::Boolean).void }
-    def print_comment_leading_space(v, last:)
-      super
-      v.print(" " * (value.size + 2))
-    end
-  end
-
-  class KwRestParam
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      v.print("**#{name}")
-    end
-
-    sig { override.params(v: Printer, last: T::Boolean).void }
-    def print_comment_leading_space(v, last:)
-      super
-      v.print("  ")
-    end
-  end
-
-  class BlockParam
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      v.print("&#{name}")
-    end
-
-    sig { override.params(v: Printer, last: T::Boolean).void }
-    def print_comment_leading_space(v, last:)
-      super
-      v.print(" ")
-    end
-  end
-
-  class Mixin
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      print_blank_line_before(v)
-
-      v.printl("# #{loc}") if loc && v.print_locs
-      v.visit_all(comments)
-      case self
-      when Include
-        v.printt("include")
-      when Extend
-        v.printt("extend")
-      when MixesInClassMethods
-        v.printt("mixes_in_class_methods")
-      end
-      v.printn(" #{names.join(", ")}")
-    end
-  end
-
-  class Visibility
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      print_blank_line_before(v)
-
-      v.printl("# #{loc}") if loc && v.print_locs
-      v.visit_all(comments)
-      v.printl(visibility.to_s)
-    end
-  end
-
-  class Send
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      print_blank_line_before(v)
-
-      v.printl("# #{loc}") if loc && v.print_locs
-      v.visit_all(comments)
-      v.printt(method)
-      unless args.empty?
-        v.print(" ")
-        args.each_with_index do |arg, index|
-          v.visit(arg)
-          v.print(", ") if index < args.size - 1
-        end
-      end
-      v.printn
-    end
-  end
-
-  class Arg
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      v.print(value)
-    end
-  end
-
-  class KwArg
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      v.print(keyword)
-      v.print(": ")
-      v.print(value)
-    end
-  end
-
-  class Sig
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      v.printl("# #{loc}") if loc && v.print_locs
-      max_line_length = v.max_line_length
-      if oneline? && max_line_length.nil?
-        print_as_line(v)
-      elsif max_line_length
-        line = string(indent: v.current_indent)
-        if line.length <= max_line_length
-          v.print(line)
-        else
-          print_as_block(v)
-        end
-      else
-        print_as_block(v)
-      end
-    end
-
-    sig { override.returns(T::Boolean) }
-    def oneline?
-      inline_params?
-    end
-
-    sig { returns(T::Boolean) }
-    def inline_params?
-      params.all? { |p| p.comments.empty? }
-    end
-
-    private
-
-    sig { returns(T::Array[String]) }
-    def sig_modifiers
-      modifiers = T.let([], T::Array[String])
-      modifiers << "abstract" if is_abstract
-      modifiers << "override" if is_override
-      modifiers << "overridable" if is_overridable
-      modifiers << "type_parameters(#{type_params.map { |type| ":#{type}" }.join(", ")})" if type_params.any?
-      modifiers << "checked(:#{checked})" if checked
-      modifiers
-    end
-
-    sig { params(v: Printer).void }
-    def print_as_line(v)
-      v.printt("sig")
-      v.print("(:final)") if is_final
-      v.print(" { ")
-      sig_modifiers.each do |modifier|
-        v.print("#{modifier}.")
-      end
-      unless params.empty?
-        v.print("params(")
-        params.each_with_index do |param, index|
-          v.print(", ") if index > 0
-          v.visit(param)
-        end
-        v.print(").")
-      end
-      if return_type && return_type != "void"
-        v.print("returns(#{return_type})")
-      else
-        v.print("void")
-      end
-      v.printn(" }")
-    end
-
-    sig { params(v: Printer).void }
-    def print_as_block(v)
-      modifiers = sig_modifiers
-
-      v.printl("sig do")
-      v.indent
-      if modifiers.any?
-        v.printl(T.must(modifiers.first))
-        v.indent
-        modifiers[1..]&.each do |modifier|
-          v.printl(".#{modifier}")
-        end
-      end
-
-      if params.any?
-        v.printt
-        v.print(".") if modifiers.any?
-        v.printn("params(")
-        v.indent
-        params.each_with_index do |param, pindex|
-          v.printt
-          v.visit(param)
-          v.print(",") if pindex < params.size - 1
-          param.comments_lines.each_with_index do |comment, cindex|
-            if cindex == 0
-              v.print(" ")
-            else
-              param.print_comment_leading_space(v, last: pindex == params.size - 1)
-            end
-            v.print("# #{comment}")
-          end
-          v.printn
-        end
-        v.dedent
-        v.printt(")")
-      end
-      v.printt if params.empty?
-      v.print(".") if modifiers.any? || params.any?
-      if return_type && return_type != "void"
-        v.print("returns(#{return_type})")
-      else
-        v.print("void")
-      end
-      v.printn
-      v.dedent
-      v.dedent if modifiers.any?
-      v.printl("end")
-    end
-  end
-
-  class SigParam
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      v.print("#{name}: #{type}")
-    end
-
-    sig { params(v: Printer, last: T::Boolean).void }
-    def print_comment_leading_space(v, last:)
-      v.printn
-      v.printt
-      v.print(" " * (name.size + type.size + 3))
-      v.print(" ") unless last
-    end
-
-    sig { returns(T::Array[String]) }
-    def comments_lines
-      comments.flat_map { |comment| comment.text.lines.map(&:rstrip) }
-    end
-  end
-
-  class TStructField
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      print_blank_line_before(v)
-
-      v.printl("# #{loc}") if loc && v.print_locs
-      v.visit_all(comments)
-      case self
-      when TStructProp
-        v.printt("prop")
-      when TStructConst
-        v.printt("const")
-      end
-      v.print(" :#{name}, #{type}")
-      default = self.default
-      v.print(", default: #{default}") if default
-      v.printn
-    end
-  end
-
-  class TEnumBlock
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      v.printl("# #{loc}") if loc && v.print_locs
-      v.visit_all(comments)
-      v.printl("enums do")
-      v.indent
-      names.each do |name|
-        v.printl("#{name} = new")
-      end
-      v.dedent
-      v.printl("end")
-    end
-  end
-
-  class TypeMember
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      print_blank_line_before(v)
-
-      v.printl("# #{loc}") if loc && v.print_locs
-      v.visit_all(comments)
-      v.printl("#{name} = #{value}")
-    end
-  end
-
-  class Helper
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      print_blank_line_before(v)
-
-      v.printl("# #{loc}") if loc && v.print_locs
-      v.visit_all(comments)
-      v.printl("#{name}!")
-    end
-  end
-
-  class Group
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      v.printn unless v.previous_node.nil?
-      v.visit_all(nodes)
-    end
-  end
-
-  class VisibilityGroup
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      v.in_visibility_group = true
-      if visibility.public?
-        v.printn unless v.previous_node.nil?
-      else
-        v.visit(visibility)
-        v.printn
-      end
-      v.visit_all(nodes)
-      v.in_visibility_group = false
-    end
-
-    sig { override.returns(T::Boolean) }
-    def oneline?
-      false
-    end
-  end
-
-  class RequiresAncestor
-    extend T::Sig
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      print_blank_line_before(v)
-
-      v.printl("# #{loc}") if loc && v.print_locs
-      v.visit_all(comments)
-      v.printl("requires_ancestor { #{name} }")
     end
   end
 end

--- a/lib/rbi/rewriters/merge_trees.rb
+++ b/lib/rbi/rewriters/merge_trees.rb
@@ -605,15 +605,6 @@ module RBI
       @right = T.let(Tree.new, Tree)
       @right.parent_tree = self
     end
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      v.printl("<<<<<<< #{@left_name}")
-      v.visit(left)
-      v.printl("=======")
-      v.visit(right)
-      v.printl(">>>>>>> #{@right_name}")
-    end
   end
 
   # A conflict between two scope headers
@@ -651,27 +642,6 @@ module RBI
       @right = right
       @left_name = left_name
       @right_name = right_name
-    end
-
-    sig { override.params(v: Printer).void }
-    def accept_printer(v)
-      previous_node = v.previous_node
-      v.printn if previous_node && (!previous_node.oneline? || !oneline?)
-
-      v.printl("# #{loc}") if loc && v.print_locs
-      v.visit_all(comments)
-
-      v.printl("<<<<<<< #{@left_name}")
-      left.print_header(v)
-      v.printl("=======")
-      right.print_header(v)
-      v.printl(">>>>>>> #{@right_name}")
-      left.print_body(v)
-    end
-
-    sig { override.returns(T::Boolean) }
-    def oneline?
-      left.oneline?
     end
   end
 end

--- a/lib/rbi/rewriters/merge_trees.rb
+++ b/lib/rbi/rewriters/merge_trees.rb
@@ -592,6 +592,9 @@ module RBI
     sig { returns(Tree) }
     attr_reader :left, :right
 
+    sig { returns(String) }
+    attr_reader :left_name, :right_name
+
     sig { params(left_name: String, right_name: String).void }
     def initialize(left_name: "left", right_name: "right")
       super()
@@ -630,6 +633,9 @@ module RBI
 
     sig { returns(Scope) }
     attr_reader :left, :right
+
+    sig { returns(String) }
+    attr_reader :left_name, :right_name
 
     sig do
       params(

--- a/lib/rbi/visitor.rb
+++ b/lib/rbi/visitor.rb
@@ -8,12 +8,243 @@ module RBI
 
     abstract!
 
-    sig { abstract.params(node: T.nilable(Node)).void }
-    def visit(node); end
+    sig { params(node: T.nilable(Node)).void }
+    def visit(node)
+      return unless node
+
+      case node
+      when BlankLine
+        visit_blank_line(node)
+      when Comment
+        visit_comment(node)
+      when Module
+        visit_module(node)
+      when Class
+        visit_class(node)
+      when SingletonClass
+        visit_singleton_class(node)
+      when Struct
+        visit_struct(node)
+      when Group
+        visit_group(node)
+      when VisibilityGroup
+        visit_visibility_group(node)
+      when ConflictTree
+        visit_conflict_tree(node)
+      when ScopeConflict
+        visit_scope_conflict(node)
+      when Tree
+        visit_tree(node)
+      when Const
+        visit_const(node)
+      when AttrAccessor
+        visit_attr_accessor(node)
+      when AttrReader
+        visit_attr_reader(node)
+      when AttrWriter
+        visit_attr_writer(node)
+      when Method
+        visit_method(node)
+      when ReqParam
+        visit_req_param(node)
+      when OptParam
+        visit_opt_param(node)
+      when RestParam
+        visit_rest_param(node)
+      when KwParam
+        visit_kw_param(node)
+      when KwOptParam
+        visit_kw_opt_param(node)
+      when KwRestParam
+        visit_kw_rest_param(node)
+      when BlockParam
+        visit_block_param(node)
+      when Include
+        visit_include(node)
+      when Extend
+        visit_extend(node)
+      when Public
+        visit_public(node)
+      when Protected
+        visit_protected(node)
+      when Private
+        visit_private(node)
+      when Send
+        visit_send(node)
+      when KwArg
+        visit_kw_arg(node)
+      when Arg
+        visit_arg(node)
+      when Sig
+        visit_sig(node)
+      when SigParam
+        visit_sig_param(node)
+      when TStruct
+        visit_tstruct(node)
+      when TStructConst
+        visit_tstruct_const(node)
+      when TStructProp
+        visit_tstruct_prop(node)
+      when TEnum
+        visit_tenum(node)
+      when TEnumBlock
+        visit_tenum_block(node)
+      when Helper
+        visit_helper(node)
+      when TypeMember
+        visit_type_member(node)
+      when MixesInClassMethods
+        visit_mixes_in_class_methods(node)
+      when RequiresAncestor
+        visit_requires_ancestor(node)
+      else
+        raise "Unhandled node: #{node.class}"
+      end
+    end
 
     sig { params(nodes: T::Array[Node]).void }
     def visit_all(nodes)
       nodes.each { |node| visit(node) }
+    end
+
+    sig { params(file: File).void }
+    def visit_file(file)
+      visit(file.root)
+    end
+
+    private
+
+    sig { params(node: Comment).void }
+    def visit_comment(node); end
+
+    sig { params(node: BlankLine).void }
+    def visit_blank_line(node); end
+
+    sig { params(node: Module).void }
+    def visit_module(node); end
+
+    sig { params(node: Class).void }
+    def visit_class(node); end
+
+    sig { params(node: SingletonClass).void }
+    def visit_singleton_class(node); end
+
+    sig { params(node: Struct).void }
+    def visit_struct(node); end
+
+    sig { params(node: Tree).void }
+    def visit_tree(node); end
+
+    sig { params(node: Const).void }
+    def visit_const(node); end
+
+    sig { params(node: AttrAccessor).void }
+    def visit_attr_accessor(node); end
+
+    sig { params(node: AttrReader).void }
+    def visit_attr_reader(node); end
+
+    sig { params(node: AttrWriter).void }
+    def visit_attr_writer(node); end
+
+    sig { params(node: Method).void }
+    def visit_method(node); end
+
+    sig { params(node: ReqParam).void }
+    def visit_req_param(node); end
+
+    sig { params(node: OptParam).void }
+    def visit_opt_param(node); end
+
+    sig { params(node: RestParam).void }
+    def visit_rest_param(node); end
+
+    sig { params(node: KwParam).void }
+    def visit_kw_param(node); end
+
+    sig { params(node: KwOptParam).void }
+    def visit_kw_opt_param(node); end
+
+    sig { params(node: KwRestParam).void }
+    def visit_kw_rest_param(node); end
+
+    sig { params(node: BlockParam).void }
+    def visit_block_param(node); end
+
+    sig { params(node: Include).void }
+    def visit_include(node); end
+
+    sig { params(node: Extend).void }
+    def visit_extend(node); end
+
+    sig { params(node: Public).void }
+    def visit_public(node); end
+
+    sig { params(node: Protected).void }
+    def visit_protected(node); end
+
+    sig { params(node: Private).void }
+    def visit_private(node); end
+
+    sig { params(node: Send).void }
+    def visit_send(node); end
+
+    sig { params(node: Arg).void }
+    def visit_arg(node); end
+
+    sig { params(node: KwArg).void }
+    def visit_kw_arg(node); end
+
+    sig { params(node: Sig).void }
+    def visit_sig(node); end
+
+    sig { params(node: SigParam).void }
+    def visit_sig_param(node); end
+
+    sig { params(node: TStruct).void }
+    def visit_tstruct(node); end
+
+    sig { params(node: TStructConst).void }
+    def visit_tstruct_const(node); end
+
+    sig { params(node: TStructProp).void }
+    def visit_tstruct_prop(node); end
+
+    sig { params(node: TEnum).void }
+    def visit_tenum(node); end
+
+    sig { params(node: TEnumBlock).void }
+    def visit_tenum_block(node); end
+
+    sig { params(node: Helper).void }
+    def visit_helper(node); end
+
+    sig { params(node: TypeMember).void }
+    def visit_type_member(node); end
+
+    sig { params(node: MixesInClassMethods).void }
+    def visit_mixes_in_class_methods(node); end
+
+    sig { params(node: RequiresAncestor).void }
+    def visit_requires_ancestor(node); end
+
+    sig { params(node: Group).void }
+    def visit_group(node); end
+
+    sig { params(node: VisibilityGroup).void }
+    def visit_visibility_group(node); end
+
+    sig { params(node: ConflictTree).void }
+    def visit_conflict_tree(node); end
+
+    sig { params(node: ScopeConflict).void }
+    def visit_scope_conflict(node); end
+  end
+
+  class Node
+    sig { params(visitor: Visitor).void }
+    def accept(visitor)
+      visitor.visit(self)
     end
   end
 end

--- a/sorbet/rbi/gems/tapioca@0.13.3.rbi
+++ b/sorbet/rbi/gems/tapioca@0.13.3.rbi
@@ -54,7 +54,7 @@ module RBI; end
 
 # source://tapioca//lib/tapioca/rbi_ext/model.rb#5
 class RBI::Tree < ::RBI::NodeWithComments
-  # source://rbi/0.1.12/lib/rbi/model.rb#119
+  # source://rbi/0.1.13/lib/rbi/model.rb#119
   sig do
     params(
       loc: T.nilable(::RBI::Loc),
@@ -64,19 +64,15 @@ class RBI::Tree < ::RBI::NodeWithComments
   end
   def initialize(loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
 
-  # source://rbi/0.1.12/lib/rbi/model.rb#126
+  # source://rbi/0.1.13/lib/rbi/model.rb#126
   sig { params(node: ::RBI::Node).void }
   def <<(node); end
 
-  # source://rbi/0.1.12/lib/rbi/printer.rb#226
-  sig { override.params(v: ::RBI::Printer).void }
-  def accept_printer(v); end
-
-  # source://rbi/0.1.12/lib/rbi/rewriters/add_sig_templates.rb#66
+  # source://rbi/0.1.13/lib/rbi/rewriters/add_sig_templates.rb#66
   sig { params(with_todo_comment: T::Boolean).void }
   def add_sig_templates!(with_todo_comment: T.unsafe(nil)); end
 
-  # source://rbi/0.1.12/lib/rbi/rewriters/annotate.rb#49
+  # source://rbi/0.1.13/lib/rbi/rewriters/annotate.rb#49
   sig { params(annotation: ::String, annotate_scopes: T::Boolean, annotate_properties: T::Boolean).void }
   def annotate!(annotation, annotate_scopes: T.unsafe(nil), annotate_properties: T.unsafe(nil)); end
 
@@ -157,27 +153,27 @@ class RBI::Tree < ::RBI::NodeWithComments
   end
   def create_type_variable(name, type:, variance: T.unsafe(nil), fixed: T.unsafe(nil), upper: T.unsafe(nil), lower: T.unsafe(nil)); end
 
-  # source://rbi/0.1.12/lib/rbi/rewriters/deannotate.rb#41
+  # source://rbi/0.1.13/lib/rbi/rewriters/deannotate.rb#41
   sig { params(annotation: ::String).void }
   def deannotate!(annotation); end
 
-  # source://rbi/0.1.12/lib/rbi/model.rb#132
+  # source://rbi/0.1.13/lib/rbi/model.rb#132
   sig { returns(T::Boolean) }
   def empty?; end
 
-  # source://rbi/0.1.12/lib/rbi/rewriters/filter_versions.rb#118
+  # source://rbi/0.1.13/lib/rbi/rewriters/filter_versions.rb#118
   sig { params(version: ::Gem::Version).void }
   def filter_versions!(version); end
 
-  # source://rbi/0.1.12/lib/rbi/rewriters/group_nodes.rb#38
+  # source://rbi/0.1.13/lib/rbi/rewriters/group_nodes.rb#80
   sig { void }
   def group_nodes!; end
 
-  # source://rbi/0.1.12/lib/rbi/index.rb#68
+  # source://rbi/0.1.13/lib/rbi/index.rb#68
   sig { returns(::RBI::Index) }
   def index; end
 
-  # source://rbi/0.1.12/lib/rbi/rewriters/merge_trees.rb#324
+  # source://rbi/0.1.13/lib/rbi/rewriters/merge_trees.rb#324
   sig do
     params(
       other: ::RBI::Tree,
@@ -188,23 +184,19 @@ class RBI::Tree < ::RBI::NodeWithComments
   end
   def merge(other, left_name: T.unsafe(nil), right_name: T.unsafe(nil), keep: T.unsafe(nil)); end
 
-  # source://rbi/0.1.12/lib/rbi/rewriters/nest_non_public_methods.rb#46
+  # source://rbi/0.1.13/lib/rbi/rewriters/nest_non_public_methods.rb#46
   sig { void }
   def nest_non_public_methods!; end
 
-  # source://rbi/0.1.12/lib/rbi/rewriters/nest_singleton_methods.rb#36
+  # source://rbi/0.1.13/lib/rbi/rewriters/nest_singleton_methods.rb#36
   sig { void }
   def nest_singleton_methods!; end
 
-  # source://rbi/0.1.12/lib/rbi/model.rb#110
+  # source://rbi/0.1.13/lib/rbi/model.rb#110
   sig { returns(T::Array[::RBI::Node]) }
   def nodes; end
 
-  # source://rbi/0.1.12/lib/rbi/printer.rb#233
-  sig { override.returns(T::Boolean) }
-  def oneline?; end
-
-  # source://rbi/0.1.12/lib/rbi/rewriters/sort_nodes.rb#119
+  # source://rbi/0.1.13/lib/rbi/rewriters/sort_nodes.rb#119
   sig { void }
   def sort_nodes!; end
 
@@ -3478,20 +3470,23 @@ end
 # source://tapioca//lib/tapioca/version.rb#5
 Tapioca::VERSION = T.let(T.unsafe(nil), String)
 
+# source://tapioca//lib/tapioca/helpers/source_uri.rb#6
+module URI
+  include ::URI::RFC2396_REGEXP
+end
+
 # source://tapioca//lib/tapioca/helpers/source_uri.rb#7
 class URI::Source < ::URI::File
   # source://tapioca//lib/tapioca/helpers/source_uri.rb#58
   sig { params(v: T.nilable(::String)).returns(T::Boolean) }
   def check_host(v); end
 
-  # source://uri/0.13.0/uri/generic.rb#243
   def gem_name; end
 
   # source://tapioca//lib/tapioca/helpers/source_uri.rb#25
   sig { returns(T.nilable(::String)) }
   def gem_version; end
 
-  # source://uri/0.13.0/uri/generic.rb#283
   def line_number; end
 
   # source://tapioca//lib/tapioca/helpers/source_uri.rb#51
@@ -3518,3 +3513,5 @@ end
 
 # source://tapioca//lib/tapioca/helpers/source_uri.rb#10
 URI::Source::COMPONENT = T.let(T.unsafe(nil), Array)
+
+class URI::WSS < ::URI::WS; end


### PR DESCRIPTION
With a simple dispatch visitor, the choice of the correct implementation for each node is done through polymorphism. While generally more elegant, it doesn't allow multiple visitors to co-exists nicely. Using a simple visitor requires "polluting" the nodes with `accept_X_visitor`.

Instead, we should use double dispatch so the complete visit logic is encapsulated into the visitor itself, it can then be inherited and redefined without requiring changes to each node. We can also hoist most of the services the visitor was delegating to the node back into the visitor as private methods and reduce the amount of public methods exposed by each node.

While this PR seems intimidating looking at the diff, it's only moving code around, there is no change in logic.