### PR TITLE
Const holds a type rather than a value

### DIFF
--- a/lib/rbi/model.rb
+++ b/lib/rbi/model.rb
@@ -269,13 +269,16 @@ module RBI
 
   class Const < NodeWithComments
     #: String
-    attr_reader :name, :value
+    attr_reader :name
 
-    #: (String name, String value, ?loc: Loc?, ?comments: Array[Comment]) ?{ (Const node) -> void } -> void
-    def initialize(name, value, loc: nil, comments: [], &block)
+    #: (String | Type)?
+    attr_reader :type
+
+    #: (String name, (String | Type)? type, ?loc: Loc?, ?comments: Array[Comment]) ?{ (Const node) -> void } -> void
+    def initialize(name, type: nil, loc: nil, comments: [], &block)
       super(loc: loc, comments: comments)
       @name = name
-      @value = value
+      @type = type
       block&.call(self)
     end
 

--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -233,7 +233,12 @@ module RBI
       print_loc(node)
       visit_all(node.comments)
 
-      printl("#{node.name} = #{node.value}")
+      type = node.type
+      if type
+        printl("#{node.name} = T.let(T.unsafe(nil), #{type})")
+      else
+        printl("#{node.name} = T.let(T.unsafe(nil), T.untyped)")
+      end
     end
 
     # @override
@@ -685,13 +690,6 @@ module RBI
         node.comments.empty? && node.empty?
       when Attr
         node.comments.empty? && node.sigs.empty?
-      when Const
-        return false unless node.comments.empty?
-
-        loc = node.loc
-        return true unless loc
-
-        loc.begin_line == loc.end_line
       when Method
         node.comments.empty? && node.sigs.empty? && node.params.all? { |p| p.comments.empty? }
       when Sig

--- a/lib/rbi/rbs_printer.rb
+++ b/lib/rbi/rbs_printer.rb
@@ -229,10 +229,9 @@ module RBI
       print_loc(node)
       visit_all(node.comments)
 
-      type = parse_t_let(node.value)
+      type = node.type
       if type
-        type = parse_type(type)
-        printl("#{node.name}: #{type.rbs_string}")
+        printl("#{node.name}: #{parse_type(type).rbs_string}")
       else
         printl("#{node.name}: untyped")
       end
@@ -852,30 +851,6 @@ module RBI
       Type.parse_string(type)
     rescue Type::Error => e
       raise Error, "Failed to parse type `#{type}` (#{e.message})"
-    end
-
-    # Parse a string containing a `T.let(x, X)` and extract the type
-    #
-    # Returns `nil` is the string is not a `T.let`.
-    #: (String? code) -> String?
-    def parse_t_let(code)
-      return unless code
-
-      res = Prism.parse(code)
-      return unless res.success?
-
-      node = res.value
-      return unless node.is_a?(Prism::ProgramNode)
-
-      node = node.statements.body.first
-      return unless node.is_a?(Prism::CallNode)
-      return unless node.name == :let
-      return unless node.receiver&.slice =~ /^(::)?T$/
-
-      arguments = node.arguments&.arguments
-      return unless arguments
-
-      arguments.fetch(1, nil)&.slice
     end
   end
 

--- a/lib/rbi/rewriters/merge_trees.rb
+++ b/lib/rbi/rewriters/merge_trees.rb
@@ -384,7 +384,7 @@ module RBI
     # @override
     #: (Node other) -> bool
     def compatible_with?(other)
-      other.is_a?(Const) && name == other.name && value == other.value
+      other.is_a?(Const) && name == other.name && type == other.type
     end
   end
 

--- a/test/rbi/model_test.rb
+++ b/test/rbi/model_test.rb
@@ -42,7 +42,7 @@ module RBI
           tree << SingletonClass.new do |node|
             node.comments << Comment.new("comment")
           end
-          tree << Const.new("C", "42") do |node|
+          tree << Const.new("C") do |node|
             node.comments << Comment.new("comment")
           end
           tree << AttrAccessor.new(:a1) do |node|
@@ -135,7 +135,7 @@ module RBI
         class << self; end
 
         # comment
-        C = 42
+        C = T.let(T.unsafe(nil), T.untyped)
 
         # comment
         attr_accessor :a1
@@ -270,19 +270,19 @@ module RBI
       cls1 << singleton_class
       assert_equal("::Foo::Bar::<self>", singleton_class.fully_qualified_name)
 
-      const = Const.new("Foo", "42")
+      const = Const.new("Foo")
       assert_equal("::Foo", const.fully_qualified_name)
 
       mod << const
       assert_equal("::Foo::Foo", const.fully_qualified_name)
 
-      const2 = Const.new("Foo::Bar", "42")
+      const2 = Const.new("Foo::Bar")
       assert_equal("::Foo::Bar", const2.fully_qualified_name)
 
       mod << const2
       assert_equal("::Foo::Foo::Bar", const2.fully_qualified_name)
 
-      const3 = Const.new("::Foo::Bar", "42")
+      const3 = Const.new("::Foo::Bar")
       assert_equal("::Foo::Bar", const3.fully_qualified_name)
 
       mod << const3
@@ -344,13 +344,13 @@ module RBI
       cls << singleton_class
       assert_equal("::Foo::Bar::<self>", singleton_class.to_s)
 
-      const = Const.new("Foo", "42")
+      const = Const.new("Foo")
       assert_equal("::Foo", const.to_s)
 
       mod << const
       assert_equal("::Foo::Foo", const.to_s)
 
-      const2 = Const.new("Foo::Bar", "42")
+      const2 = Const.new("Foo::Bar")
       assert_equal("::Foo::Bar", const2.to_s)
 
       mod << const2

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -75,17 +75,26 @@ module RBI
     def test_parse_constants
       rbi = <<~RBI
         Foo = 42
-        Bar = "foo"
+        Bar = T.let("foo", String)
         Baz = Bar
         A = nil
         B = :s
-        C = T.nilable(String)
-        D = A::B::C
+        C = T.let(nil, T.nilable(String))
+        D = T.let(A::B::C, T.class_of(A::B::C))
         A::B::C = Foo
       RBI
 
       tree = parse_rbi(rbi)
-      assert_equal(rbi, tree.string)
+      assert_equal(<<~RBI, tree.string)
+        Foo = T.let(T.unsafe(nil), T.untyped)
+        Bar = T.let(T.unsafe(nil), String)
+        Baz = T.let(T.unsafe(nil), T.untyped)
+        A = T.let(T.unsafe(nil), T.untyped)
+        B = T.let(T.unsafe(nil), T.untyped)
+        C = T.let(T.unsafe(nil), T.nilable(String))
+        D = T.let(T.unsafe(nil), T.class_of(A::B::C))
+        A::B::C = T.let(T.unsafe(nil), T.untyped)
+      RBI
     end
 
     def test_parse_constants_with_heredoc
@@ -130,7 +139,16 @@ module RBI
       RBI
 
       tree = parse_rbi(rbi)
-      assert_equal(rbi, tree.string)
+      assert_equal(<<~RBI, tree.string)
+        A = T.let(T.unsafe(nil), T.untyped)
+        B = T.let(T.unsafe(nil), T.untyped)
+        C = T.let(T.unsafe(nil), T.untyped)
+        D = T.let(T.unsafe(nil), T.untyped)
+        E = T.let(T.unsafe(nil), String)
+        F = T.let(T.unsafe(nil), T.untyped)
+        G = T.let(T.unsafe(nil), T.untyped)
+        H = T.let(T.unsafe(nil), T.untyped)
+      RBI
     end
 
     def test_parse_constants_multiline_calls
@@ -144,7 +162,9 @@ module RBI
       RBI
 
       tree = parse_rbi(rbi)
-      assert_equal(rbi, tree.string)
+      assert_equal(<<~RBI, tree.string)
+        A = T.let(T.unsafe(nil), T.untyped)
+      RBI
     end
 
     def test_parse_constants_with_newlines
@@ -628,13 +648,13 @@ module RBI
       tree = parse_rbi(rbi)
       assert_equal(<<~RBI, tree.string(print_locs: true))
         # -:1:0-1:8
-        Foo = 42
+        Foo = T.let(T.unsafe(nil), T.untyped)
         # -:2:0-2:11
-        Bar = "foo"
+        Bar = T.let(T.unsafe(nil), T.untyped)
         # -:3:0-3:11
-        ::Baz = Bar
+        ::Baz = T.let(T.unsafe(nil), T.untyped)
         # -:4:0-4:13
-        A::B::C = Foo
+        A::B::C = T.let(T.unsafe(nil), T.untyped)
       RBI
     end
 
@@ -971,7 +991,7 @@ module RBI
             attr_reader :a
 
             # E comment
-            E = _
+            E = T.let(T.unsafe(nil), T.untyped)
           end
         end
       RBI

--- a/test/rbi/printer_test.rb
+++ b/test/rbi/printer_test.rb
@@ -96,14 +96,14 @@ module RBI
 
     def test_print_constants
       rbi = Tree.new
-      rbi << Const.new("Foo", "42")
-      rbi << Const.new("Bar", "'foo'")
-      rbi << Const.new("Baz", "Bar")
+      rbi << Const.new("Foo")
+      rbi << Const.new("Bar", type: nil)
+      rbi << Const.new("Baz", type: "String")
 
       assert_equal(<<~RBI, rbi.string)
-        Foo = 42
-        Bar = 'foo'
-        Baz = Bar
+        Foo = T.let(T.unsafe(nil), T.untyped)
+        Bar = T.let(T.unsafe(nil), T.untyped)
+        Baz = T.let(T.unsafe(nil), String)
       RBI
     end
 
@@ -401,7 +401,7 @@ module RBI
       rbi << Module.new("Foo", comments: comments_single)
       rbi << Class.new("Bar", comments: comments_multi)
       rbi << SingletonClass.new(comments: comments_single)
-      rbi << Const.new("Foo", "42", comments: comments_multi)
+      rbi << Const.new("Foo", comments: comments_multi)
       rbi << Include.new("A", comments: comments_single)
       rbi << Extend.new("A", comments: comments_multi)
 
@@ -442,7 +442,7 @@ module RBI
 
         # This is a
         # Multiline Comment
-        Foo = 42
+        Foo = T.let(T.unsafe(nil), T.untyped)
 
         # This is a single line comment
         include A
@@ -1092,7 +1092,7 @@ module RBI
       rbi << SingletonClass.new(loc: loc)
       rbi << TEnum.new("TE", loc: loc)
       rbi << TStruct.new("TS", loc: loc)
-      rbi << Const.new("C", "42", loc: loc)
+      rbi << Const.new("C", loc: loc)
       rbi << Extend.new("E", loc: loc)
       rbi << Include.new("I", loc: loc)
       rbi << Send.new("foo", loc: loc)
@@ -1113,10 +1113,8 @@ module RBI
         class TE < T::Enum; end
         # file.rbi:1:3-2:4
         class TS < T::Struct; end
-
         # file.rbi:1:3-2:4
-        C = 42
-
+        C = T.let(T.unsafe(nil), T.untyped)
         # file.rbi:1:3-2:4
         extend E
         # file.rbi:1:3-2:4

--- a/test/rbi/rewriters/flatten_singleton_methods_test.rb
+++ b/test/rbi/rewriters/flatten_singleton_methods_test.rb
@@ -125,7 +125,7 @@ module RBI
     def test_flatten_does_not_flatten_other_nodes
       rbi = <<~RBI
         module Foo
-          C1 = 42
+          C1 = T.let(T.unsafe(nil), T.untyped)
           module M1; end
           abtract!
         end

--- a/test/rbi/rewriters/group_nodes_test.rb
+++ b/test/rbi/rewriters/group_nodes_test.rb
@@ -61,7 +61,7 @@ module RBI
 
         class << self; end
 
-        C = 42
+        C = T.let(T.unsafe(nil), T.untyped)
         module S1; end
         class S2; end
         S3 = ::Struct.new
@@ -109,8 +109,8 @@ module RBI
           module Scope2
             class << self; end
 
-            C1 = 42
-            C2 = 42
+            C1 = T.let(T.unsafe(nil), T.untyped)
+            C2 = T.let(T.unsafe(nil), T.untyped)
             module M1; end
 
             Scope3 = ::Struct.new do
@@ -170,7 +170,7 @@ module RBI
 
         class << self; end
 
-        C = 42
+        C = T.let(T.unsafe(nil), T.untyped)
         module S1; end
         class S2; end
         S3 = ::Struct.new
@@ -295,7 +295,7 @@ module RBI
 
           class << self; end
 
-          C = 42
+          C = T.let(T.unsafe(nil), T.untyped)
           module S1; end
           class S2; end
           S3 = ::Struct.new
@@ -368,8 +368,8 @@ module RBI
 
         class << self; end
 
-        C1 = 42
-        C2 = 42
+        C1 = T.let(T.unsafe(nil), T.untyped)
+        C2 = T.let(T.unsafe(nil), T.untyped)
         class S1; end
         module S2; end
         S3 = ::Struct.new
@@ -383,7 +383,7 @@ module RBI
     def test_group_sort_nested_groups
       rbi = Tree.new
       sscope = Class.new("Scope2.1")
-      sscope << Const.new("C2", "42")
+      sscope << Const.new("C2")
       sscope << Module.new("S2")
       sscope << Method.new("m2")
       sscope << Include.new("I2")
@@ -395,7 +395,7 @@ module RBI
       sscope << TStructConst.new("SC2", "Type")
       sscope << TEnum.new("TE2")
       sscope << TStruct.new("TS2")
-      sscope << Const.new("C1", "42")
+      sscope << Const.new("C1")
       sscope << Class.new("S1")
       sscope << Method.new("m1")
       sscope << Include.new("I1")
@@ -413,7 +413,7 @@ module RBI
 
       scope = Class.new("Scope2")
       scope << sscope
-      scope << Const.new("C2", "42")
+      scope << Const.new("C2")
       scope << Module.new("S2")
       scope << Method.new("m2")
       scope << Include.new("I2")
@@ -425,7 +425,7 @@ module RBI
       scope << TStructConst.new("SC2", "Type")
       scope << TEnum.new("TE2")
       scope << TStruct.new("TS2")
-      scope << Const.new("C1", "42")
+      scope << Const.new("C1")
       scope << Class.new("S1")
       scope << Method.new("m1")
       scope << Include.new("I1")
@@ -443,7 +443,7 @@ module RBI
       rbi << scope
 
       scope = Class.new("Scope1")
-      scope << Const.new("C2", "42")
+      scope << Const.new("C2")
       scope << Module.new("S2")
       scope << Method.new("m2")
       scope << Include.new("I2")
@@ -455,7 +455,7 @@ module RBI
       scope << TStructConst.new("SC2", "Type")
       scope << TEnum.new("TE2")
       scope << TStruct.new("TS2")
-      scope << Const.new("C1", "42")
+      scope << Const.new("C1")
       scope << Class.new("S1")
       scope << Method.new("m1")
       scope << Include.new("I1")
@@ -502,8 +502,8 @@ module RBI
           def m1; end
           def m2; end
 
-          C1 = 42
-          C2 = 42
+          C1 = T.let(T.unsafe(nil), T.untyped)
+          C2 = T.let(T.unsafe(nil), T.untyped)
           class S1; end
           module S2; end
           S3 = ::Struct.new
@@ -539,8 +539,8 @@ module RBI
           def m1; end
           def m2; end
 
-          C1 = 42
-          C2 = 42
+          C1 = T.let(T.unsafe(nil), T.untyped)
+          C2 = T.let(T.unsafe(nil), T.untyped)
           class S1; end
           module S2; end
           S3 = ::Struct.new
@@ -571,8 +571,8 @@ module RBI
             def m1; end
             def m2; end
 
-            C1 = 42
-            C2 = 42
+            C1 = T.let(T.unsafe(nil), T.untyped)
+            C2 = T.let(T.unsafe(nil), T.untyped)
             class S1; end
             module S2; end
             S3 = ::Struct.new

--- a/test/rbi/rewriters/merge_trees_test.rb
+++ b/test/rbi/rewriters/merge_trees_test.rb
@@ -127,11 +127,11 @@ module RBI
       res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         class A
-          A = 42
-          B = 42
+          A = T.let(T.unsafe(nil), T.untyped)
+          B = T.let(T.unsafe(nil), T.untyped)
         end
 
-        B = 42
+        B = T.let(T.unsafe(nil), T.untyped)
       RBI
     end
 
@@ -517,28 +517,28 @@ module RBI
     def test_merge_create_conflict_tree_for_scopes
       tree1 = parse_rbi(<<~RBI)
         class Foo
-          A = 10
+          A = T.let(T.unsafe(nil), T.untyped)
         end
 
         module Bar
-          B = 10
+          B = T.let(T.unsafe(nil), T.untyped)
 
           class Baz < Foo
-            C = 10
+            C = T.let(T.unsafe(nil), T.untyped)
           end
         end
       RBI
 
       tree2 = parse_rbi(<<~RBI)
         module Foo
-          A = 10
+          A = T.let(T.unsafe(nil), T.untyped)
         end
 
         class Bar
-          B = 10
+          B = T.let(T.unsafe(nil), T.untyped)
 
           class Baz < Bar
-            C = 10
+            C = T.let(T.unsafe(nil), T.untyped)
           end
         end
       RBI
@@ -550,7 +550,7 @@ module RBI
         =======
         module Foo
         >>>>>>> right
-          A = 10
+          A = T.let(T.unsafe(nil), T.untyped)
         end
 
         <<<<<<< left
@@ -558,14 +558,14 @@ module RBI
         =======
         class Bar
         >>>>>>> right
-          B = 10
+          B = T.let(T.unsafe(nil), T.untyped)
 
           <<<<<<< left
           class Baz < Foo
           =======
           class Baz < Bar
           >>>>>>> right
-            C = 10
+            C = T.let(T.unsafe(nil), T.untyped)
           end
         end
       RBI
@@ -627,31 +627,44 @@ module RBI
       tree1 = parse_rbi(<<~RBI)
         class Foo
           A = 10
+          B = T.let(T.unsafe(nil), Integer)
+          C = T.let(T.unsafe(nil), String)
         end
-        B = 10
+        A = 10
+        B = T.let(T.unsafe(nil), Integer)
+        C = T.let(T.unsafe(nil), String)
       RBI
 
       tree2 = parse_rbi(<<~RBI)
         class Foo
           A = 42
+          B = T.let(T.unsafe(nil), String)
+          C = T.let(T.unsafe(nil), String)
         end
-        B = 42
+        A = 42
+        B = T.let(T.unsafe(nil), String)
+        C = T.let(T.unsafe(nil), String)
       RBI
 
       res = tree1.merge(tree2)
       assert_equal(<<~RBI, res.string)
         class Foo
+          A = T.let(T.unsafe(nil), T.untyped)
           <<<<<<< left
-          A = 10
+          B = T.let(T.unsafe(nil), Integer)
           =======
-          A = 42
+          B = T.let(T.unsafe(nil), String)
           >>>>>>> right
+          C = T.let(T.unsafe(nil), String)
         end
+
+        A = T.let(T.unsafe(nil), T.untyped)
         <<<<<<< left
-        B = 10
+        B = T.let(T.unsafe(nil), Integer)
         =======
-        B = 42
+        B = T.let(T.unsafe(nil), String)
         >>>>>>> right
+        C = T.let(T.unsafe(nil), String)
       RBI
     end
 
@@ -689,7 +702,7 @@ module RBI
         <<<<<<< left
         module C; end
         =======
-        C = 42
+        C = T.let(T.unsafe(nil), T.untyped)
         >>>>>>> right
         <<<<<<< left
         class D < A; end
@@ -985,16 +998,16 @@ module RBI
     def test_merge_return_the_list_of_conflicts
       tree1 = parse_rbi(<<~RBI)
         class Foo
-          A = 10
+          A = T.let(T.unsafe(nil), T.untyped)
         end
-        B = 10
+        B = T.let(T.unsafe(nil), T.untyped)
       RBI
 
       tree2 = parse_rbi(<<~RBI)
         module Foo
-          A = 42
+          A = T.let(T.unsafe(nil), String)
         end
-        B = 42
+        B = T.let(T.unsafe(nil), String)
       RBI
 
       merged_tree = tree1.merge(tree2)
@@ -1009,7 +1022,7 @@ module RBI
     def test_merge_keep_left
       tree1 = parse_rbi(<<~RBI)
         module Foo
-          A = 10
+          A = T.let(T.unsafe(nil), T.untyped)
 
           class Bar
             def m1; end
@@ -1024,7 +1037,7 @@ module RBI
 
       tree2 = parse_rbi(<<~RBI)
         module Foo
-          A = 42
+          A = T.let(T.unsafe(nil), String)
 
           module Bar
             def m1(x); end
@@ -1041,7 +1054,7 @@ module RBI
 
       assert_equal(<<~RBI, res.string)
         module Foo
-          A = 10
+          A = T.let(T.unsafe(nil), T.untyped)
 
           class Bar
             def m1; end
@@ -1059,7 +1072,7 @@ module RBI
     def test_merge_keep_right
       tree1 = parse_rbi(<<~RBI)
         module Foo
-          A = 10
+          A = T.let(T.unsafe(nil), T.untyped)
 
           class Bar
             def m1; end
@@ -1074,7 +1087,7 @@ module RBI
 
       tree2 = parse_rbi(<<~RBI)
         module Foo
-          A = 42
+          A = T.let(T.unsafe(nil), String)
 
           module Bar
             def m1(x); end
@@ -1091,7 +1104,7 @@ module RBI
 
       assert_equal(<<~RBI, res.string)
         module Foo
-          A = 42
+          A = T.let(T.unsafe(nil), String)
 
           module Bar
             def m1(x); end

--- a/test/rbi/rewriters/nest_singleton_methods_test.rb
+++ b/test/rbi/rewriters/nest_singleton_methods_test.rb
@@ -92,7 +92,7 @@ module RBI
     def test_nest_does_not_nest_other_nodes
       rbi = <<~RBI
         module Foo
-          C1 = 42
+          C1 = T.let(T.unsafe(nil), T.untyped)
           module M1; end
           h1!
         end

--- a/test/rbi/rewriters/remove_known_definitions_test.rb
+++ b/test/rbi/rewriters/remove_known_definitions_test.rb
@@ -19,7 +19,7 @@ module RBI
           def bar; end
         end
 
-        BAZ = 42
+        BAZ = T.let(T.unsafe(nil), T.untyped)
       RBI
 
       original = parse_rbi(shim)
@@ -97,7 +97,7 @@ module RBI
       assert_equal(<<~RBI, cleaned.string)
         class Foo
           def bar; end
-          BAR = 42
+          BAR = T.let(T.unsafe(nil), T.untyped)
         end
       RBI
 

--- a/test/rbi/rewriters/sort_nodes_test.rb
+++ b/test/rbi/rewriters/sort_nodes_test.rb
@@ -17,9 +17,9 @@ module RBI
       tree.sort_nodes!
 
       assert_equal(<<~RBI, tree.string)
-        A = 42
-        B = 42
-        C = 42
+        A = T.let(T.unsafe(nil), T.untyped)
+        B = T.let(T.unsafe(nil), T.untyped)
+        C = T.let(T.unsafe(nil), T.untyped)
       RBI
     end
 
@@ -84,12 +84,12 @@ module RBI
       tree.sort_nodes!
 
       assert_equal(<<~RBI, tree.string)
-        A = 42
+        A = T.let(T.unsafe(nil), T.untyped)
         module A; end
         class A; end
         class B; end
         module B; end
-        B = 42
+        B = T.let(T.unsafe(nil), T.untyped)
       RBI
     end
 
@@ -259,7 +259,7 @@ module RBI
         def m1; end
         def m2; end
         def self.m3; end
-        A = 42
+        A = T.let(T.unsafe(nil), T.untyped)
         module B; end
         class C < T::Enum; end
         class D < T::Struct; end
@@ -319,7 +319,7 @@ module RBI
         class << self; end
         class << self; end
         class << self; end
-        A = 42
+        A = T.let(T.unsafe(nil), T.untyped)
         module B; end
         class C < T::Enum; end
         class D < T::Struct; end


### PR DESCRIPTION
Follow up on https://github.com/Shopify/rbi/pull/408#issuecomment-2755037767.

In the context of an RBI file, does it really make sense to hold the value of constants?

This PR proposes to change `Const` so it only stores the type we find a the `T.let` if any.

So this:

```rb
A = 42
B = T.let(42, Integer)
C = foo(T.let(42, Integer))
```

gives this:

```rb
A = T.let(T.unsafe(nil), T.untyped)
B = T.let(T.unsafe(nil), Integer)
C = T.let(T.unsafe(nil), T.untyped)
```

This is quite a breaking change for the gem's API and should be released with at least a minor version bump.

I think we can apply the same logic to optional positional and keyword parameters 🤔 