### PR TITLE
Fix parsing of type members and templates

### DIFF
--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -800,10 +800,7 @@ module RBI
 
       sig { params(node: T.nilable(Prism::Node)).returns(T::Boolean) }
       def type_variable_definition?(node)
-        return false unless node.is_a?(Prism::CallNode)
-        return false unless node.block
-
-        node.message == "type_member" || node.message == "type_template"
+        node.is_a?(Prism::CallNode) && (node.message == "type_member" || node.message == "type_template")
       end
     end
 

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -319,7 +319,7 @@ module RBI
         class Foo
           A = type_member
           B = type_member(:in)
-          C = type_member(:tree)
+          C = type_member(:out) {}
           D = type_member(lower: A)
           E = type_member(upper: A)
           F = type_member(:in, fixed: A)
@@ -329,7 +329,13 @@ module RBI
         end
       RBI
 
-      tree = parse_rbi(rbi)
+      tree = Parser.parse_string(rbi)
+
+      # Make sure the type members and templates are not parsed as constants
+      cls = T.must(tree.nodes.grep(Class).first)
+      assert_equal(0, cls.nodes.grep(Const).size)
+      assert_equal(9, cls.nodes.grep(TypeMember).size)
+
       assert_equal(rbi, tree.string)
     end
 


### PR DESCRIPTION
Type member / template is incorrectly parsed as `Constant` if no block is passed.

While it doesn't change the RBI output as we print both a `Constant` and a `TypeMember` the same way, it is representing the semantics of the RBI incorrectly.

