### PR TITLE
Fix parsing of dangling things

### DIFF
--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -476,7 +476,7 @@ module RBI
 
         last_node_last_line = node.child_nodes.last&.location&.end_line
 
-        last_line.downto(first_line) do |line|
+        first_line.upto(last_line) do |line|
           comment = @comments_by_line[line]
           next unless comment
           break if last_node_last_line && line <= last_node_last_line

--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -185,6 +185,7 @@ module RBI
         current_scope << scope
         @scopes_stack << scope
         visit(node.body)
+        scope.nodes.concat(current_sigs)
         collect_dangling_comments(node)
         @scopes_stack.pop
         @last_node = nil
@@ -269,6 +270,7 @@ module RBI
         current_scope << scope
         @scopes_stack << scope
         visit(node.body)
+        scope.nodes.concat(current_sigs)
         collect_dangling_comments(node)
         @scopes_stack.pop
         @last_node = nil
@@ -278,7 +280,7 @@ module RBI
       def visit_program_node(node)
         @last_node = node
         super
-
+        @tree.nodes.concat(current_sigs)
         collect_orphan_comments
         separate_header_comments
         set_root_tree_loc
@@ -296,6 +298,7 @@ module RBI
         current_scope << scope
         @scopes_stack << scope
         visit(node.body)
+        scope.nodes.concat(current_sigs)
         collect_dangling_comments(node)
         @scopes_stack.pop
         @last_node = nil

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -153,6 +153,36 @@ module RBI
       RBI
     end
 
+    def test_parse_dangling_sigs
+      rbi = <<~RBI
+        class Foo
+          sig { void }
+        end
+
+        module Bar
+          class << self
+            sig { void }
+          end
+          sig { void }
+        end
+        sig { void }
+        sig { returns(A) }
+      RBI
+
+      out = Parser.parse_string(rbi)
+      assert_equal(rbi, out.string)
+    end
+
+    def test_parse_sig_standalone
+      rbi = <<~RBI
+        sig { void }
+        sig { returns(A) }
+      RBI
+
+      out = Parser.parse_string(rbi)
+      assert_equal(rbi, out.string)
+    end
+
     def test_parse_methods_with_visibility
       rbi = <<~RBI
         private def m1; end

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -808,30 +808,21 @@ module RBI
           # B comment
           class B; end
           # A comment 3
+          # A comment 4
         end
       RBI
       out = Parser.parse_string(rbi)
-      assert_equal(<<~RBI, out.string)
-        # A comment 1
-        # A comment 2
-        module A
-          # B comment
-          class B; end
-          # A comment 3
-        end
-      RBI
+      assert_equal(rbi, out.string)
     end
 
     def test_parse_collect_dangling_file_comments
       rbi = <<~RBI
         module A; end
-        # Orphan comment
+        # Orphan comment1
+        # Orphan comment2
       RBI
       out = Parser.parse_string(rbi)
-      assert_equal(<<~RBI, out.string)
-        module A; end
-        # Orphan comment
-      RBI
+      assert_equal(rbi, out.string)
     end
 
     def test_parse_params_comments


### PR DESCRIPTION
Comments dangling from a scope where returned reversed:

```rb
module M
  # comment 1
  # comment 2
end
```

was returning:

```rb
module M
  # comment 2
  # comment 1
end
```

Signatures left dangling at the end of a scope where ignored:

```rb
module M
  sig { void }
end
```

so the RBI built looked like:

```rb
module M
end
```