### PR TITLE
Uniformize variable names in tests

### DIFF
--- a/test/rbi/index_test.rb
+++ b/test/rbi/index_test.rb
@@ -9,13 +9,13 @@ module RBI
     extend T::Sig
 
     def test_index_empty_trees
-      rbi = Tree.new
-      index_string = index_string(rbi.index)
+      tree = Tree.new
+      index_string = index_string(tree.index)
       assert_empty(index_string)
     end
 
     def test_index_scopes_and_consts
-      rbi = parse_rbi(<<~RBI)
+      tree = parse_rbi(<<~RBI)
         class A
           module B
             module ::C; end
@@ -28,7 +28,7 @@ module RBI
         A::B = 10
       RBI
 
-      index_string = index_string(rbi.index)
+      index_string = index_string(tree.index)
       assert_equal(<<~IDX, index_string)
         ::A: -:1:0-5:3, -:7:2-7:16
         ::A::B: -:2:2-4:5, -:10:0-10:9
@@ -39,7 +39,7 @@ module RBI
     end
 
     def test_index_properties
-      rbi = parse_rbi(<<~RBI)
+      tree = parse_rbi(<<~RBI)
         class A
           attr_reader :a, :b
           attr_writer :a, :b
@@ -52,7 +52,7 @@ module RBI
         end
       RBI
 
-      index_string = index_string(rbi.index)
+      index_string = index_string(tree.index)
       assert_equal(<<~IDX, index_string)
         ::A: -:1:0-10:3
         ::A#a: -:2:2-2:20
@@ -71,7 +71,7 @@ module RBI
     end
 
     def test_index_sorbet_constructs
-      rbi = parse_rbi(<<~RBI)
+      tree = parse_rbi(<<~RBI)
         class A < T::Struct
           const :a, Integer
           prop :b, String
@@ -90,7 +90,7 @@ module RBI
         D = type_template
       RBI
 
-      index_string = index_string(rbi.index)
+      index_string = index_string(tree.index)
       assert_equal(<<~IDX, index_string)
         .mixes_in_class_method(A): -:13:0-13:24
         .requires_ancestor(A): -:14:0-14:23

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -16,8 +16,8 @@ module RBI
         class << self; end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(rbi, out.string)
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
     end
 
     def test_parse_nested_scopes
@@ -31,8 +31,8 @@ module RBI
         end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(rbi, out.string)
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
     end
 
     def test_parse_structs
@@ -51,8 +51,8 @@ module RBI
         end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(<<~RBI, out.string)
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string)
         A = ::Struct.new
         B = ::Struct.new(:a, :b)
         C = ::Struct.new(:a, :b)
@@ -84,8 +84,8 @@ module RBI
         A::B::C = Foo
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(rbi, out.string)
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
     end
 
     def test_parse_attributes
@@ -101,8 +101,8 @@ module RBI
         attr_accessor :a, :b, :c
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(rbi, out.string)
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
     end
 
     def test_parse_methods
@@ -112,8 +112,8 @@ module RBI
         def m3(a, b = 42, *c, d:, e: "bar", **f, &g); end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(rbi, out.string)
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
     end
 
     def test_parse_sigs
@@ -135,8 +135,8 @@ module RBI
         def foo; end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(<<~RBI, out.string)
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string)
         sig { void }
         sig(:final) { void }
         sig { returns(String) }
@@ -192,12 +192,8 @@ module RBI
         private attr_reader :a
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(<<~RBI, out.string)
-        private def m1; end
-        protected def self.m2; end
-        private attr_reader :a
-      RBI
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
     end
 
     def test_parse_mixins
@@ -212,8 +208,8 @@ module RBI
         end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(rbi, out.string)
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
     end
 
     def test_parse_visibility_labels
@@ -226,8 +222,8 @@ module RBI
         def m3; end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(rbi, out.string)
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
     end
 
     def test_parse_visibility_labels_with_comments
@@ -257,8 +253,8 @@ module RBI
         end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(<<~RBI, out.string)
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string)
         class Foo < ::T::Struct
           const :a, A
           const :b, B, default: B.new
@@ -299,8 +295,8 @@ module RBI
         end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(rbi, out.string)
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
     end
 
     def test_parse_sorbet_helpers
@@ -314,8 +310,8 @@ module RBI
         end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(rbi, out.string)
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
     end
 
     def test_parse_sorbet_type_members_and_templates
@@ -323,18 +319,18 @@ module RBI
         class Foo
           A = type_member
           B = type_member(:in)
-          C = type_member(:out)
+          C = type_member(:tree)
           D = type_member(lower: A)
           E = type_member(upper: A)
           F = type_member(:in, fixed: A)
           G = type_template
           H = type_template(:in)
-          I = type_template(:out, lower: A)
+          I = type_template(:tree, lower: A)
         end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(rbi, out.string)
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
     end
 
     def test_parse_root_tree_location
@@ -355,8 +351,8 @@ module RBI
         end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(rbi, out.string)
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
     end
 
     def test_parse_scopes_locations
@@ -367,8 +363,8 @@ module RBI
         class << self; end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(<<~RBI, out.string(print_locs: true))
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string(print_locs: true))
         # -:1:0-1:15
         module Foo; end
         # -:2:0-2:14
@@ -391,8 +387,8 @@ module RBI
         end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(<<~RBI, out.string(print_locs: true))
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string(print_locs: true))
         # -:1:0-7:3
         module Foo
           # -:2:2-6:5
@@ -415,8 +411,8 @@ module RBI
         end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(<<~RBI, out.string(print_locs: true))
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string(print_locs: true))
         # -:1:0-4:3
         Foo = ::Struct.new(:a) do
           # -:2:2-2:14
@@ -435,8 +431,8 @@ module RBI
         A::B::C = Foo
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(<<~RBI, out.string(print_locs: true))
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string(print_locs: true))
         # -:1:0-1:8
         Foo = 42
         # -:2:0-2:11
@@ -461,8 +457,8 @@ module RBI
         attr_accessor :a, :b, :c
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(<<~RBI, out.string(print_locs: true))
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string(print_locs: true))
         # -:1:0-1:14
         attr_reader :a
         # -:2:0-2:18
@@ -495,8 +491,8 @@ module RBI
         def m4; end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(<<~RBI, out.string(print_locs: true))
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string(print_locs: true))
         # -:1:0-1:11
         def m1; end
         # -:2:0-2:16
@@ -525,8 +521,8 @@ module RBI
         end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(<<~RBI, out.string(print_locs: true))
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string(print_locs: true))
         # -:1:0-4:3
         class Foo
           # -:2:2-2:11
@@ -547,8 +543,8 @@ module RBI
         def m3; end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(<<~RBI, out.string(print_locs: true))
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string(print_locs: true))
         # -:1:0-1:6
         public
         # -:2:0-2:11
@@ -575,8 +571,8 @@ module RBI
         end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(<<~RBI, out.string(print_locs: true))
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string(print_locs: true))
         # -:1:0-7:3
         class Foo < ::T::Struct
           # -:2:2-2:13
@@ -605,8 +601,8 @@ module RBI
         end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(<<~RBI, out.string(print_locs: true))
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string(print_locs: true))
         # -:1:0-8:3
         class Foo < T::Enum
           # -:2:2-6:5
@@ -632,8 +628,8 @@ module RBI
         end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(<<~RBI, out.string(print_locs: true))
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string(print_locs: true))
         # -:1:0-7:3
         class Foo
           # -:2:2-2:11
@@ -658,8 +654,8 @@ module RBI
         end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(<<~RBI, out.string(print_locs: true))
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string(print_locs: true))
         # -:1:0-4:3
         class Foo
           # -:2:2-2:17
@@ -682,8 +678,8 @@ module RBI
         # Preserving empty lines
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(<<~RBI, out.string)
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string)
         # typed: false
         # frozen_string_literal: true
 
@@ -701,8 +697,9 @@ module RBI
 
         module A; end
       RBI
-      out = parse_rbi(rbi)
-      assert_equal(<<~RBI, out.string)
+
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string)
         # typed: true
 
         module A; end
@@ -716,8 +713,9 @@ module RBI
 
         module A; end
       RBI
-      out = parse_rbi(rbi)
-      assert_equal(<<~RBI, out.string)
+
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string)
         # typed: true
         # frozen_string_literal: true
 
@@ -732,13 +730,9 @@ module RBI
         # A comment
         module A; end
       RBI
-      out = parse_rbi(rbi)
-      assert_equal(<<~RBI, out.string)
-        # typed: true
 
-        # A comment
-        module A; end
-      RBI
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
     end
 
     def test_parse_file_header_and_node_comments
@@ -752,8 +746,9 @@ module RBI
         # for the module
         module A; end
       RBI
-      out = parse_rbi(rbi)
-      assert_equal(<<~RBI, out.string)
+
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string)
         # typed: true
         # frozen_string_literal: true
 
@@ -783,8 +778,8 @@ module RBI
         end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(rbi, out.string)
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
     end
 
     def test_parse_comments_with_sigs
@@ -804,8 +799,8 @@ module RBI
         end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(<<~RBI, out.string)
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string)
         module A
           # foo comment
           sig { void }
@@ -835,8 +830,8 @@ module RBI
         end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(rbi, out.string)
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
     end
 
     def test_parse_struct_comments
@@ -848,8 +843,8 @@ module RBI
         end
       RBI
 
-      out = parse_rbi(rbi)
-      assert_equal(rbi, out.string)
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
     end
 
     def test_parse_collect_dangling_scope_comments
@@ -863,8 +858,9 @@ module RBI
           # A comment 4
         end
       RBI
-      out = Parser.parse_string(rbi)
-      assert_equal(rbi, out.string)
+
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
     end
 
     def test_parse_collect_dangling_file_comments
@@ -873,8 +869,9 @@ module RBI
         # Orphan comment1
         # Orphan comment2
       RBI
-      out = Parser.parse_string(rbi)
-      assert_equal(rbi, out.string)
+
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
     end
 
     def test_parse_params_comments
@@ -890,8 +887,8 @@ module RBI
           e: _
         ); end
       RBI
-      out = parse_rbi(rbi)
-      assert_equal(<<~RBI, out.string)
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string)
         def bar; end
 
         def foo(
@@ -945,10 +942,10 @@ module RBI
     end
 
     def test_parse_strings
-      rbi1 = "class Foo; end"
-      rbi2 = "class Bar; end"
-
-      trees = Parser.parse_strings([rbi1, rbi2])
+      trees = Parser.parse_strings([
+        "class Foo; end",
+        "class Bar; end",
+      ])
 
       assert_equal(<<~RBI, trees.map(&:string).join("\n"))
         class Foo; end

--- a/test/rbi/rewriters/annotate_test.rb
+++ b/test/rbi/rewriters/annotate_test.rb
@@ -8,7 +8,7 @@ module RBI
     include TestHelper
 
     def test_add_annotation_to_root_nodes
-      rbi = parse_rbi(<<~RBI)
+      tree = parse_rbi(<<~RBI)
         module A
           class B
             def m; end
@@ -20,9 +20,9 @@ module RBI
         end
       RBI
 
-      rbi.annotate!("test")
+      tree.annotate!("test")
 
-      assert_equal(<<~RBI, rbi.string)
+      assert_equal(<<~RBI, tree.string)
         # @test
         module A
           class B
@@ -38,7 +38,7 @@ module RBI
     end
 
     def test_add_annotation_to_all_scopes
-      rbi = parse_rbi(<<~RBI)
+      tree = parse_rbi(<<~RBI)
         module A
           FOO = type_member
 
@@ -56,9 +56,9 @@ module RBI
         end
       RBI
 
-      rbi.annotate!("test", annotate_scopes: true)
+      tree.annotate!("test", annotate_scopes: true)
 
-      assert_equal(<<~RBI, rbi.string)
+      assert_equal(<<~RBI, tree.string)
         # @test
         module A
           FOO = type_member
@@ -80,7 +80,7 @@ module RBI
     end
 
     def test_add_annotation_to_all_properties
-      rbi = parse_rbi(<<~RBI)
+      tree = parse_rbi(<<~RBI)
         # Root scope are always annotated
         module A
           FOO = type_member
@@ -100,9 +100,9 @@ module RBI
         end
       RBI
 
-      rbi.annotate!("test", annotate_properties: true)
+      tree.annotate!("test", annotate_properties: true)
 
-      assert_equal(<<~RBI, rbi.string)
+      assert_equal(<<~RBI, tree.string)
         # Root scope are always annotated
         # @test
         module A
@@ -134,7 +134,7 @@ module RBI
     end
 
     def test_add_annotation_to_all_nodes
-      rbi = parse_rbi(<<~RBI)
+      tree = parse_rbi(<<~RBI)
         module A
           FOO = type_member
 
@@ -152,9 +152,9 @@ module RBI
         end
       RBI
 
-      rbi.annotate!("test", annotate_scopes: true, annotate_properties: true)
+      tree.annotate!("test", annotate_scopes: true, annotate_properties: true)
 
-      assert_equal(<<~RBI, rbi.string)
+      assert_equal(<<~RBI, tree.string)
         # @test
         module A
           # @test
@@ -185,7 +185,7 @@ module RBI
     end
 
     def test_does_not_reannotate_already_annotated_nodes
-      rbi = parse_rbi(<<~RBI)
+      tree = parse_rbi(<<~RBI)
         # @test
         module A
           # @test
@@ -196,9 +196,9 @@ module RBI
         end
       RBI
 
-      rbi.annotate!("test", annotate_scopes: true, annotate_properties: true)
+      tree.annotate!("test", annotate_scopes: true, annotate_properties: true)
 
-      assert_equal(<<~RBI, rbi.string)
+      assert_equal(<<~RBI, tree.string)
         # @test
         module A
           # @test
@@ -211,7 +211,7 @@ module RBI
     end
 
     def test_add_different_annotation_to_nodes
-      rbi = parse_rbi(<<~RBI)
+      tree = parse_rbi(<<~RBI)
         # @test
         module A
           # @test
@@ -222,9 +222,9 @@ module RBI
         end
       RBI
 
-      rbi.annotate!("other", annotate_scopes: true, annotate_properties: true)
+      tree.annotate!("other", annotate_scopes: true, annotate_properties: true)
 
-      assert_equal(<<~RBI, rbi.string)
+      assert_equal(<<~RBI, tree.string)
         # @test
         # @other
         module A

--- a/test/rbi/rewriters/attr_to_methods_test.rb
+++ b/test/rbi/rewriters/attr_to_methods_test.rb
@@ -8,15 +8,15 @@ module RBI
     include TestHelper
 
     def test_replaces_attr_reader_with_method
-      rbi = Parser.parse_string(<<~RBI)
+      tree = parse_rbi(<<~RBI)
         # Lorum ipsum...
         sig { returns(Integer) }
         attr_reader :a
       RBI
 
-      rbi.replace_attributes_with_methods!
+      tree.replace_attributes_with_methods!
 
-      assert_equal(<<~RBI, rbi.string)
+      assert_equal(<<~RBI, tree.string)
         # Lorum ipsum...
         sig { returns(Integer) }
         def a; end
@@ -24,15 +24,15 @@ module RBI
     end
 
     def test_replaces_attr_writer_with_setter_method
-      rbi = Parser.parse_string(<<~RBI)
+      tree = parse_rbi(<<~RBI)
         # Lorum ipsum...
         sig { params(a: Integer).void }
         attr_writer :a
       RBI
 
-      rbi.replace_attributes_with_methods!
+      tree.replace_attributes_with_methods!
 
-      assert_equal(<<~RBI, rbi.string)
+      assert_equal(<<~RBI, tree.string)
         # Lorum ipsum...
         sig { params(a: Integer).void }
         def a=(a); end
@@ -43,15 +43,15 @@ module RBI
       # Sorbet allows either `.void` or `.returns(TheType)`.
       # We'll support both, until Sorbet starts to prefer one or the other.
 
-      rbi = Parser.parse_string(<<~RBI)
+      tree = parse_rbi(<<~RBI)
         # Lorum ipsum...
         sig { params(a: Integer).returns(Integer) }
         attr_writer :a
       RBI
 
-      rbi.replace_attributes_with_methods!
+      tree.replace_attributes_with_methods!
 
-      assert_equal(<<~RBI, rbi.string)
+      assert_equal(<<~RBI, tree.string)
         # Lorum ipsum...
         sig { params(a: Integer).void }
         def a=(a); end
@@ -59,15 +59,15 @@ module RBI
     end
 
     def test_replaces_attr_accessor_with_getter_and_setter_methods
-      rbi = Parser.parse_string(<<~RBI)
+      tree = parse_rbi(<<~RBI)
         # Lorum ipsum...
         sig { returns(Integer) }
         attr_accessor :a
       RBI
 
-      rbi.replace_attributes_with_methods!
+      tree.replace_attributes_with_methods!
 
-      assert_equal(<<~RBI, rbi.string)
+      assert_equal(<<~RBI, tree.string)
         # Lorum ipsum...
         sig { returns(Integer) }
         def a; end
@@ -81,15 +81,15 @@ module RBI
     ### Testing for multiple attributes defined in a single declaration
 
     def test_replaces_multi_attr_reader_with_methods
-      rbi = Parser.parse_string(<<~RBI)
+      tree = parse_rbi(<<~RBI)
         # Lorum ipsum...
         sig { returns(Integer) }
         attr_reader :a, :b, :c
       RBI
 
-      rbi.replace_attributes_with_methods!
+      tree.replace_attributes_with_methods!
 
-      assert_equal(<<~RBI, rbi.string)
+      assert_equal(<<~RBI, tree.string)
         # Lorum ipsum...
         sig { returns(Integer) }
         def a; end
@@ -105,15 +105,15 @@ module RBI
     end
 
     def test_replaces_multi_attr_writer_with_methods
-      rbi = Parser.parse_string(<<~RBI)
+      tree = parse_rbi(<<~RBI)
         # Lorum ipsum...
         sig { params(a: Integer).void }
         attr_writer :a, :b, :c
       RBI
 
-      rbi.replace_attributes_with_methods!
+      tree.replace_attributes_with_methods!
 
-      assert_equal(<<~RBI, rbi.string)
+      assert_equal(<<~RBI, tree.string)
         # Lorum ipsum...
         sig { params(a: Integer).void }
         def a=(a); end
@@ -129,15 +129,15 @@ module RBI
     end
 
     def test_replaces_multi_attr_accessor_with_methods
-      rbi = Parser.parse_string(<<~RBI)
+      tree = parse_rbi(<<~RBI)
         # Lorum ipsum...
         sig { returns(Integer) }
         attr_accessor :a, :b, :c
       RBI
 
-      rbi.replace_attributes_with_methods!
+      tree.replace_attributes_with_methods!
 
-      assert_equal(<<~RBI, rbi.string)
+      assert_equal(<<~RBI, tree.string)
         # Lorum ipsum...
         sig { returns(Integer) }
         def a; end
@@ -169,7 +169,7 @@ module RBI
     # they have always have a method body, and so they could never be abstract.
 
     def test_replacing_attr_reader_copies_sig_modifiers
-      rbi = Parser.parse_string(<<~RBI)
+      tree = parse_rbi(<<~RBI)
         class GrandParent
           sig { overridable.returns(Integer) }
           attr_reader :a
@@ -186,9 +186,9 @@ module RBI
         end
       RBI
 
-      rbi.replace_attributes_with_methods!
+      tree.replace_attributes_with_methods!
 
-      assert_equal(<<~RBI, rbi.string)
+      assert_equal(<<~RBI, tree.string)
         class GrandParent
           sig { overridable.returns(Integer) }
           def a; end
@@ -207,7 +207,7 @@ module RBI
     end
 
     def test_replacing_attr_writer_copies_sig_modifiers
-      rbi = Parser.parse_string(<<~RBI)
+      tree = parse_rbi(<<~RBI)
         class GrandParent
           sig { overridable.params(a: Integer).void }
           attr_writer :a
@@ -224,9 +224,9 @@ module RBI
         end
       RBI
 
-      rbi.replace_attributes_with_methods!
+      tree.replace_attributes_with_methods!
 
-      assert_equal(<<~RBI, rbi.string)
+      assert_equal(<<~RBI, tree.string)
         class GrandParent
           sig { overridable.params(a: Integer).void }
           def a=(a); end
@@ -245,7 +245,7 @@ module RBI
     end
 
     def test_replacing_attr_accessor_copies_sig_modifiers
-      rbi = Parser.parse_string(<<~RBI)
+      tree = parse_rbi(<<~RBI)
         class GrandParent
           sig { overridable.returns(Integer) }
           attr_accessor :a
@@ -262,9 +262,9 @@ module RBI
         end
       RBI
 
-      rbi.replace_attributes_with_methods!
+      tree.replace_attributes_with_methods!
 
-      assert_equal(<<~RBI, rbi.string)
+      assert_equal(<<~RBI, tree.string)
         class GrandParent
           sig { overridable.returns(Integer) }
           def a; end
@@ -292,13 +292,13 @@ module RBI
     end
 
     def test_raise_on_multiple_sigs
-      rbi = Parser.parse_string(<<~RBI)
+      tree = parse_rbi(<<~RBI)
         sig { returns(Integer) }
         sig { returns(String) }
         attr_accessor :a
       RBI
 
-      e = assert_raises(RBI::UnexpectedMultipleSigsError) { rbi.replace_attributes_with_methods! }
+      e = assert_raises(RBI::UnexpectedMultipleSigsError) { tree.replace_attributes_with_methods! }
 
       assert_equal(["Integer", "String"], e.node.sigs.map(&:return_type))
       # This is just to test the message rendering. Please don't depend on the exact message content.

--- a/test/rbi/rewriters/deannotate_test.rb
+++ b/test/rbi/rewriters/deannotate_test.rb
@@ -8,7 +8,7 @@ module RBI
     include TestHelper
 
     def test_deannotate_nodes
-      rbi = parse_rbi(<<~RBI)
+      tree = parse_rbi(<<~RBI)
         # @test
         module A
           # @test
@@ -37,9 +37,9 @@ module RBI
         end
       RBI
 
-      rbi.deannotate!("test")
+      tree.deannotate!("test")
 
-      assert_equal(<<~RBI, rbi.string)
+      assert_equal(<<~RBI, tree.string)
         module A
           FOO = type_member
 
@@ -58,7 +58,7 @@ module RBI
     end
 
     def test_deannotate_only_removes_the_matching_annotation
-      rbi = parse_rbi(<<~RBI)
+      tree = parse_rbi(<<~RBI)
         # @test
         # @other
         module A
@@ -72,9 +72,9 @@ module RBI
         end
       RBI
 
-      rbi.deannotate!("other")
+      tree.deannotate!("other")
 
-      assert_equal(<<~RBI, rbi.string)
+      assert_equal(<<~RBI, tree.string)
         # @test
         module A
           # @test

--- a/test/rbi/rewriters/filter_versions_test.rb
+++ b/test/rbi/rewriters/filter_versions_test.rb
@@ -16,13 +16,13 @@ module RBI
       RBI
 
       tree = parse_rbi(rbi)
-
       Rewriters::FilterVersions.filter(tree, Gem::Version.new("0.4.0"))
+
       assert_equal(rbi, tree.string)
     end
 
     def test_filter_versions_less_than
-      rbi = <<~RBI
+      tree = parse_rbi(<<~RBI)
         # @version < 1.0.0
         class Foo; end
 
@@ -36,9 +36,8 @@ module RBI
         class Buzz; end
       RBI
 
-      tree = parse_rbi(rbi)
-
       tree.filter_versions!(Gem::Version.new("0.4.0"))
+
       assert_equal(<<~RBI, tree.string)
         # @version < 1.0.0
         class Foo; end
@@ -46,7 +45,7 @@ module RBI
     end
 
     def test_filter_versions_greater_than
-      rbi = <<~RBI
+      tree = parse_rbi(<<~RBI)
         # @version > 1.0.0
         class Foo; end
 
@@ -60,9 +59,8 @@ module RBI
         class Buzz; end
       RBI
 
-      tree = parse_rbi(rbi)
-
       tree.filter_versions!(Gem::Version.new("0.4.0"))
+
       assert_equal(<<~RBI, tree.string)
         # @version > 0.4.0-prerelease
         class Bar; end
@@ -73,7 +71,7 @@ module RBI
     end
 
     def test_filter_versions_equals
-      rbi = <<~RBI
+      tree = parse_rbi(<<~RBI)
         # @version = 1.0.0
         class Foo; end
 
@@ -87,9 +85,8 @@ module RBI
         class Buzz; end
       RBI
 
-      tree = parse_rbi(rbi)
-
       tree.filter_versions!(Gem::Version.new("0.4.0"))
+
       assert_equal(<<~RBI, tree.string)
         # @version = 0.4.0
         class Baz; end
@@ -97,7 +94,7 @@ module RBI
     end
 
     def test_filter_versions_not_equal
-      rbi = <<~RBI
+      tree = parse_rbi(<<~RBI)
         # @version != 1.0.0
         class Foo; end
 
@@ -111,9 +108,8 @@ module RBI
         class Buzz; end
       RBI
 
-      tree = parse_rbi(rbi)
-
       tree.filter_versions!(Gem::Version.new("0.4.0"))
+
       assert_equal(<<~RBI, tree.string)
         # @version != 1.0.0
         class Foo; end
@@ -127,7 +123,7 @@ module RBI
     end
 
     def test_filter_versions_twiddle_wakka
-      rbi = <<~RBI
+      tree = parse_rbi(<<~RBI)
         # @version ~> 1.1.0
         class Foo; end
 
@@ -138,9 +134,8 @@ module RBI
         class Baz; end
       RBI
 
-      tree = parse_rbi(rbi)
-
       tree.filter_versions!(Gem::Version.new("1.1.5"))
+
       assert_equal(<<~RBI, tree.string)
         # @version ~> 1.1.0
         class Foo; end
@@ -148,7 +143,7 @@ module RBI
     end
 
     def test_filter_versions_greater_than_or_equals
-      rbi = <<~RBI
+      tree = parse_rbi(<<~RBI)
         # @version >= 1.0.0
         class Foo; end
 
@@ -162,9 +157,8 @@ module RBI
         class Buzz; end
       RBI
 
-      tree = parse_rbi(rbi)
-
       tree.filter_versions!(Gem::Version.new("0.4.0"))
+
       assert_equal(<<~RBI, tree.string)
         # @version >= 0.4.0-prerelease
         class Bar; end
@@ -178,7 +172,7 @@ module RBI
     end
 
     def test_filter_versions_less_than_or_equals
-      rbi = <<~RBI
+      tree = parse_rbi(<<~RBI)
         # @version <= 1.0.0
         class Foo; end
 
@@ -192,9 +186,8 @@ module RBI
         class Buzz; end
       RBI
 
-      tree = parse_rbi(rbi)
-
       tree.filter_versions!(Gem::Version.new("0.4.0"))
+
       assert_equal(<<~RBI, tree.string)
         # @version <= 1.0.0
         class Foo; end
@@ -205,7 +198,7 @@ module RBI
     end
 
     def test_filter_versions_prerelease
-      rbi = <<~RBI
+      tree = parse_rbi(<<~RBI)
         # @version <= 1.0.0
         class Foo; end
 
@@ -219,9 +212,8 @@ module RBI
         class Buzz; end
       RBI
 
-      tree = parse_rbi(rbi)
-
       tree.filter_versions!(Gem::Version.new("0.4.0-prerelease"))
+
       assert_equal(<<~RBI, tree.string)
         # @version <= 1.0.0
         class Foo; end
@@ -235,7 +227,7 @@ module RBI
     end
 
     def test_filter_versions_and
-      rbi = <<~RBI
+      tree = parse_rbi(<<~RBI)
         # @version > 0.3.0, < 1.0.0
         class Foo; end
 
@@ -246,9 +238,8 @@ module RBI
         class Baz; end
       RBI
 
-      tree = parse_rbi(rbi)
-
       tree.filter_versions!(Gem::Version.new("0.4.0"))
+
       assert_equal(<<~RBI, tree.string)
         # @version > 0.3.0, < 1.0.0
         class Foo; end
@@ -259,7 +250,7 @@ module RBI
     end
 
     def test_filter_versions_or
-      rbi = <<~RBI
+      tree = parse_rbi(<<~RBI)
         # @version < 0.3.0
         # @version > 1.0.0
         class Foo; end
@@ -274,9 +265,8 @@ module RBI
         class Baz; end
       RBI
 
-      tree = parse_rbi(rbi)
-
       tree.filter_versions!(Gem::Version.new("0.4.0"))
+
       assert_equal(<<~RBI, tree.string)
         # @version = 0.4.0
         # @version > 0.5.0
@@ -285,7 +275,7 @@ module RBI
     end
 
     def test_filter_versions_andor
-      rbi = <<~RBI
+      tree = parse_rbi(<<~RBI)
         # @version > 0.3.0, < 1.0.0
         # @version > 1.5.0
         class Foo; end
@@ -299,9 +289,8 @@ module RBI
         class Baz; end
       RBI
 
-      tree = parse_rbi(rbi)
-
       tree.filter_versions!(Gem::Version.new("0.4.0"))
+
       assert_equal(<<~RBI, tree.string)
         # @version > 0.3.0, < 1.0.0
         # @version > 1.5.0
@@ -314,12 +303,10 @@ module RBI
     end
 
     def test_filter_versions_parse_errors
-      rbi = <<~RBI
+      tree = parse_rbi(<<~RBI)
         # @version >
         class Foo; end
       RBI
-
-      tree = parse_rbi(rbi)
 
       assert_raises(Gem::Requirement::BadRequirementError) do
         tree.filter_versions!(Gem::Version.new("0.4.0"))

--- a/test/rbi/rewriters/merge_trees_test.rb
+++ b/test/rbi/rewriters/merge_trees_test.rb
@@ -8,50 +8,50 @@ module RBI
     include TestHelper
 
     def test_merge_empty_trees
-      rbi1 = Tree.new
-      rbi2 = Tree.new
-      res = rbi1.merge(rbi2)
+      tree1 = Tree.new
+      tree2 = Tree.new
+      res = tree1.merge(tree2)
       assert_equal("", res.string)
     end
 
     def test_merge_empty_tree_into_tree
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         class Foo; end
       RBI
 
-      rbi2 = Tree.new
+      tree2 = Tree.new
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         class Foo; end
       RBI
     end
 
     def test_merge_tree_into_empty_tree
-      rbi1 = Tree.new
+      tree1 = Tree.new
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         class Foo; end
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         class Foo; end
       RBI
     end
 
     def test_merge_scopes_together
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         class A; end
         class B; end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         class C; end
         class D; end
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         class A; end
         class B; end
@@ -61,19 +61,19 @@ module RBI
     end
 
     def test_merge_nested_scopes_together
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         class A
           class B; end
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         class C
           class D; end
         end
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         class A
           class B; end
@@ -86,20 +86,20 @@ module RBI
     end
 
     def test_merge_same_scopes_together
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         class A
           class B; end
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         class A
           class B; end
           class C; end
         end
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         class A
           class B; end
@@ -109,14 +109,14 @@ module RBI
     end
 
     def test_merge_constants_together
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         class A
           A = 42
         end
         B = 42
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         class A
           A = 42
           B = 42
@@ -124,7 +124,7 @@ module RBI
         B = 42
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         class A
           A = 42
@@ -136,7 +136,7 @@ module RBI
     end
 
     def test_merge_attributes_together
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         class A
           attr_reader :a
           attr_writer :a
@@ -146,7 +146,7 @@ module RBI
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         class A
           attr_reader :a
           attr_writer :a
@@ -156,7 +156,7 @@ module RBI
         end
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         class A
           attr_reader :a
@@ -170,7 +170,7 @@ module RBI
     end
 
     def test_merge_methods_together
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         class A
           def a; end
           def b; end
@@ -180,7 +180,7 @@ module RBI
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         class A
           def a; end
           def b; end
@@ -190,7 +190,7 @@ module RBI
         end
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         class A
           def a; end
@@ -204,7 +204,7 @@ module RBI
     end
 
     def test_merge_mixins_together
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         class A
           include A
           extend B
@@ -214,7 +214,7 @@ module RBI
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         class A
           include A
           extend B
@@ -224,7 +224,7 @@ module RBI
         end
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         class A
           include A
@@ -238,21 +238,21 @@ module RBI
     end
 
     def test_merge_helpers_together
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         class A
           abstract!
           interface!
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         class A
           interface!
           sealed!
         end
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         class A
           abstract!
@@ -263,21 +263,21 @@ module RBI
     end
 
     def test_merge_sends_together
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         class A
           foo :bar, :baz
           bar
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         class A
           foo :bar, :baz
           baz
         end
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         class A
           foo :bar, :baz
@@ -288,14 +288,14 @@ module RBI
     end
 
     def test_merge_type_members_together
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         class A
           Foo = type_member {{ fixed: Integer }}
           Bar = type_template {{ upper: String }}
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         class A
           Foo = type_member {
             { fixed: Integer }
@@ -307,7 +307,7 @@ module RBI
         end
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         class A
           Foo = type_member {{ fixed: Integer }}
@@ -316,7 +316,7 @@ module RBI
         end
       RBI
 
-      res = rbi2.merge(rbi1)
+      res = tree2.merge(tree1)
       assert_equal(<<~RBI, res.string)
         class A
           Foo = type_member {
@@ -331,21 +331,21 @@ module RBI
     end
 
     def test_merge_structs_together
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         class A < T::Struct
           prop :a, Integer
           const :b, Integer
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         class A < T::Struct
           const :b, Integer
           prop :c, Integer
         end
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         class A < T::Struct
           prop :a, Integer
@@ -356,7 +356,7 @@ module RBI
     end
 
     def test_merge_enums_together
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         class A < T::Enum
           enums do
             A = new
@@ -365,7 +365,7 @@ module RBI
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         class A < T::Enum
           enums do
             B = new
@@ -374,7 +374,7 @@ module RBI
         end
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         class A < T::Enum
           enums do
@@ -387,7 +387,7 @@ module RBI
     end
 
     def test_merge_signatures
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         class A
           def m1; end
 
@@ -407,7 +407,7 @@ module RBI
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         class A
           sig { returns(Integer) }
           def m1; end
@@ -427,7 +427,7 @@ module RBI
         end
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         class A
           sig { returns(Integer) }
@@ -452,7 +452,7 @@ module RBI
     end
 
     def test_merge_comments
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         # Comment A1
         class A
           # Comment a1
@@ -462,7 +462,7 @@ module RBI
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         # Comment A1
         # Comment A2
         # Comment A3
@@ -475,7 +475,7 @@ module RBI
         end
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         # Comment A1
         # Comment A2
@@ -493,19 +493,19 @@ module RBI
     end
 
     def test_merge_tree_comments_together
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         # typed: true
 
         # Some comments
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         # typed: true
 
         # Other comments
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         # typed: true
 
@@ -515,7 +515,7 @@ module RBI
     end
 
     def test_merge_create_conflict_tree_for_scopes
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         class Foo
           A = 10
         end
@@ -529,7 +529,7 @@ module RBI
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         module Foo
           A = 10
         end
@@ -543,7 +543,7 @@ module RBI
         end
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         <<<<<<< left
         class Foo
@@ -572,7 +572,7 @@ module RBI
     end
 
     def test_merge_create_conflict_tree_for_structs
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         A = Struct.new(:a) do
           def m; end
         end
@@ -584,7 +584,7 @@ module RBI
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         A = Struct.new(:a) do
           def m1; end
         end
@@ -598,7 +598,7 @@ module RBI
         end
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         A = ::Struct.new(:a) do
           def m; end
@@ -624,21 +624,21 @@ module RBI
     end
 
     def test_merge_create_conflict_tree_for_constants
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         class Foo
           A = 10
         end
         B = 10
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         class Foo
           A = 42
         end
         B = 42
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         class Foo
           <<<<<<< left
@@ -656,7 +656,7 @@ module RBI
     end
 
     def test_merge_create_conflict_tree_constants_and_scopes
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         class A; end
         module B; end
         module C; end
@@ -666,7 +666,7 @@ module RBI
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         module A; end
         class B; end
         C = 42
@@ -674,7 +674,7 @@ module RBI
         module E::F; end
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         <<<<<<< left
         class A; end
@@ -704,7 +704,7 @@ module RBI
     end
 
     def test_merge_create_conflict_tree_for_attributes
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         class Foo
           attr_accessor :a
           attr_accessor :b
@@ -712,7 +712,7 @@ module RBI
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         class Foo
           attr_reader :a
           attr_writer :b
@@ -721,7 +721,7 @@ module RBI
         end
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         class Foo
           <<<<<<< left
@@ -739,7 +739,7 @@ module RBI
     end
 
     def test_merge_create_conflict_tree_for_methods
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         class Foo
           def m1; end
           def m2(a); end
@@ -752,7 +752,7 @@ module RBI
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         class Foo
           def m1(a); end
           def m2; end
@@ -765,7 +765,7 @@ module RBI
         end
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         class Foo
           <<<<<<< left
@@ -789,7 +789,7 @@ module RBI
         end
       RBI
 
-      res = rbi2.merge(rbi1)
+      res = tree2.merge(tree1)
       assert_equal(<<~RBI, res.string)
         class Foo
           <<<<<<< left
@@ -815,7 +815,7 @@ module RBI
     end
 
     def test_merge_create_conflict_tree_for_mixins
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         class A
           include A, B
           extend A, B
@@ -823,7 +823,7 @@ module RBI
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         class A
           include B
           extend B
@@ -831,7 +831,7 @@ module RBI
         end
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         class A
           <<<<<<< left
@@ -848,7 +848,7 @@ module RBI
     end
 
     def test_merge_create_conflict_tree_for_sends
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         class A
           foo A
           bar :bar
@@ -856,7 +856,7 @@ module RBI
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         class A
           foo B
           bar "bar"
@@ -864,7 +864,7 @@ module RBI
         end
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         class A
           <<<<<<< left
@@ -881,7 +881,7 @@ module RBI
     end
 
     def test_merge_create_conflict_tree_for_tstructs
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         class A < T::Struct
           prop :a, Integer
           const :b, Integer
@@ -890,7 +890,7 @@ module RBI
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         class A < T::Struct
           const :a, Integer
           prop :b, Integer
@@ -899,7 +899,7 @@ module RBI
         end
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         class A < T::Struct
           <<<<<<< left
@@ -918,7 +918,7 @@ module RBI
     end
 
     def test_merge_create_conflict_tree_for_signatures
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         class Foo
           sig { returns(Integer) }
           attr_reader :a
@@ -934,7 +934,7 @@ module RBI
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         class Foo
           sig { returns(String) }
           attr_reader :a
@@ -950,7 +950,7 @@ module RBI
         end
       RBI
 
-      res = rbi1.merge(rbi2)
+      res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         class Foo
           <<<<<<< left
@@ -983,21 +983,21 @@ module RBI
     end
 
     def test_merge_return_the_list_of_conflicts
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         class Foo
           A = 10
         end
         B = 10
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         module Foo
           A = 42
         end
         B = 42
       RBI
 
-      merged_tree = rbi1.merge(rbi2)
+      merged_tree = tree1.merge(tree2)
 
       assert_equal(<<~STR.strip, merged_tree.conflicts.join("\n"))
         Conflicting definitions for `::Foo`
@@ -1007,7 +1007,7 @@ module RBI
     end
 
     def test_merge_keep_left
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         module Foo
           A = 10
 
@@ -1022,7 +1022,7 @@ module RBI
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         module Foo
           A = 42
 
@@ -1037,7 +1037,7 @@ module RBI
         end
       RBI
 
-      res = rbi1.merge(rbi2, keep: Rewriters::Merge::Keep::LEFT)
+      res = tree1.merge(tree2, keep: Rewriters::Merge::Keep::LEFT)
 
       assert_equal(<<~RBI, res.string)
         module Foo
@@ -1057,7 +1057,7 @@ module RBI
     end
 
     def test_merge_keep_right
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         module Foo
           A = 10
 
@@ -1072,7 +1072,7 @@ module RBI
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         module Foo
           A = 42
 
@@ -1087,7 +1087,7 @@ module RBI
         end
       RBI
 
-      res = rbi1.merge(rbi2, keep: Rewriters::Merge::Keep::RIGHT)
+      res = tree1.merge(tree2, keep: Rewriters::Merge::Keep::RIGHT)
 
       assert_equal(<<~RBI, res.string)
         module Foo
@@ -1107,7 +1107,7 @@ module RBI
     end
 
     def test_merge_trees_with_singleton_classes
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         module Foo
           class << self
             def m1; end
@@ -1118,7 +1118,7 @@ module RBI
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         module Foo
           def self.m1(x); end
 
@@ -1127,7 +1127,7 @@ module RBI
         end
       RBI
 
-      res = rbi1.merge(rbi2, keep: Rewriters::Merge::Keep::RIGHT)
+      res = tree1.merge(tree2, keep: Rewriters::Merge::Keep::RIGHT)
 
       assert_equal(<<~RBI, res.string)
         module Foo
@@ -1142,7 +1142,7 @@ module RBI
     end
 
     def test_merge_trees_with_singleton_classes_with_scope
-      rbi1 = parse_rbi(<<~RBI)
+      tree1 = parse_rbi(<<~RBI)
         module Foo
           def self.m1(x); end
 
@@ -1151,7 +1151,7 @@ module RBI
         end
       RBI
 
-      rbi2 = parse_rbi(<<~RBI)
+      tree2 = parse_rbi(<<~RBI)
         module Foo
           class << self
             def m1; end
@@ -1162,7 +1162,7 @@ module RBI
         end
       RBI
 
-      res = rbi1.merge(rbi2, keep: Rewriters::Merge::Keep::RIGHT)
+      res = tree1.merge(tree2, keep: Rewriters::Merge::Keep::RIGHT)
 
       assert_equal(<<~RBI, res.string)
         module Foo


### PR DESCRIPTION
Always use the same variable names when it make sense.

```rb
tree = parse_rbi("RBI input")
assert_equal("expected RBI output", tree.string)
```

when we need the original RBI input around:

```rb
rbi = "RBI input"
tree = parse_rbi(rbi)
assert_equal(rbi, tree.string)
```