### PR TITLE
Fix RBS translation of attr_writer signatures

### DIFF
--- a/test/rbi/rbs_printer_test.rb
+++ b/test/rbi/rbs_printer_test.rb
@@ -233,7 +233,7 @@ module RBI
         sig { returns(Integer) }
         attr_reader :bar
 
-        sig { params(baz: String).returns(String) }
+        sig { params(baz: String).returns(T.nilable(String)) }
         attr_writer :baz
 
         sig { params(qux: String).void }
@@ -249,9 +249,9 @@ module RBI
       assert_equal(<<~RBI, rbi.rbs_string)
         attr_accessor foo: Integer
         attr_reader bar: String
-        attr_writer baz: String
+        attr_writer baz: String?
         attr_writer qux: String
-        attr_writer quux: untyped
+        attr_writer quux: Integer
       RBI
     end
 


### PR DESCRIPTION
I found some occurrences where the RBI signature for attribute writers where using a different type for the parameter and the return:

```rb
sig { params(baz: String).returns(T.nilable(String)) }
attr_writer :x
```

In this case Sorbet would only consider the return type so we need to keep this information during the translation to RBS:

```rbs
attr_writer x: String?
```