### PR TITLE
Translate all `T.let` to RBS inline comments supported by Sorbet

### DIFF
--- a/lib/rbi/index.rb
+++ b/lib/rbi/index.rb
@@ -17,7 +17,7 @@ module RBI
     #: -> void
     def initialize
       super
-      @index = T.let({}, T::Hash[String, T::Array[Node]])
+      @index = {} #: Hash[String, Array[Node]]
     end
 
     #: -> Array[String]

--- a/lib/rbi/model.rb
+++ b/lib/rbi/model.rb
@@ -45,7 +45,7 @@ module RBI
 
     #: -> Scope?
     def parent_scope
-      parent = T.let(parent_tree, T.nilable(Tree))
+      parent = parent_tree #: Tree?
       parent = parent.parent_tree until parent.is_a?(Scope) || parent.nil?
       parent
     end
@@ -116,7 +116,7 @@ module RBI
     #: (?loc: Loc?, ?comments: Array[Comment]) ?{ (Tree node) -> void } -> void
     def initialize(loc: nil, comments: [], &block)
       super(loc: loc, comments: comments)
-      @nodes = T.let([], T::Array[Node])
+      @nodes = [] #: Array[Node]
       block&.call(self)
     end
 
@@ -144,7 +144,7 @@ module RBI
 
     #: (?strictness: String?, ?comments: Array[Comment]) ?{ (File file) -> void } -> void
     def initialize(strictness: nil, comments: [], &block)
-      @root = T.let(Tree.new, Tree)
+      @root = Tree.new #: Tree
       @strictness = strictness
       @comments = comments
       block&.call(self)
@@ -313,7 +313,7 @@ module RBI
     #: (Symbol name, Array[Symbol] names, ?visibility: Visibility, ?sigs: Array[Sig], ?loc: Loc?, ?comments: Array[Comment]) -> void
     def initialize(name, names, visibility: Public.new, sigs: [], loc: nil, comments: [])
       super(loc: loc, comments: comments)
-      @names = T.let([name, *names], T::Array[Symbol])
+      @names = [name, *names] #: Array[Symbol]
       @visibility = visibility
       @sigs = sigs
     end
@@ -671,7 +671,7 @@ module RBI
     #: (String name, Array[String] names, ?loc: Loc?, ?comments: Array[Comment]) -> void
     def initialize(name, names, loc: nil, comments: [])
       super(loc: loc, comments: comments)
-      @names = T.let([name, *names], T::Array[String])
+      @names = [name, *names] #: Array[String]
     end
   end
 

--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -151,12 +151,12 @@ module RBI
       def initialize(source, comments:, file:)
         super(source, file: file)
 
-        @comments_by_line = T.let(comments.to_h { |c| [c.location.start_line, c] }, T::Hash[Integer, Prism::Comment])
-        @tree = T.let(Tree.new, Tree)
+        @comments_by_line = comments.to_h { |c| [c.location.start_line, c] } #: Hash[Integer, Prism::Comment]
+        @tree = Tree.new #: Tree
 
-        @scopes_stack = T.let([@tree], T::Array[Tree])
-        @last_node = T.let(nil, T.nilable(Prism::Node))
-        @last_sigs = T.let([], T::Array[RBI::Sig])
+        @scopes_stack = [@tree] #: Array[Tree]
+        @last_node = nil #: Prism::Node?
+        @last_sigs = [] #: Array[RBI::Sig]
       end
 
       # @override
@@ -509,7 +509,7 @@ module RBI
       # Collect all the remaining comments after visiting the tree
       #: -> void
       def collect_orphan_comments
-        last_line = T.let(nil, T.nilable(Integer))
+        last_line = nil #: Integer?
         last_node_end = @tree.nodes.last&.loc&.end_line
 
         @comments_by_line.each do |line, comment|
@@ -544,7 +544,7 @@ module RBI
 
       #: (Array[Sig] sigs) -> Array[Comment]
       def detach_comments_from_sigs(sigs)
-        comments = T.let([], T::Array[Comment])
+        comments = [] #: Array[Comment]
 
         sigs.each do |sig|
           comments += sig.comments.dup
@@ -587,7 +587,7 @@ module RBI
 
       #: (Prism::Node? node) -> Array[Arg]
       def parse_send_args(node)
-        args = T.let([], T::Array[Arg])
+        args = [] #: Array[Arg]
         return args unless node.is_a?(Prism::ArgumentsNode)
 
         node.arguments.each do |arg|
@@ -703,7 +703,7 @@ module RBI
         return unless node_string(recv) =~ /(::)?Struct/
 
         members = []
-        keyword_init = T.let(false, T::Boolean)
+        keyword_init = false #: bool
 
         args = send.arguments
         if args.is_a?(Prism::ArgumentsNode)
@@ -753,7 +753,7 @@ module RBI
         type = node_string!(type_arg)
         loc = node_loc(send)
         comments = node_comments(send)
-        default_value = T.let(nil, T.nilable(String))
+        default_value = nil #: String?
 
         rest.each do |arg|
           next unless arg.is_a?(Prism::KeywordHashNode)
@@ -829,7 +829,7 @@ module RBI
       def initialize(content, file:)
         super
 
-        @current = T.let(Sig.new, Sig)
+        @current = Sig.new #: Sig
       end
 
       # @override

--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -23,8 +23,8 @@ module RBI
       @out = out
       @current_indent = indent
       @print_locs = print_locs
-      @in_visibility_group = T.let(false, T::Boolean)
-      @previous_node = T.let(nil, T.nilable(Node))
+      @in_visibility_group = false #: bool
+      @previous_node = nil #: Node?
       @max_line_length = max_line_length
     end
 
@@ -771,7 +771,7 @@ module RBI
 
     #: (Sig node) -> Array[String]
     def sig_modifiers(node)
-      modifiers = T.let([], T::Array[String])
+      modifiers = [] #: Array[String]
       modifiers << "abstract" if node.is_abstract
 
       if node.is_override

--- a/lib/rbi/rbs/method_type_translator.rb
+++ b/lib/rbi/rbs/method_type_translator.rb
@@ -21,7 +21,7 @@ module RBI
       #: (Method) -> void
       def initialize(method)
         @method = method
-        @result = T.let(Sig.new, Sig)
+        @result = Sig.new #: Sig
       end
 
       #: (::RBS::MethodType) -> void

--- a/lib/rbi/rbs_printer.rb
+++ b/lib/rbi/rbs_printer.rb
@@ -23,9 +23,9 @@ module RBI
       @out = out
       @current_indent = indent
       @print_locs = print_locs
-      @in_visibility_group = T.let(false, T::Boolean)
-      @previous_node = T.let(nil, T.nilable(Node))
-      @positional_names = T.let(positional_names, T::Boolean)
+      @in_visibility_group = false #: bool
+      @previous_node = nil #: Node?
+      @positional_names = positional_names #: bool
     end
 
     # Printing
@@ -882,7 +882,7 @@ module RBI
 
     #: -> void
     def initialize
-      @string = T.let(String.new, String)
+      @string = String.new #: String
     end
 
     #: (Type node) -> void

--- a/lib/rbi/rewriters/flatten_visibilities.rb
+++ b/lib/rbi/rewriters/flatten_visibilities.rb
@@ -29,7 +29,7 @@ module RBI
       def initialize
         super
 
-        @current_visibility = T.let([Public.new], T::Array[Visibility])
+        @current_visibility = [Public.new] #: Array[Visibility]
       end
 
       # @override

--- a/lib/rbi/rewriters/merge_trees.rb
+++ b/lib/rbi/rewriters/merge_trees.rb
@@ -67,8 +67,8 @@ module RBI
         @left_name = left_name
         @right_name = right_name
         @keep = keep
-        @tree = T.let(MergeTree.new, MergeTree)
-        @scope_stack = T.let([@tree], T::Array[Tree])
+        @tree = MergeTree.new #: MergeTree
+        @scope_stack = [@tree] #: Array[Tree]
       end
 
       #: (Tree tree) -> void
@@ -99,12 +99,12 @@ module RBI
         def initialize(output, left_name: "left", right_name: "right", keep: Keep::NONE)
           super()
           @tree = output
-          @index = T.let(output.index, Index)
-          @scope_stack = T.let([@tree], T::Array[Tree])
+          @index = output.index #: Index
+          @scope_stack = [@tree] #: Array[Tree]
           @left_name = left_name
           @right_name = right_name
           @keep = keep
-          @conflicts = T.let([], T::Array[Conflict])
+          @conflicts = [] #: Array[Conflict]
         end
 
         # @override
@@ -245,7 +245,7 @@ module RBI
         # @override
         #: (Array[Node] nodes) -> void
         def visit_all(nodes)
-          last_conflict_tree = T.let(nil, T.nilable(ConflictTree))
+          last_conflict_tree = nil #: ConflictTree?
           nodes.dup.each do |node|
             if node.is_a?(ConflictTree)
               if last_conflict_tree
@@ -287,7 +287,7 @@ module RBI
 
     #: -> ConflictTree?
     def parent_conflict_tree
-      parent = T.let(parent_tree, T.nilable(Node))
+      parent = parent_tree #: Node?
       while parent
         return parent if parent.is_a?(ConflictTree)
 
@@ -555,9 +555,9 @@ module RBI
       super()
       @left_name = left_name
       @right_name = right_name
-      @left = T.let(Tree.new, Tree)
+      @left = Tree.new #: Tree
       @left.parent_tree = self
-      @right = T.let(Tree.new, Tree)
+      @right = Tree.new #: Tree
       @right.parent_tree = self
     end
   end

--- a/lib/rbi/rewriters/nest_top_level_members.rb
+++ b/lib/rbi/rewriters/nest_top_level_members.rb
@@ -24,7 +24,7 @@ module RBI
       def initialize
         super
 
-        @top_level_object_class = T.let(nil, T.nilable(Class))
+        @top_level_object_class = nil #: Class?
       end
 
       # @override

--- a/lib/rbi/rewriters/remove_known_definitions.rb
+++ b/lib/rbi/rewriters/remove_known_definitions.rb
@@ -53,7 +53,7 @@ module RBI
       def initialize(index)
         super()
         @index = index
-        @operations = T.let([], T::Array[Operation])
+        @operations = [] #: Array[Operation]
       end
 
       class << self

--- a/lib/rbi/rewriters/translate_rbs_sigs.rb
+++ b/lib/rbi/rewriters/translate_rbs_sigs.rb
@@ -35,7 +35,7 @@ module RBI
         comments = node.comments.dup
         node.comments.clear
 
-        rbs_sigs = T.let([], T::Array[RBSComment])
+        rbs_sigs = [] #: Array[RBSComment]
 
         comments.each do |comment|
           case comment

--- a/lib/rbi/type.rb
+++ b/lib/rbi/type.rb
@@ -285,7 +285,7 @@ module RBI
       def initialize(name, *params)
         super()
         @name = name
-        @params = T.let(params, T::Array[Type])
+        @params = params #: Array[Type]
       end
 
       # @override
@@ -395,9 +395,9 @@ module RBI
       #: -> void
       def initialize
         super
-        @proc_params = T.let({}, T::Hash[Symbol, Type])
-        @proc_returns = T.let(Type.void, Type)
-        @proc_bind = T.let(nil, T.nilable(Type))
+        @proc_params = {} #: Hash[Symbol, Type]
+        @proc_returns = Type.void #: Type
+        @proc_bind = nil #: Type?
       end
 
       # @override
@@ -596,7 +596,7 @@ module RBI
           end
         end
 
-        is_nilable = T.let(false, T::Boolean)
+        is_nilable = false #: bool
 
         types = flattened.filter_map do |type|
           case type
@@ -693,7 +693,7 @@ module RBI
 
     #: -> void
     def initialize
-      @nilable = T.let(false, T::Boolean)
+      @nilable = false #: bool
     end
 
     # Returns a new type that is `nilable` if it is not already.

--- a/lib/rbi/type_parser.rb
+++ b/lib/rbi/type_parser.rb
@@ -261,8 +261,8 @@ module RBI
 
       #: (Prism::CallNode node) -> Array[Prism::Node]
       def call_chain(node)
-        call_chain = T.let([node], T::Array[Prism::Node])
-        receiver = T.let(node.receiver, T.nilable(Prism::Node))
+        call_chain = [node] #: Array[Prism::Node]
+        receiver = node.receiver #: Prism::Node?
         while receiver
           call_chain.prepend(receiver)
           break unless receiver.is_a?(Prism::CallNode)

--- a/sorbet/config
+++ b/sorbet/config
@@ -3,3 +3,4 @@
 --ignore=rbi/rbi.rbi
 --enable-experimental-requires-ancestor
 --enable-experimental-rbs-signatures
+--enable-experimental-rbs-assertions


### PR DESCRIPTION
Using `spoom srb assertions translate` all assertions like:

```rb
x = T.let(foo, String)
```

can be translated to:

```rb
x = foo #: String
```

and understood by Sorbet with the option `--enable-experimental-rbs-assertions`.