### PR TITLE
Fix constants with heredoc values

### DIFF
--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -138,6 +138,17 @@ module RBI
       def node_string!(node)
         T.must(node_string(node))
       end
+
+      #: (Prism::Node node) -> Prism::Location
+      def adjust_prism_location_for_heredoc(node)
+        visitor = HeredocLocationVisitor.new(
+          node.location.send(:source),
+          node.location.start_offset,
+          node.location.end_offset,
+        )
+        visitor.visit(node)
+        visitor.location
+      end
     end
 
     class TreeBuilder < Visitor
@@ -217,30 +228,40 @@ module RBI
 
         current_scope << if struct
           struct
-        elsif type_variable_definition?(node.value)
-          TypeMember.new(
-            case node
-            when Prism::ConstantWriteNode
-              node.name.to_s
-            when Prism::ConstantPathWriteNode
-              node_string!(node.target)
-            end,
-            node_string!(node.value),
-            loc: node_loc(node),
-            comments: node_comments(node),
-          )
         else
-          Const.new(
-            case node
-            when Prism::ConstantWriteNode
-              node.name.to_s
-            when Prism::ConstantPathWriteNode
-              node_string!(node.target)
-            end,
-            node_string!(node.value),
-            loc: node_loc(node),
-            comments: node_comments(node),
+          adjusted_node_location = adjust_prism_location_for_heredoc(node)
+
+          adjusted_value_location = Prism::Location.new(
+            node.value.location.send(:source),
+            node.value.location.start_offset,
+            adjusted_node_location.end_offset - node.value.location.start_offset,
           )
+
+          if type_variable_definition?(node.value)
+            TypeMember.new(
+              case node
+              when Prism::ConstantWriteNode
+                node.name.to_s
+              when Prism::ConstantPathWriteNode
+                node_string!(node.target)
+              end,
+              adjusted_value_location.slice,
+              loc: Loc.from_prism(@file, adjusted_node_location),
+              comments: node_comments(node),
+            )
+          else
+            Const.new(
+              case node
+              when Prism::ConstantWriteNode
+                node.name.to_s
+              when Prism::ConstantPathWriteNode
+                node_string!(node.target)
+              end,
+              adjusted_value_location.slice,
+              loc: Loc.from_prism(@file, adjusted_node_location),
+              comments: node_comments(node),
+            )
+          end
         end
       end
 
@@ -901,6 +922,58 @@ module RBI
           node_string!(node.key).delete_suffix(":"),
           node_string!(node.value),
         )
+      end
+    end
+
+    class HeredocLocationVisitor < Prism::Visitor
+      #: (Prism::Source source, Integer begin_offset, Integer end_offset) -> void
+      def initialize(source, begin_offset, end_offset)
+        super()
+        @source = source
+        @begin_offset = begin_offset
+        @end_offset = end_offset
+        @offset_last_newline = false #: bool
+      end
+
+      #: (Prism::StringNode node) -> void
+      def visit_string_node(node)
+        return unless node.heredoc?
+
+        closing_loc = node.closing_loc
+        return unless closing_loc
+
+        handle_string_node(node)
+      end
+
+      #: (Prism::InterpolatedStringNode node) -> void
+      def visit_interpolated_string_node(node)
+        return super unless node.heredoc?
+
+        closing_loc = node.closing_loc
+        return super unless closing_loc
+
+        handle_string_node(node)
+      end
+
+      #: -> Prism::Location
+      def location
+        Prism::Location.new(
+          @source,
+          @begin_offset,
+          @end_offset - @begin_offset - (@offset_last_newline ? 1 : 0),
+        )
+      end
+
+      private
+
+      #: (Prism::StringNode | Prism::InterpolatedStringNode node) -> void
+      def handle_string_node(node)
+        closing_loc = T.must(node.closing_loc)
+
+        if closing_loc.end_offset > @end_offset
+          @end_offset = closing_loc.end_offset
+          @offset_last_newline = true if node.closing_loc&.slice&.end_with?("\n")
+        end
       end
     end
   end

--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -675,6 +675,13 @@ module RBI
         node.comments.empty? && node.empty?
       when Attr
         node.comments.empty? && node.sigs.empty?
+      when Const
+        return false unless node.comments.empty?
+
+        loc = node.loc
+        return true unless loc
+
+        loc.begin_line == loc.end_line
       when Method
         node.comments.empty? && node.sigs.empty? && node.params.all? { |p| p.comments.empty? }
       when Sig

--- a/rbi/rbi.rbi
+++ b/rbi/rbi.rbi
@@ -1005,6 +1005,25 @@ class RBI::Parser
   end
 end
 
+class RBI::Parser::HeredocLocationVisitor < ::Prism::Visitor
+  sig { params(source: ::Prism::Source, begin_offset: ::Integer, end_offset: ::Integer).void }
+  def initialize(source, begin_offset, end_offset); end
+
+  sig { returns(::Prism::Location) }
+  def location; end
+
+  sig { params(node: ::Prism::InterpolatedStringNode).void }
+  def visit_interpolated_string_node(node); end
+
+  sig { params(node: ::Prism::StringNode).void }
+  def visit_string_node(node); end
+
+  private
+
+  sig { params(node: T.any(::Prism::InterpolatedStringNode, ::Prism::StringNode)).void }
+  def handle_string_node(node); end
+end
+
 class RBI::Parser::SigBuilder < ::RBI::Parser::Visitor
   sig { params(content: ::String, file: ::String).void }
   def initialize(content, file:); end
@@ -1118,6 +1137,9 @@ class RBI::Parser::Visitor < ::Prism::Visitor
   def initialize(source, file:); end
 
   private
+
+  sig { params(node: ::Prism::Node).returns(::Prism::Location) }
+  def adjust_prism_location_for_heredoc(node); end
 
   sig { params(node: ::Prism::Node).returns(::RBI::Loc) }
   def node_loc(node); end

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -88,6 +88,65 @@ module RBI
       assert_equal(rbi, tree.string)
     end
 
+    def test_parse_constants_with_heredoc
+      rbi = <<~RBI
+        A = <<-EOF
+          foo
+          foo
+        EOF
+
+        B = <<~EOF.strip
+          bar
+        EOF
+
+        C = <<-'EOF'
+          baz
+        EOF
+
+        D = %Q(
+
+          qux
+
+        )
+
+        E = T.let(<<~EOF, String)
+          foo
+        EOF
+
+        F = "foo" \\
+           "bar"
+
+        G = "\#{<<~begin}\#{<<~end}"
+        begin
+          foo
+          foo
+        end
+
+        H = foo(<<~begin, <<~end)
+        begin
+          foo
+          foo
+        end
+      RBI
+
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
+    end
+
+    def test_parse_constants_multiline_calls
+      rbi = <<~RBI
+        A = foo(
+          <<~EOF,
+            bar
+          EOF
+          baz,
+        )
+      RBI
+
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
+    end
+
     def test_parse_constants_with_newlines
       rbi = <<~RBI
         sig { returns(Foo::

--- a/test/rbi/printer_test.rb
+++ b/test/rbi/printer_test.rb
@@ -1113,8 +1113,10 @@ module RBI
         class TE < T::Enum; end
         # file.rbi:1:3-2:4
         class TS < T::Struct; end
+
         # file.rbi:1:3-2:4
         C = 42
+
         # file.rbi:1:3-2:4
         extend E
         # file.rbi:1:3-2:4


### PR DESCRIPTION
As reported in #406, constants values are truncated so parsing this input:

```rb
FOO = <<EOF
  bar
EOF
```

will incorrectly output the following RBI:

```rb
FOO = <<EOF
```

The problem stems from the location Prism returns for an heredoc.

Consider this snippet:
```rb
require "prism"

ruby_string = <<~RUBY
  FOO = <<~EOF
    foo
  EOF
RUBY

puts Prism.parse(ruby_string).inspect
```

Prism will return the following AST:
```
#<Prism::ParseResult:0x000000011f9556f8 @value=@ ProgramNode (location: (1,0)-(1,12))
├── flags: ∅
├── locals: []
└── statements:
    @ StatementsNode (location: (1,0)-(1,12))
    ├── flags: ∅
    └── body: (length: 1)
        └── @ ConstantWriteNode (location: (1,0)-(1,12))
            ├── flags: newline
            ├── name: :FOO
            ├── name_loc: (1,0)-(1,3) = "FOO"
            ├── value:
            │   @ StringNode (location: (1,6)-(1,12))
            │   ├── flags: ∅
            │   ├── opening_loc: (1,6)-(1,12) = "<<~EOF"
            │   ├── content_loc: (2,0)-(3,0) = "  foo\n"
            │   ├── closing_loc: (3,0)-(4,0) = "EOF\n"
            │   └── unescaped: "foo\n"
            └── operator_loc: (1,4)-(1,5) = "="
```

Note how the `closing_loc` points to the correct location at the end of the `EOF` marker yet the node location (`@ StringNode (location: (1,6)-(1,12))`) only includes the opening marker.

Digging a bit in Prism issues, I found https://github.com/ruby/prism/pull/1260 explaining this behavior is actually desirable.

Given this, I think the best way is to adjust the Prism location when we encounter a constant that holds a heredoc value.

I also fixed the printing of multiline constants so we insert a blank line as we do with other multiline definitions.

Closes #406.