### PR TITLE
Do not parse rdoc annotations as RBS comments

### DIFF
--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -576,7 +576,9 @@ module RBI
       def parse_comment(node)
         loc = Loc.from_prism(@file, node.location)
         string = node.location.slice
-        if string.start_with?("#:")
+        # We also ignore RDoc directives such as `:nodoc:`
+        # See https://ruby.github.io/rdoc/RDoc/MarkupReference.html#class-RDoc::MarkupReference-label-Directives
+        if string.start_with?("#:") && !(string =~ /^#:[a-z_]+:/)
           RBSComment.new(string.gsub(/^#: ?/, "").rstrip, loc: loc)
         else
           Comment.new(string.gsub(/^# ?/, "").rstrip, loc: loc)

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -1054,6 +1054,21 @@ module RBI
       RBI
     end
 
+    def test_parse_rbs_comments_ignores_rdoc_directives
+      rbi = <<~RBI
+        #:nodoc:
+        #:yields: something
+        #:start_doc:
+        def foo; end
+      RBI
+
+      tree = parse_rbi(rbi)
+      foo = T.cast(tree.nodes.first, RBI::Method)
+      assert_equal(3, foo.comments.size)
+      assert_equal(3, foo.comments.grep(Comment).size)
+      assert_equal(0, foo.comments.grep(RBSComment).size)
+    end
+
     def test_parse_strings
       trees = Parser.parse_strings([
         "class Foo; end",


### PR DESCRIPTION
So this:

```rb
#:nodoc:
#:yields: something
def foo; end
```

is not considered having RBS comments