### PR TITLE
Handle incompatible overrides in RBS translation

### DIFF
--- a/lib/rbi/model.rb
+++ b/lib/rbi/model.rb
@@ -1111,7 +1111,7 @@ module RBI
     attr_accessor :return_type
 
     sig { returns(T::Boolean) }
-    attr_accessor :is_abstract, :is_override, :is_overridable, :is_final
+    attr_accessor :is_abstract, :is_override, :is_overridable, :is_final, :allow_incompatible_override
 
     sig { returns(T::Array[String]) }
     attr_reader :type_params
@@ -1127,6 +1127,7 @@ module RBI
         is_override: T::Boolean,
         is_overridable: T::Boolean,
         is_final: T::Boolean,
+        allow_incompatible_override: T::Boolean,
         type_params: T::Array[String],
         checked: T.nilable(Symbol),
         loc: T.nilable(Loc),
@@ -1141,6 +1142,7 @@ module RBI
       is_override: false,
       is_overridable: false,
       is_final: false,
+      allow_incompatible_override: false,
       type_params: [],
       checked: nil,
       loc: nil,
@@ -1154,6 +1156,7 @@ module RBI
       @is_override = is_override
       @is_overridable = is_overridable
       @is_final = is_final
+      @allow_incompatible_override = allow_incompatible_override
       @type_params = type_params
       @checked = checked
       block&.call(self)

--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -858,6 +858,22 @@ module RBI
           end
         when "override"
           @current.is_override = true
+
+          args = node.arguments&.arguments
+
+          keywords_hash = args
+            &.grep(Prism::KeywordHashNode)
+            &.first
+
+          allow_incompatible_override = keywords_hash
+            &.elements
+            &.any? do |assoc|
+              assoc.is_a?(Prism::AssocNode) &&
+                node_string(assoc.key) == "allow_incompatible:" &&
+                node_string(assoc.value) == "true"
+            end
+
+          @current.allow_incompatible_override = !!allow_incompatible_override
         when "overridable"
           @current.is_overridable = true
         when "params"

--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -721,7 +721,15 @@ module RBI
     def sig_modifiers(node)
       modifiers = T.let([], T::Array[String])
       modifiers << "abstract" if node.is_abstract
-      modifiers << "override" if node.is_override
+
+      if node.is_override
+        modifiers << if node.allow_incompatible_override
+          "override(allow_incompatible: true)"
+        else
+          "override"
+        end
+      end
+
       modifiers << "overridable" if node.is_overridable
       modifiers << "type_parameters(#{node.type_params.map { |type| ":#{type}" }.join(", ")})" if node.type_params.any?
       modifiers << "checked(:#{node.checked})" if node.checked

--- a/lib/rbi/rbs_printer.rb
+++ b/lib/rbi/rbs_printer.rb
@@ -298,7 +298,11 @@ module RBI
       end
 
       if node.sigs.any?(&:is_override)
-        printl("# @override")
+        if node.sigs.any?(&:allow_incompatible_override)
+          printl("# @override(allow_incompatible: true)")
+        else
+          printl("# @override")
+        end
       end
 
       if node.sigs.any?(&:is_overridable)

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -127,7 +127,7 @@ module RBI
         sig { abstract.params(a: Integer).void }
         sig { checked(:never).returns(T::Array[String]) }
         sig { override.params(printer: Spoom::LSP::SymbolPrinter).void }
-        sig { returns(T.nilable(String)) }
+        sig { override(allow_incompatible: true).returns(T.nilable(String)) }
         sig { params(requested_generators: T::Array[String]).returns(T.proc.params(klass: Class).returns(T::Boolean)) }
         sig { type_parameters(:U).params(step: Integer, _blk: T.proc.returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
         sig { type_parameters(:A, :B).params(a: T::Array[T.type_parameter(:A)], fa: T.proc.params(item: T.type_parameter(:A)).returns(T.untyped), b: T::Array[T.type_parameter(:B)], fb: T.proc.params(item: T.type_parameter(:B)).returns(T.untyped)).returns(T::Array[[T.type_parameter(:A), T.type_parameter(:B)]]) }
@@ -146,7 +146,7 @@ module RBI
         sig { abstract.params(a: Integer).void }
         sig { checked(:never).returns(T::Array[String]) }
         sig { override.params(printer: Spoom::LSP::SymbolPrinter).void }
-        sig { returns(T.nilable(String)) }
+        sig { override(allow_incompatible: true).returns(T.nilable(String)) }
         sig { params(requested_generators: T::Array[String]).returns(T.proc.params(klass: Class).returns(T::Boolean)) }
         sig { type_parameters(:U).params(step: Integer, _blk: T.proc.returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
         sig { type_parameters(:A, :B).params(a: T::Array[T.type_parameter(:A)], fa: T.proc.params(item: T.type_parameter(:A)).returns(T.untyped), b: T::Array[T.type_parameter(:B)], fb: T.proc.params(item: T.type_parameter(:B)).returns(T.untyped)).returns(T::Array[[T.type_parameter(:A), T.type_parameter(:B)]]) }

--- a/test/rbi/printer_test.rb
+++ b/test/rbi/printer_test.rb
@@ -201,21 +201,26 @@ module RBI
       sig3.is_overridable = true
       sig3.checked = :never
 
-      sig4 = Sig.new(return_type: "T.type_parameter(:V)")
-      sig4.type_params << "U"
-      sig4.type_params << "V"
-      sig4 << SigParam.new("a", "T.type_parameter(:U)")
+      sig4 = Sig.new(return_type: "T.nilable(String)")
+      sig4.is_override = true
+      sig4.allow_incompatible_override = true
+
+      sig5 = Sig.new(return_type: "T.type_parameter(:V)")
+      sig5.type_params << "U"
+      sig5.type_params << "V"
+      sig5 << SigParam.new("a", "T.type_parameter(:U)")
 
       method = Method.new("foo")
       method.sigs << sig1
       method.sigs << sig2
       method.sigs << sig3
       method.sigs << sig4
-
+      method.sigs << sig5
       assert_equal(<<~RBI, method.string)
         sig { void }
         sig { params(a: A, b: T.nilable(B), b: T.proc.void).returns(R) }
         sig { abstract.override.overridable.checked(:never).void }
+        sig { override(allow_incompatible: true).returns(T.nilable(String)) }
         sig { type_parameters(:U, :V).params(a: T.type_parameter(:U)).returns(T.type_parameter(:V)) }
         def foo; end
       RBI

--- a/test/rbi/rbs_printer_test.rb
+++ b/test/rbi/rbs_printer_test.rb
@@ -365,6 +365,9 @@ module RBI
       rbi = parse_rbi(<<~RBI)
         sig { abstract.override.overridable.returns(void).checked(:never) }
         def foo; end
+
+        sig { override(allow_incompatible: true).returns(T.nilable(String)) }
+        def bar; end
       RBI
 
       # Modifiers are ignored in RBS, but we generate comments for them
@@ -374,6 +377,9 @@ module RBI
         # @override
         # @overridable
         def foo: -> void
+
+        # @override(allow_incompatible: true)
+        def bar: -> String?
       RBI
     end
 


### PR DESCRIPTION
Handle `allow_incompatible` flag on `override` in signatures so this RBI:

```rb
sig { override(allow_incompatible: true).void }
def foo; end
```

Is translated to this RBS signature:

```rbs
# @override(allow_incompatible: true)
def foo: -> void
```