### PR TITLE
Add more specific error classes

### DIFF
--- a/lib/rbi.rb
+++ b/lib/rbi.rb
@@ -3,6 +3,11 @@
 
 require "sorbet-runtime"
 require "stringio"
+
+module RBI
+  class Error < StandardError; end
+end
+
 require "rbi/loc"
 require "rbi/model"
 require "rbi/visitor"

--- a/lib/rbi/model.rb
+++ b/lib/rbi/model.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 module RBI
+  class ReplaceNodeError < Error; end
+
   class Node
     extend T::Sig
     extend T::Helpers
@@ -32,10 +34,10 @@ module RBI
     sig { params(node: Node).void }
     def replace(node)
       tree = parent_tree
-      raise unless tree
+      raise ReplaceNodeError, "Can't replace #{self} without a parent tree" unless tree
 
       index = tree.nodes.index(self)
-      raise unless index
+      raise ReplaceNodeError, "Can't find #{self} in #{tree} child nodes" unless index
 
       tree.nodes[index] = node
       node.parent_tree = tree

--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -4,7 +4,7 @@
 require "prism"
 
 module RBI
-  class ParseError < StandardError
+  class ParseError < Error
     extend T::Sig
 
     sig { returns(Loc) }
@@ -17,7 +17,7 @@ module RBI
     end
   end
 
-  class UnexpectedParserError < StandardError
+  class UnexpectedParserError < Error
     extend T::Sig
 
     sig { returns(Loc) }

--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 module RBI
+  class PrinterError < Error; end
+
   class Printer < Visitor
     extend T::Sig
 
@@ -187,7 +189,7 @@ module RBI
       when TEnum
         printt("class #{node.name} < T::Enum")
       else
-        raise "Unhandled node: #{node.class}"
+        raise PrinterError, "Unhandled node: #{node.class}"
       end
       if node.empty? && !node.is_a?(Struct)
         print("; end")

--- a/lib/rbi/rewriters/group_nodes.rb
+++ b/lib/rbi/rewriters/group_nodes.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 module RBI
+  class GroupNodesError < Error; end
+
   module Rewriters
     class GroupNodes < Visitor
       extend T::Sig
@@ -66,7 +68,7 @@ module RBI
         when Scope, Const
           Group::Kind::Consts
         else
-          raise "Unknown group for #{self}"
+          raise GroupNodesError, "Unknown group for #{self}"
         end
       end
     end

--- a/lib/rbi/rewriters/merge_trees.rb
+++ b/lib/rbi/rewriters/merge_trees.rb
@@ -348,6 +348,8 @@ module RBI
     end
   end
 
+  class DuplicateNodeError < Error; end
+
   class Scope
     extend T::Sig
 
@@ -364,7 +366,7 @@ module RBI
       when SingletonClass
         SingletonClass.new(loc: loc, comments: comments)
       else
-        raise "Can't duplicate node #{self}"
+        raise DuplicateNodeError, "Can't duplicate node #{self}"
       end
     end
   end

--- a/lib/rbi/visitor.rb
+++ b/lib/rbi/visitor.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 module RBI
+  class VisitorError < Error; end
+
   class Visitor
     extend T::Helpers
     extend T::Sig
@@ -98,7 +100,7 @@ module RBI
       when RequiresAncestor
         visit_requires_ancestor(node)
       else
-        raise "Unhandled node: #{node.class}"
+        raise VisitorError, "Unhandled node: #{node.class}"
       end
     end
 


### PR DESCRIPTION
We shouldn't raise bare errors as it forces the client to rescue `RuntimeErrror`, it's bad practice and bad design.

This PR adds specific error classes that can be rescued more cleanly.

This may be a breaking change since people rescuing `RuntimeError` to catch exceptions raised from `rbi` won't catch anything now since `RBI::Error` is a `StandardError` and will need to update their rescues.