### PR TITLE
Fix parsing of visibility comments

### DIFF
--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -751,11 +751,11 @@ module RBI
       def parse_visibility(name, node)
         case name
         when "public"
-          Public.new(loc: node_loc(node))
+          Public.new(loc: node_loc(node), comments: node_comments(node))
         when "protected"
-          Protected.new(loc: node_loc(node))
+          Protected.new(loc: node_loc(node), comments: node_comments(node))
         when "private"
-          Private.new(loc: node_loc(node))
+          Private.new(loc: node_loc(node), comments: node_comments(node))
         else
           raise ParseError.new("Unexpected visibility `#{name}`", node_loc(node))
         end

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -198,6 +198,22 @@ module RBI
       assert_equal(rbi, out.string)
     end
 
+    def test_parse_visibility_labels_with_comments
+      rbi = <<~RBI
+        # Public
+        public
+
+        # Protected
+        protected
+
+        # Private
+        private
+      RBI
+
+      out = Parser.parse_string(rbi)
+      assert_equal(rbi, out.string)
+    end
+
     def test_parse_t_struct
       rbi = <<~RBI
         class Foo < ::T::Struct


### PR DESCRIPTION
Comments associated with a visibility call where lost