### PR TITLE
Add basic support for parsing and generating heredocs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ end
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -216,6 +216,7 @@ module RBI
       visit_all(node.comments)
 
       printl("#{node.name} = #{node.value}")
+      printt(node.heredocs) if node.heredocs
     end
 
     sig { override.params(node: AttrAccessor).void }
@@ -402,6 +403,7 @@ module RBI
       print_loc(node)
       visit_all(node.comments)
 
+      printt("#{node.receiver}.") if node.receiver
       printt(node.method)
       unless node.args.empty?
         print(" ")
@@ -411,6 +413,10 @@ module RBI
         end
       end
       printn
+      if node.heredocs
+        printt(node.heredocs)
+        printn
+      end
     end
 
     sig { override.params(node: Arg).void }

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -82,6 +82,16 @@ module RBI
         C = T.nilable(String)
         D = A::B::C
         A::B::C = Foo
+        E = <<~EOF
+          foo
+          bar
+        EOF
+        F = "foo" \\
+            "bar"
+        G = T.let(<<~EOF, T.nilable(String))
+          foo
+          bar
+        EOF
       RBI
 
       tree = parse_rbi(rbi)


### PR DESCRIPTION
Without this change, the data lines in a heredoc are not generated, resulting in a syntax error in the generated RBI:


```
FOO = <<EOF
bar
EOF
```

becomes just

```
FOO = <<EOF
```