### PR TITLE
Bump tapioca version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,5 @@ group(:development, :test) do
   gem("rubocop-shopify", require: false)
   gem("rubocop-sorbet", require: false)
   gem("sorbet", ">= 0.5.9204", require: false)
-  gem("tapioca", github: "Shopify/tapioca", branch: "at-bump-rbi", require: false)
+  gem("tapioca", require: false)
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,3 @@
-GIT
-  remote: https://github.com/Shopify/tapioca.git
-  revision: 497f35d4e0bbb48e3945eb431175ae15e8b67889
-  branch: at-bump-rbi
-  specs:
-    tapioca (0.15.1)
-      bundler (>= 2.2.25)
-      netrc (>= 0.11.0)
-      parallel (>= 1.21.0)
-      rbi (>= 0.1.4)
-      sorbet-static-and-runtime (>= 0.5.11087)
-      spoom (>= 1.2.0)
-      thor (>= 1.2.0)
-      yard-sorbet
-
 PATH
   remote: .
   specs:
@@ -80,6 +65,15 @@ GEM
       sorbet-static-and-runtime (>= 0.5.10187)
       thor (>= 0.19.2)
     strscan (3.1.0)
+    tapioca (0.16.2)
+      bundler (>= 2.2.25)
+      netrc (>= 0.11.0)
+      parallel (>= 1.21.0)
+      rbi (~> 0.2)
+      sorbet-static-and-runtime (>= 0.5.11087)
+      spoom (>= 1.2.0)
+      thor (>= 1.2.0)
+      yard-sorbet
     thor (1.3.1)
     unicode-display_width (2.5.0)
     yard (0.9.36)
@@ -103,7 +97,7 @@ DEPENDENCIES
   rubocop-shopify
   rubocop-sorbet
   sorbet (>= 0.5.9204)
-  tapioca!
+  tapioca
 
 BUNDLED WITH
    2.4.22


### PR DESCRIPTION
Undoing https://github.com/Shopify/rbi/commit/ef626482780a0269481f898ccee9e5f5caf17245 now that we bumped Tapioca version.