### PR TITLE
Do not raise unnecessarily during parsing

### DIFF
--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -451,11 +451,6 @@ module RBI
                 loc: node_loc(node),
                 comments: node_comments(node),
               )
-            else
-              raise ParseError.new(
-                "Unexpected token `#{node.message}` before `#{last_node&.string&.strip}`",
-                node_loc(node),
-              )
             end
           else
             current_scope << parse_visibility(node.name.to_s, node)
@@ -722,8 +717,6 @@ module RBI
 
                 keyword_init = val == "true" if key == "keyword_init:"
               end
-            else
-              raise ParseError.new("Unexpected node type `#{arg.class}`", node_loc(arg))
             end
           end
         end

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -1019,44 +1019,6 @@ module RBI
       RBI
     end
 
-    def test_parse_errors
-      e = assert_raises(ParseError) do
-        Parser.parse_string(<<~RBI)
-          def bar
-        RBI
-      end
-      assert_equal(
-        "unexpected end-of-input, assuming it is closing the parent top level context. expected an `end` " \
-          "to close the `def` statement.",
-        e.message,
-      )
-      assert_equal("-:1:7", e.location.to_s)
-
-      e = assert_raises(ParseError) do
-        Parser.parse_string(<<~RBI)
-          private include Foo
-        RBI
-      end
-      assert_equal("Unexpected token `private` before `include Foo`", e.message)
-      assert_equal("-:1:0-1:19", e.location.to_s)
-
-      e = assert_raises(ParseError) do
-        Parser.parse_string(<<~RBI)
-          private class Foo; end
-        RBI
-      end
-      assert_equal("Unexpected token `private` before `class Foo; end`", e.message)
-      assert_equal("-:1:0-1:22", e.location.to_s)
-
-      e = assert_raises(ParseError) do
-        Parser.parse_string(<<~RBI)
-          private CST = 42
-        RBI
-      end
-      assert_equal("Unexpected token `private` before `CST = 42`", e.message)
-      assert_equal("-:1:0-1:16", e.location.to_s)
-    end
-
     def test_parse_strings
       trees = Parser.parse_strings([
         "class Foo; end",


### PR DESCRIPTION
Since https://github.com/Shopify/spoom/pull/611, we started using the `RBI::Parser` to parse actual Ruby files rather than just RBI files. This means the parser may encounter a more complex syntax than what we can expect in a RBI file and I noticed that we were raising a few `RBI::ParseError` for such cases. 

While these errors may be useful to lint RBI files, the RBI parser is _not_ a linter and shouldn't raise solely for this purpose. In most cases we can just no-op the case and continue without any issue.

This PR removes two cases that raise while we could have continued.