### PR TITLE
Fix parsing of `T::Enum`

### DIFF
--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -175,12 +175,22 @@ module RBI
       sig { override.params(node: Prism::ClassNode).void }
       def visit_class_node(node)
         @last_node = node
-        scope = Class.new(
-          node_string!(node.constant_path),
-          superclass_name: node_string(node.superclass),
-          loc: node_loc(node),
-          comments: node_comments(node),
-        )
+        superclass_name = node_string(node.superclass)
+        scope = case superclass_name
+        when /^(::)?T::Enum$/
+          TEnum.new(
+            node_string!(node.constant_path),
+            loc: node_loc(node),
+            comments: node_comments(node),
+          )
+        else
+          Class.new(
+            node_string!(node.constant_path),
+            superclass_name: superclass_name,
+            loc: node_loc(node),
+            comments: node_comments(node),
+          )
+        end
 
         current_scope << scope
         @scopes_stack << scope

--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -169,6 +169,8 @@ module RBI
       case node
       when Module
         printt("module #{node.name}")
+      when TEnum
+        printt("class #{node.name} < T::Enum")
       when Class
         printt("class #{node.name}")
         superclass = node.superclass_name
@@ -186,8 +188,6 @@ module RBI
         printt("class << self")
       when TStruct
         printt("class #{node.name} < T::Struct")
-      when TEnum
-        printt("class #{node.name} < T::Enum")
       else
         raise PrinterError, "Unhandled node: #{node.class}"
       end

--- a/lib/rbi/rewriters/merge_trees.rb
+++ b/lib/rbi/rewriters/merge_trees.rb
@@ -359,6 +359,8 @@ module RBI
       case self
       when Module
         Module.new(name, loc: loc, comments: comments)
+      when TEnum
+        TEnum.new(name, loc: loc, comments: comments)
       when Class
         Class.new(name, superclass_name: superclass_name, loc: loc, comments: comments)
       when Struct

--- a/lib/rbi/visitor.rb
+++ b/lib/rbi/visitor.rb
@@ -19,6 +19,8 @@ module RBI
         visit_blank_line(node)
       when Comment
         visit_comment(node)
+      when TEnum
+        visit_tenum(node)
       when Module
         visit_module(node)
       when Class
@@ -87,8 +89,6 @@ module RBI
         visit_tstruct_const(node)
       when TStructProp
         visit_tstruct_prop(node)
-      when TEnum
-        visit_tenum(node)
       when TEnumBlock
         visit_tenum_block(node)
       when Helper

--- a/test/rbi/model_test.rb
+++ b/test/rbi/model_test.rb
@@ -182,7 +182,7 @@ module RBI
           prop :foo, Foo
         end
 
-        class Enum < ::T::Enum
+        class Enum < T::Enum
           # comment
           enums do
             A = new

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -233,8 +233,12 @@ module RBI
         end
       RBI
 
-      out = Parser.parse_string(rbi)
-      assert_equal(rbi, out.string)
+      tree = Parser.parse_string(rbi)
+
+      # Make sure the enums are not parsed as normal classes
+      assert_equal(TEnum, tree.nodes.first.class)
+
+      assert_equal(rbi, tree.string)
     end
 
     def test_parse_t_enums_with_one_value

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -223,7 +223,7 @@ module RBI
 
     def test_parse_t_enums
       rbi = <<~RBI
-        class Foo < ::T::Enum
+        class Foo < T::Enum
           enums do
             A = new
             B = new
@@ -243,7 +243,7 @@ module RBI
 
     def test_parse_t_enums_with_one_value
       rbi = <<~RBI
-        class Foo < ::T::Enum
+        class Foo < T::Enum
           enums do
             A = new
           end
@@ -547,7 +547,7 @@ module RBI
 
     def test_t_enums_locations
       rbi = <<~RBI
-        class Foo < ::T::Enum
+        class Foo < T::Enum
           enums do
             A = new
             B = new
@@ -560,7 +560,7 @@ module RBI
       out = Parser.parse_string(rbi)
       assert_equal(<<~RBI, out.string(print_locs: true))
         # -:1:0-8:3
-        class Foo < ::T::Enum
+        class Foo < T::Enum
           # -:2:2-6:5
           enums do
             A = new

--- a/test/rbi/printer_test.rb
+++ b/test/rbi/printer_test.rb
@@ -300,7 +300,7 @@ module RBI
       rbi << Method.new("baz")
 
       assert_equal(<<~RBI, rbi.string)
-        class Foo < ::T::Enum
+        class Foo < T::Enum
           enums do
             A = new
             B = new
@@ -461,7 +461,7 @@ module RBI
 
         # This is a
         # Multiline Comment
-        class Foo < ::T::Enum
+        class Foo < T::Enum
           # This is a single line comment
           enums do
             A = new
@@ -1096,7 +1096,7 @@ module RBI
         # file.rbi:1:3-2:4
         class << self; end
         # file.rbi:1:3-2:4
-        class TE < ::T::Enum; end
+        class TE < T::Enum; end
         # file.rbi:1:3-2:4
         class TS < ::T::Struct; end
         # file.rbi:1:3-2:4

--- a/test/rbi/rewriters/group_nodes_test.rb
+++ b/test/rbi/rewriters/group_nodes_test.rb
@@ -62,7 +62,7 @@ module RBI
         module S1; end
         class S2; end
         S3 = ::Struct.new
-        class TE < ::T::Enum; end
+        class TE < T::Enum; end
         class TS < ::T::Struct; end
       RBI
     end
@@ -171,7 +171,7 @@ module RBI
         module S1; end
         class S2; end
         S3 = ::Struct.new
-        class TE < ::T::Enum; end
+        class TE < T::Enum; end
         class TS < ::T::Struct; end
       RBI
     end
@@ -292,7 +292,7 @@ module RBI
           module S1; end
           class S2; end
           S3 = ::Struct.new
-          class TE < ::T::Enum; end
+          class TE < T::Enum; end
           class TS < ::T::Struct; end
         end
       RBI
@@ -365,8 +365,8 @@ module RBI
         class S1; end
         module S2; end
         S3 = ::Struct.new
-        class TE1 < ::T::Enum; end
-        class TE2 < ::T::Enum; end
+        class TE1 < T::Enum; end
+        class TE2 < T::Enum; end
         class TS1 < ::T::Struct; end
         class TS2 < ::T::Struct; end
       RBI
@@ -500,8 +500,8 @@ module RBI
           class S1; end
           module S2; end
           S3 = ::Struct.new
-          class TE1 < ::T::Enum; end
-          class TE2 < ::T::Enum; end
+          class TE1 < T::Enum; end
+          class TE2 < T::Enum; end
           class TS1 < ::T::Struct; end
           class TS2 < ::T::Struct; end
         end
@@ -569,14 +569,14 @@ module RBI
             class S1; end
             module S2; end
             S3 = ::Struct.new
-            class TE1 < ::T::Enum; end
-            class TE2 < ::T::Enum; end
+            class TE1 < T::Enum; end
+            class TE2 < T::Enum; end
             class TS1 < ::T::Struct; end
             class TS2 < ::T::Struct; end
           end
 
-          class TE1 < ::T::Enum; end
-          class TE2 < ::T::Enum; end
+          class TE1 < T::Enum; end
+          class TE2 < T::Enum; end
           class TS1 < ::T::Struct; end
           class TS2 < ::T::Struct; end
         end

--- a/test/rbi/rewriters/sort_nodes_test.rb
+++ b/test/rbi/rewriters/sort_nodes_test.rb
@@ -200,10 +200,10 @@ module RBI
       rbi.sort_nodes!
 
       assert_equal(<<~RBI, rbi.string)
-        class A < ::T::Enum; end
-        class B < ::T::Enum; end
-        class C < ::T::Enum; end
-        class D < ::T::Enum; end
+        class A < T::Enum; end
+        class B < T::Enum; end
+        class C < T::Enum; end
+        class D < T::Enum; end
       RBI
     end
 
@@ -246,7 +246,7 @@ module RBI
         def self.m3; end
         A = 42
         module B; end
-        class C < ::T::Enum; end
+        class C < T::Enum; end
         class D < ::T::Struct; end
         class E; end
       RBI
@@ -305,7 +305,7 @@ module RBI
         class << self; end
         A = 42
         module B; end
-        class C < ::T::Enum; end
+        class C < T::Enum; end
         class D < ::T::Struct; end
         class E; end
       RBI


### PR DESCRIPTION
The parser was returning a `Class` node for subclasses of `T::Enum` when we have a more precise type of node with `TEnum`.

This also showed that we were not visiting the `TEnum` properly as we called the visit on it as if a `Class`.

Maybe `T::Enum` shouldn't descend from `Class`?