### PR TITLE
Translate RBI `attached_class` to RBS `instance`

### DIFF
--- a/lib/rbi/rbs_printer.rb
+++ b/lib/rbi/rbs_printer.rb
@@ -880,7 +880,7 @@ module RBI
 
     sig { params(type: Type::AttachedClass).void }
     def visit_attached_class(type)
-      @string << "attached_class"
+      @string << "instance"
     end
 
     sig { params(type: Type::Nilable).void }

--- a/test/rbi/rbs_printer_test.rb
+++ b/test/rbi/rbs_printer_test.rb
@@ -519,6 +519,17 @@ module RBI
       assert_empty(rbi.rbs_string)
     end
 
+    def test_print_attached_class
+      rbi = parse_rbi(<<~RBI)
+        sig { returns(T.attached_class) }
+        def foo; end
+      RBI
+
+      assert_equal(<<~RBI, rbi.rbs_string)
+        def foo: -> instance
+      RBI
+    end
+
     def test_print_t_structs
       rbi = parse_rbi(<<~RBI)
         class Foo < T::Struct; end


### PR DESCRIPTION
The `attached_class` in RBI:

```rb
sig { returns(T.attached_class) }
def foo; end
```

should be translated to `instance` in RBS:

```rbs
def foo: -> instance
```