### PR TITLE
Do not print type parameters as `TYPE_` when translating to RBS

### DIFF
--- a/lib/rbi/rbs_printer.rb
+++ b/lib/rbi/rbs_printer.rb
@@ -357,7 +357,7 @@ module RBI
     sig { params(node: RBI::Method, sig: Sig).void }
     def print_method_sig(node, sig)
       unless sig.type_params.empty?
-        print("[#{sig.type_params.map { |t| "TYPE_#{t}" }.join(", ")}] ")
+        print("[#{sig.type_params.join(", ")}] ")
       end
 
       block_param = node.params.find { |param| param.is_a?(BlockParam) }
@@ -972,7 +972,7 @@ module RBI
 
     sig { params(type: Type::TypeParameter).void }
     def visit_type_parameter(type)
-      @string << "TYPE_#{type.name}"
+      @string << type.name.to_s
     end
 
     sig { params(type: Type::Class).void }

--- a/test/rbi/rbs_printer_test.rb
+++ b/test/rbi/rbs_printer_test.rb
@@ -390,9 +390,8 @@ module RBI
         def foo(a); end
       RBI
 
-      # To avoid conflict with existing constants, we prefix type parameters with `TYPE_`
       assert_equal(<<~RBI, rbi.rbs_string)
-        def foo: [TYPE_U, TYPE_V] (TYPE_U a) -> TYPE_V
+        def foo: [U, V] (U a) -> V
       RBI
     end
 


### PR DESCRIPTION
We actually don't need to translate these types with the `TYPE_` prefix to differentiate from actual types.

Since all type parameters need to be declared in the signature preamble, we can easily figure which types are parameters and which ones are actual types.