### PR TITLE
Fix parsing of visibility send

### DIFF
--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -421,6 +421,13 @@ module RBI
             case last_node
             when Method, Attr
               last_node.visibility = parse_visibility(node.name.to_s, node)
+            when Send
+              current_scope << Send.new(
+                message,
+                parse_send_args(node.arguments),
+                loc: node_loc(node),
+                comments: node_comments(node),
+              )
             else
               raise ParseError.new(
                 "Unexpected token `#{node.message}` before `#{last_node&.string&.strip}`",

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -300,6 +300,7 @@ module RBI
         class ActiveRecord::Base
           class_attribute :typed_stores, :store_accessors, instance_accessor: false, default: "Foo"
           foo bar, "bar", :bar
+          private :foo
         end
       RBI
 


### PR DESCRIPTION
Parser was chocking on `private :foo` sends