### PR TITLE
Fix RBI -> RBS translation for generics

### DIFF
--- a/lib/rbi/rbs/type_translator.rb
+++ b/lib/rbi/rbs/type_translator.rb
@@ -99,7 +99,8 @@ module RBI
         def translate_class_instance(type)
           return Type.simple(type.name.to_s) if type.args.empty?
 
-          T.unsafe(Type).generic(type.name.to_s, *type.args.map { |arg| translate(arg) })
+          type_name = translate_t_generic_type(type.name.to_s)
+          T.unsafe(Type).generic(type_name, *type.args.map { |arg| translate(arg) })
         end
 
         #: (::RBS::Types::Function) -> Type
@@ -147,6 +148,32 @@ module RBI
 
           proc.returns(translate(type.return_type))
           proc
+        end
+
+        #: (String type_name) -> String
+        def translate_t_generic_type(type_name)
+          case type_name.delete_prefix("::")
+          when "Array"
+            "T::Array"
+          when "Class"
+            "T::Class"
+          when "Enumerable"
+            "T::Enumerable"
+          when "Enumerator"
+            "T::Enumerator"
+          when "Enumerator::Chain"
+            "T::Enumerator::Chain"
+          when "Enumerator::Lazy"
+            "T::Enumerator::Lazy"
+          when "Hash"
+            "T::Hash"
+          when "Set"
+            "T::Set"
+          when "Range"
+            "T::Range"
+          else
+            type_name
+          end
         end
       end
     end

--- a/test/rbi/rbs/type_translator_test.rb
+++ b/test/rbi/rbs/type_translator_test.rb
@@ -55,6 +55,28 @@ module RBI
         assert_equal(Type.generic("Foo", Type.simple("Bar"), Type.simple("::Baz")), translate("Foo[Bar, ::Baz]"))
       end
 
+      def test_translate_class_instance_generics_as_t_types
+        assert_equal(Type.generic("T::Array", Type.simple("Foo")), translate("Array[Foo]"))
+        assert_equal(Type.generic("T::Class", Type.simple("Foo")), translate("Class[Foo]"))
+        assert_equal(Type.generic("T::Enumerable", Type.simple("Foo")), translate("Enumerable[Foo]"))
+        assert_equal(Type.generic("T::Enumerator", Type.simple("Foo")), translate("Enumerator[Foo]"))
+        assert_equal(Type.generic("T::Enumerator::Chain", Type.simple("Foo")), translate("Enumerator::Chain[Foo]"))
+        assert_equal(Type.generic("T::Enumerator::Lazy", Type.simple("Foo")), translate("Enumerator::Lazy[Foo]"))
+        assert_equal(Type.generic("T::Hash", Type.simple("Foo"), Type.simple("Bar")), translate("Hash[Foo, Bar]"))
+        assert_equal(Type.generic("T::Set", Type.simple("Foo")), translate("Set[Foo]"))
+        assert_equal(Type.generic("T::Range", Type.simple("Foo"), Type.simple("Bar")), translate("Range[Foo, Bar]"))
+
+        assert_equal(Type.generic("T::Array", Type.simple("Foo")), translate("::Array[Foo]"))
+        assert_equal(Type.generic("T::Class", Type.simple("Foo")), translate("::Class[Foo]"))
+        assert_equal(Type.generic("T::Enumerable", Type.simple("Foo")), translate("::Enumerable[Foo]"))
+        assert_equal(Type.generic("T::Enumerator", Type.simple("Foo")), translate("::Enumerator[Foo]"))
+        assert_equal(Type.generic("T::Enumerator::Chain", Type.simple("Foo")), translate("::Enumerator::Chain[Foo]"))
+        assert_equal(Type.generic("T::Enumerator::Lazy", Type.simple("Foo")), translate("::Enumerator::Lazy[Foo]"))
+        assert_equal(Type.generic("T::Hash", Type.simple("Foo"), Type.simple("Bar")), translate("::Hash[Foo, Bar]"))
+        assert_equal(Type.generic("T::Set", Type.simple("Foo")), translate("::Set[Foo]"))
+        assert_equal(Type.generic("T::Range", Type.simple("Foo"), Type.simple("Bar")), translate("::Range[Foo, Bar]"))
+      end
+
       def test_translate_class_singleton
         assert_equal(Type.class_of(Type.simple("Foo")), translate("singleton(Foo)"))
         assert_equal(Type.class_of(Type.simple("Foo::Bar")), translate("singleton(Foo::Bar)"))


### PR DESCRIPTION
Two fixes in there:

1. Properly translate generic classes so RBS `Foo[A, B]` is not just translated as `Foo`
2. Translate generic `Array` to `T::Array` and friends