### PR TITLE
Handle `final` in RBS translation

### DIFF
--- a/lib/rbi/rbs_printer.rb
+++ b/lib/rbi/rbs_printer.rb
@@ -305,6 +305,10 @@ module RBI
         printl("# @overridable")
       end
 
+      if node.sigs.any?(&:is_final)
+        printl("# @final")
+      end
+
       print_loc(node)
       printt
       unless in_visibility_group || node.visibility.public?

--- a/test/rbi/rbs_printer_test.rb
+++ b/test/rbi/rbs_printer_test.rb
@@ -363,7 +363,7 @@ module RBI
 
     def test_print_methods_with_signature_with_modifiers
       rbi = parse_rbi(<<~RBI)
-        sig { abstract.override.overridable.returns(void).checked(:never) }
+        sig(:final) { abstract.override.overridable.returns(void).checked(:never) }
         def foo; end
       RBI
 
@@ -373,6 +373,7 @@ module RBI
         # @abstract
         # @override
         # @overridable
+        # @final
         def foo: -> void
       RBI
     end


### PR DESCRIPTION
Since there is no equivalent in RBS we just translate it to an ad-hoc annotation.

Thus, this RBI signature:

```rb
sig(:final) { void }
def foo; en
```

Becomes this in RBS:

```rbs
# @final
def foo: -> void
```