### PR TITLE
Handle spaces in types during RBS translation

### DIFF
--- a/lib/rbi/rbs_printer.rb
+++ b/lib/rbi/rbs_printer.rb
@@ -842,7 +842,7 @@ module RBI
 
     sig { params(type: Type::Simple).void }
     def visit_simple(type)
-      @string << translate_t_type(type.name)
+      @string << translate_t_type(type.name.gsub(/\s/, ""))
     end
 
     sig { params(type: Type::Boolean).void }
@@ -852,7 +852,7 @@ module RBI
 
     sig { params(type: Type::Generic).void }
     def visit_generic(type)
-      @string << translate_t_type(type.name)
+      @string << translate_t_type(type.name.gsub(/\s/, ""))
       @string << "["
       type.params.each_with_index do |arg, index|
         visit(arg)

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -88,6 +88,16 @@ module RBI
       assert_equal(rbi, tree.string)
     end
 
+    def test_parse_constants_with_newlines
+      rbi = <<~RBI
+        sig { returns(Foo::
+              Bar) }
+      RBI
+
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
+    end
+
     def test_parse_attributes
       rbi = <<~RBI
         attr_reader :a

--- a/test/rbi/rbs_printer_test.rb
+++ b/test/rbi/rbs_printer_test.rb
@@ -268,6 +268,18 @@ module RBI
       RBI
     end
 
+    def test_print_signature_with_newlines
+      rbi = parse_rbi(<<~RBI)
+        sig { returns(T.class_of(Foo::
+          Bar)) }
+        def foo; end
+      RBI
+
+      assert_equal(<<~RBI, rbi.rbs_string)
+        def foo: -> singleton(Foo::Bar)
+      RBI
+    end
+
     def test_print_methods_without_signature
       rbi = parse_rbi(<<~RBI)
         def foo; end


### PR DESCRIPTION
I found some signatures formatted as follow:

```rb
sig { returns(Foo::
              Bar) }
```

While this is valid in Ruby/RBI, having spaces or new lines in a type is a syntax error in RBS.