### PR TITLE
Protect nilable procs with parenthesis when translating to RBS

### DIFF
--- a/lib/rbi/rbs_printer.rb
+++ b/lib/rbi/rbs_printer.rb
@@ -885,7 +885,13 @@ module RBI
 
     sig { params(type: Type::Nilable).void }
     def visit_nilable(type)
+      if type.type.is_a?(Type::Proc)
+        @string << "("
+      end
       visit(type.type)
+      if type.type.is_a?(Type::Proc)
+        @string << ")"
+      end
       @string << "?"
     end
 

--- a/test/rbi/rbs_printer_test.rb
+++ b/test/rbi/rbs_printer_test.rb
@@ -530,6 +530,17 @@ module RBI
       RBI
     end
 
+    def test_print_nilable_proc
+      rbi = parse_rbi(<<~RBI)
+        sig { params(x: T.nilable(T.proc.void)) }
+        def foo(x); end
+      RBI
+
+      assert_equal(<<~RBI, rbi.rbs_string)
+        def foo: ((^-> void)? x) -> void
+      RBI
+    end
+
     def test_print_t_structs
       rbi = parse_rbi(<<~RBI)
         class Foo < T::Struct; end


### PR DESCRIPTION
When translating this RBI signature:

```rb
sig { params(x: T.nilable(T.proc.returns(Foo)) }
def foo(x); end
```

We need to put the proc into parenthesis to keep the current semantics:

```rbs
def foo: ((^-> Foo)? x) -> void
```

Otherwise we end up with the return type of the block being nilable rather than the proc itself:

```rbs
def foo: (^-> Foo? x) -> void
```