### PR TITLE
Do not rely on return type for `attr_writer` RBS signatures

### DIFF
--- a/lib/rbi/rbs_printer.rb
+++ b/lib/rbi/rbs_printer.rb
@@ -262,8 +262,8 @@ module RBI
         print(" #{name}")
         first_sig, *_rest = node.sigs # discard remaining signatures
         if first_sig
-          type = parse_type(first_sig.return_type)
-          print(": #{type.rbs_string}")
+          print(": ")
+          print_attr_sig(node, first_sig)
         else
           print(": untyped")
         end
@@ -273,7 +273,18 @@ module RBI
 
     sig { params(node: RBI::Attr, sig: Sig).void }
     def print_attr_sig(node, sig)
-      type = parse_type(sig.return_type)
+      type = case node
+      when AttrAccessor, AttrReader
+        parse_type(sig.return_type)
+      else
+        first_arg = sig.params.first
+        if first_arg
+          parse_type(first_arg.type)
+        else
+          Type.untyped
+        end
+      end
+
       print(type.rbs_string)
     end
 

--- a/test/rbi/rbs_printer_test.rb
+++ b/test/rbi/rbs_printer_test.rb
@@ -230,7 +230,17 @@ module RBI
         attr_accessor :foo
 
         sig { returns(String) }
-        attr_accessor :bar
+        sig { returns(Integer) }
+        attr_reader :bar
+
+        sig { params(baz: String).returns(String) }
+        attr_writer :baz
+
+        sig { params(qux: String).void }
+        attr_writer :qux
+
+        sig { returns(Integer) }
+        attr_writer :quux
       RBI
 
       # With RBS, attributes can only have one and only one return type
@@ -238,7 +248,10 @@ module RBI
       # and ignore the rest
       assert_equal(<<~RBI, rbi.rbs_string)
         attr_accessor foo: Integer
-        attr_accessor bar: String
+        attr_reader bar: String
+        attr_writer baz: String
+        attr_writer qux: String
+        attr_writer quux: untyped
       RBI
     end
 


### PR DESCRIPTION
The current RBS translation mechanism for attr_writers relies on the return type of its signature. However, the return type can't always be trusted as both these syntax are valid for Sorbet:

```rb
sig { params(x: Integer).returns(Integer) }
attr_writer :x

sig { params(y: Integer).void }
attr_writer :y
```

Instead, we should rely on the first parameter which we can be sure to find since Sorbet requires it.