### PR TITLE
Introduce `RBSSig` node

### DIFF
--- a/lib/rbi/model.rb
+++ b/lib/rbi/model.rb
@@ -423,13 +423,17 @@ module RBI
     #: Array[Sig]
     attr_accessor :sigs
 
-    #: (String name, ?params: Array[Param], ?is_singleton: bool, ?visibility: Visibility, ?sigs: Array[Sig], ?loc: Loc?, ?comments: Array[Comment]) ?{ (Method node) -> void } -> void
+    #: Array[RBSSig]
+    attr_accessor :rbs_sigs
+
+    #: (String name, ?params: Array[Param], ?is_singleton: bool, ?visibility: Visibility, ?sigs: Array[Sig], ?rbs_sigs: Array[RBSSig], ?loc: Loc?, ?comments: Array[Comment]) ?{ (Method node) -> void } -> void
     def initialize(
       name,
       params: [],
       is_singleton: false,
       visibility: Public.new,
       sigs: [],
+      rbs_sigs: [],
       loc: nil,
       comments: [],
       &block
@@ -440,6 +444,7 @@ module RBI
       @is_singleton = is_singleton
       @visibility = visibility
       @sigs = sigs
+      @rbs_sigs = rbs_sigs
       block&.call(self)
     end
 
@@ -979,6 +984,21 @@ module RBI
     #: (Object other) -> bool
     def ==(other)
       other.is_a?(SigParam) && name == other.name && type.to_s == other.type.to_s
+    end
+  end
+
+  # RBS signatures
+
+  class RBSSig < Node
+    extend T::Sig
+
+    #: String
+    attr_reader :string
+
+    #: (String string, ?loc: Loc?) -> void
+    def initialize(string, loc: nil)
+      super(loc: loc)
+      @string = string
     end
   end
 

--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -273,6 +273,7 @@ module RBI
       print_blank_line_before(node)
       visit_all(node.comments)
       visit_all(node.sigs)
+      visit_all(node.rbs_sigs)
 
       print_loc(node)
       printt
@@ -464,6 +465,15 @@ module RBI
       else
         print_sig_as_block(node)
       end
+    end
+
+    # @override
+    #: (RBSSig node) -> void
+    def visit_rbs_sig(node)
+      print_loc(node)
+      printt("#: ")
+      print(node.string)
+      printn
     end
 
     # @override

--- a/lib/rbi/visitor.rb
+++ b/lib/rbi/visitor.rb
@@ -85,6 +85,8 @@ module RBI
         visit_arg(node)
       when Sig
         visit_sig(node)
+      when RBSSig
+        visit_rbs_sig(node)
       when SigParam
         visit_sig_param(node)
       when TStructConst
@@ -199,6 +201,9 @@ module RBI
 
     #: (Sig node) -> void
     def visit_sig(node); end
+
+    #: (RBSSig node) -> void
+    def visit_rbs_sig(node); end
 
     #: (SigParam node) -> void
     def visit_sig_param(node); end

--- a/test/rbi/printer_test.rb
+++ b/test/rbi/printer_test.rb
@@ -1166,5 +1166,18 @@ module RBI
         end
       RBI
     end
+
+    def test_print_rbs_sigs
+      comments = [Comment.new("comment")]
+      rbs_sig = RBSSig.new("-> String")
+      method = Method.new("foo", comments: comments, rbs_sigs: [rbs_sig])
+      method.comments << Comment.new("comment2")
+
+      assert_equal(<<~RBI, method.string)
+        # comment
+        #: -> String
+        def foo; end
+      RBI
+    end
   end
 end


### PR DESCRIPTION
A simple node that's currently used for printing RBS signatures correctly.