### PR TITLE
Don't use `Minitest::Reporter` for RubyMine

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,4 +8,6 @@ require "minitest/test"
 require "minitest/autorun"
 require "minitest/reporters"
 
-Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new(color: true))
+unless ENV["RM_INFO"]
+  Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new(color: true))
+end


### PR DESCRIPTION
Workaround for [this issue](https://youtrack.jetbrains.com/issue/RUBY-33007/Using-Minitest-should-not-require-changes-to-testhelper.rb).