### PR TITLE
Handle multiline RBS signatures

### DIFF
--- a/lib/rbi/loc.rb
+++ b/lib/rbi/loc.rb
@@ -31,6 +31,17 @@ module RBI
       @end_column = end_column
     end
 
+    #: (Loc) -> Loc
+    def join(other)
+      Loc.new(
+        file: file,
+        begin_line: begin_line,
+        begin_column: begin_column,
+        end_line: other.end_line,
+        end_column: other.end_column,
+      )
+    end
+
     #: -> String
     def to_s
       if end_line && end_column

--- a/rbi/rbi.rbi
+++ b/rbi/rbi.rbi
@@ -667,6 +667,9 @@ class RBI::Loc
   sig { returns(T.nilable(::String)) }
   def file; end
 
+  sig { params(other: ::RBI::Loc).returns(::RBI::Loc) }
+  def join(other); end
+
   sig { returns(T.nilable(::String)) }
   def source; end
 
@@ -1485,31 +1488,11 @@ class RBI::RBS::MethodTypeTranslator::Error < ::RBI::Error; end
 
 class RBI::RBS::TypeTranslator
   class << self
-    # : (
-    # |   ::RBS::Types::Alias |
-    # |   ::RBS::Types::Bases::Any |
-    # |   ::RBS::Types::Bases::Bool |
-    # |   ::RBS::Types::Bases::Bottom |
-    # |   ::RBS::Types::Bases::Class |
-    # |   ::RBS::Types::Bases::Instance |
-    # |   ::RBS::Types::Bases::Nil |
-    # |   ::RBS::Types::Bases::Self |
-    # |   ::RBS::Types::Bases::Top |
-    # |   ::RBS::Types::Bases::Void |
-    # |   ::RBS::Types::ClassSingleton |
-    # |   ::RBS::Types::ClassInstance |
-    # |   ::RBS::Types::Function |
-    # |   ::RBS::Types::Interface |
-    # |   ::RBS::Types::Intersection |
-    # |   ::RBS::Types::Literal |
-    # |   ::RBS::Types::Optional |
-    # |   ::RBS::Types::Proc |
-    # |   ::RBS::Types::Record |
-    # |   ::RBS::Types::Tuple |
-    # |   ::RBS::Types::Union |
-    # |   ::RBS::Types::UntypedFunction |
-    # |   ::RBS::Types::Variable
-    # | ) -> Type
+    sig do
+      params(
+        type: T.any(::RBS::Types::Alias, ::RBS::Types::Bases::Any, ::RBS::Types::Bases::Bool, ::RBS::Types::Bases::Bottom, ::RBS::Types::Bases::Class, ::RBS::Types::Bases::Instance, ::RBS::Types::Bases::Nil, ::RBS::Types::Bases::Self, ::RBS::Types::Bases::Top, ::RBS::Types::Bases::Void, ::RBS::Types::ClassInstance, ::RBS::Types::ClassSingleton, ::RBS::Types::Function, ::RBS::Types::Interface, ::RBS::Types::Intersection, ::RBS::Types::Literal, ::RBS::Types::Optional, ::RBS::Types::Proc, ::RBS::Types::Record, ::RBS::Types::Tuple, ::RBS::Types::Union, ::RBS::Types::UntypedFunction, ::RBS::Types::Variable)
+      ).returns(::RBI::Type)
+    end
     def translate(type); end
 
     private
@@ -1537,10 +1520,11 @@ class RBI::RBSPrinter < ::RBI::Visitor
       out: T.any(::IO, ::StringIO),
       indent: ::Integer,
       print_locs: T::Boolean,
-      positional_names: T::Boolean
+      positional_names: T::Boolean,
+      max_line_length: T.nilable(::Integer)
     ).void
   end
-  def initialize(out: T.unsafe(nil), indent: T.unsafe(nil), print_locs: T.unsafe(nil), positional_names: T.unsafe(nil)); end
+  def initialize(out: T.unsafe(nil), indent: T.unsafe(nil), print_locs: T.unsafe(nil), positional_names: T.unsafe(nil), max_line_length: T.unsafe(nil)); end
 
   sig { returns(::Integer) }
   def current_indent; end
@@ -1557,6 +1541,9 @@ class RBI::RBSPrinter < ::RBI::Visitor
   # Printing
   sig { void }
   def indent; end
+
+  sig { returns(T.nilable(::Integer)) }
+  def max_line_length; end
 
   sig { returns(T::Boolean) }
   def positional_names; end
@@ -1582,6 +1569,12 @@ class RBI::RBSPrinter < ::RBI::Visitor
 
   sig { params(node: ::RBI::Method, sig: ::RBI::Sig).void }
   def print_method_sig(node, sig); end
+
+  sig { params(node: ::RBI::Method, sig: ::RBI::Sig).void }
+  def print_method_sig_inline(node, sig); end
+
+  sig { params(node: ::RBI::Method, sig: ::RBI::Sig).void }
+  def print_method_sig_multiline(node, sig); end
 
   # Print a string with indentation and `\n` at the end.
   sig { params(string: ::String).void }
@@ -3454,8 +3447,8 @@ class RBI::TypeMember < ::RBI::NodeWithComments
 end
 
 class RBI::TypePrinter
-  sig { void }
-  def initialize; end
+  sig { params(max_line_length: T.nilable(::Integer)).void }
+  def initialize(max_line_length: T.unsafe(nil)); end
 
   sig { returns(::String) }
   def string; end

--- a/test/rbi/loc_test.rb
+++ b/test/rbi/loc_test.rb
@@ -38,6 +38,12 @@ module RBI
       assert_equal("foo.rb:1:2", loc.to_s)
     end
 
+    def test_loc_join_with_other_loc
+      loc = Loc.new(file: "foo.rb", begin_line: 1, begin_column: 1, end_line: 2, end_column: 2)
+      other = Loc.new(file: "foo.rb", begin_line: 2, begin_column: 2, end_line: 3, end_column: 3)
+      assert_equal("foo.rb:1:1-3:3", loc.join(other).to_s)
+    end
+
     def test_loc_source_without_file_returns_nil
       loc = Loc.new(file: nil)
       assert_nil(loc.source)

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -1176,6 +1176,46 @@ module RBI
       RBI
     end
 
+    def test_parse_rbs_comments_multiline
+      rbi = <<~RBI
+        #: [
+        #|    A < Numeric
+        #| ]
+        class Foo
+          #: (
+          #|    Integer
+          #| ) -> Integer
+          def bar; end
+
+          #| this comment is not a continuation
+          #| and should be kept
+          def baz; end
+
+          # this one
+          #| as
+          #| well
+          def baz; end
+        end
+      RBI
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string)
+        #: [A < Numeric]
+        class Foo
+          #: (Integer) -> Integer
+          def bar; end
+
+          # | this comment is not a continuation
+          # | and should be kept
+          def baz; end
+
+          # this one
+          # | as
+          # | well
+          def baz; end
+        end
+      RBI
+    end
+
     def test_parse_rbs_comments_ignores_rdoc_directives
       rbi = <<~RBI
         #:nodoc:

--- a/test/rbi/rewriters/translate_rbs_sigs_test.rb
+++ b/test/rbi/rewriters/translate_rbs_sigs_test.rb
@@ -70,6 +70,28 @@ module RBI
       RBI
     end
 
+    def test_translate_multiline_sigs
+      tree = rewrite(<<~RBI)
+        #: Array[
+        #|   Integer
+        #| ]
+        attr_reader :a
+
+        #: (
+        #|   Integer
+        #| ) -> Integer
+        def foo(a); end
+      RBI
+
+      assert_equal(<<~RBI, tree)
+        sig { returns(T::Array[Integer]) }
+        attr_reader :a
+
+        sig { params(a: Integer).returns(Integer) }
+        def foo(a); end
+      RBI
+    end
+
     private
 
     #: (String) -> String


### PR DESCRIPTION
So this is parsed properly:

```rb
#: (
#|   Integer
#| ) -> void
def foo(x); end
```