### PR TITLE
Fix RBS translation of shape string keys

### DIFF
--- a/lib/rbi/rbs_printer.rb
+++ b/lib/rbi/rbs_printer.rb
@@ -930,7 +930,16 @@ module RBI
     def visit_shape(type)
       @string << "{"
       type.types.each_with_index do |(key, value), index|
-        @string << "#{key}: "
+        @string << case key
+        when String
+          "\"#{key}\" => "
+        when Symbol
+          if key.match?(/\A[a-zA-Z_]+[a-zA-Z0-9_]*\z/)
+            "#{key}: "
+          else
+            "\"#{key}\": "
+          end
+        end
         visit(value)
         @string << ", " if index < type.types.size - 1
       end

--- a/test/rbi/rbs_printer_test.rb
+++ b/test/rbi/rbs_printer_test.rb
@@ -530,6 +530,32 @@ module RBI
       RBI
     end
 
+    def test_print_record_type
+      rbi = parse_rbi(<<~RBI)
+        sig { returns({a: A, b: B}) }
+        def a; end
+
+        sig { returns({"a" => A, "b" => B}) }
+        def b; end
+
+        sig { returns({a: A, "b": B, :c => C, "d" => D}) }
+        def c; end
+
+        sig { returns({a: A, "B-B": B})}
+        def d; end
+      RBI
+
+      assert_equal(<<~RBI, rbi.rbs_string)
+        def a: -> {a: A, b: B}
+
+        def b: -> {"a" => A, "b" => B}
+
+        def c: -> {a: A, b: B, c: C, "d" => D}
+
+        def d: -> {a: A, "B-B": B}
+      RBI
+    end
+
     def test_print_t_structs
       rbi = parse_rbi(<<~RBI)
         class Foo < T::Struct; end


### PR DESCRIPTION
Before this change all shape keys were always translated as symbol, this change makes it possible to use string keys in shapes.

So this RBI signature:

```rb
sig { returns({a: A, "b": B, :c => C, "d" => D}) }
def foo; end
```

Is properly translated as:

```rbs
def foo: -> {a: A, b: B, c: C, "d" => D}
```