### PR TITLE
Introduce RBSComment node

### DIFF
--- a/lib/rbi/model.rb
+++ b/lib/rbi/model.rb
@@ -82,6 +82,18 @@ module RBI
     end
   end
 
+  # A comment representing a RBS type prefixed with `#:`
+  class RBSComment < Comment
+    extend T::Sig
+
+    #: (Object other) -> bool
+    def ==(other)
+      return false unless other.is_a?(RBSComment)
+
+      text == other.text
+    end
+  end
+
   class NodeWithComments < Node
     extend T::Sig
     extend T::Helpers

--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -586,7 +586,13 @@ module RBI
 
       #: (Prism::Comment node) -> Comment
       def parse_comment(node)
-        Comment.new(node.location.slice.gsub(/^# ?/, "").rstrip, loc: Loc.from_prism(@file, node.location))
+        loc = Loc.from_prism(@file, node.location)
+        string = node.location.slice
+        if string.start_with?("#:")
+          RBSComment.new(string.gsub(/^#: ?/, "").rstrip, loc: loc)
+        else
+          Comment.new(string.gsub(/^# ?/, "").rstrip, loc: loc)
+        end
       end
 
       #: (Prism::Node? node) -> Array[Arg]

--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -102,6 +102,23 @@ module RBI
     private
 
     # @override
+    #: (RBSComment node) -> void
+    def visit_rbs_comment(node)
+      lines = node.text.lines
+
+      if lines.empty?
+        printl("#:")
+      end
+
+      lines.each do |line|
+        text = line.rstrip
+        printt("#:")
+        print(" #{text}") unless text.empty?
+        printn
+      end
+    end
+
+    # @override
     #: (Comment node) -> void
     def visit_comment(node)
       lines = node.text.lines

--- a/lib/rbi/visitor.rb
+++ b/lib/rbi/visitor.rb
@@ -17,6 +17,8 @@ module RBI
       case node
       when BlankLine
         visit_blank_line(node)
+      when RBSComment
+        visit_rbs_comment(node)
       when Comment
         visit_comment(node)
       when TEnum
@@ -118,6 +120,9 @@ module RBI
 
     #: (Comment node) -> void
     def visit_comment(node); end
+
+    #: (RBSComment node) -> void
+    def visit_rbs_comment(node); end
 
     #: (BlankLine node) -> void
     def visit_blank_line(node); end

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -1019,6 +1019,41 @@ module RBI
       RBI
     end
 
+    def test_parse_rbs_comments
+      rbi = <<~RBI
+        #: rbs1
+        class Foo
+          #: rbs2
+          def bar; end
+
+          #: rbs3
+          def self.baz; end
+
+          #: rbs4
+          attr_accessor :a
+
+          def qux; end #: rbs5
+        end
+      RBI
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string)
+        #: rbs1
+        class Foo
+          #: rbs2
+          def bar; end
+
+          #: rbs3
+          def self.baz; end
+
+          #: rbs4
+          attr_accessor :a
+
+          #: rbs5
+          def qux; end
+        end
+      RBI
+    end
+
     def test_parse_strings
       trees = Parser.parse_strings([
         "class Foo; end",


### PR DESCRIPTION
Parse and storer RBS comments on nodes.

For now RBS comments are just stored as a special kind of comments, we'll then plug this with #420 to parse them into actual RBS signatures.