### PR TITLE
Fix parsing of comments on signatures

### DIFF
--- a/lib/rbi/model.rb
+++ b/lib/rbi/model.rb
@@ -1101,7 +1101,7 @@ module RBI
 
   # Sorbet's sigs
 
-  class Sig < Node
+  class Sig < NodeWithComments
     extend T::Sig
 
     sig { returns(T::Array[SigParam]) }
@@ -1130,6 +1130,7 @@ module RBI
         type_params: T::Array[String],
         checked: T.nilable(Symbol),
         loc: T.nilable(Loc),
+        comments: T::Array[Comment],
         block: T.nilable(T.proc.params(node: Sig).void),
       ).void
     end
@@ -1143,9 +1144,10 @@ module RBI
       type_params: [],
       checked: nil,
       loc: nil,
+      comments: [],
       &block
     )
-      super(loc: loc)
+      super(loc: loc, comments: comments)
       @params = params
       @return_type = return_type
       @is_abstract = is_abstract

--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -426,6 +426,7 @@ module RBI
     sig { override.params(node: Sig).void }
     def visit_sig(node)
       print_loc(node)
+      visit_all(node.comments)
 
       max_line_length = self.max_line_length
       if oneline?(node) && max_line_length.nil?

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -185,6 +185,19 @@ module RBI
       assert_equal(rbi, out.string)
     end
 
+    def test_parse_sig_comments
+      rbi = <<~RBI
+        # Sig comment
+        sig { void }
+        # Multi line
+        # sig comment
+        sig { void }
+      RBI
+
+      out = Parser.parse_string(rbi)
+      assert_equal(rbi, out.string)
+    end
+
     def test_parse_methods_with_visibility
       rbi = <<~RBI
         private def m1; end


### PR DESCRIPTION
Before this change comments put on a signature were lost:

```rb
# Some comment
sig { void }
```

This PR makes `Sig` a `NodeWithComment` so it can have a sig.

When the sig is actually attached to a method like this:

```rb
# Some comment
sig { void }
def foo; end
```

The parser will move the comment from the signature to the method so it's available through `Method#comments`.

This simplifies a lot how we handle comments and signatures in the parser and doesn't change the current behavior.