### PR TITLE
Fix parsing of `posts` parameters

### DIFF
--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -185,6 +185,15 @@ module RBI
       assert_equal(rbi, tree.string)
     end
 
+    def test_parse_methods_with_vararg_followed_by_positional_arg
+      rbi = <<~RBI
+        def m1(*a, b); end
+      RBI
+
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
+    end
+
     def test_parse_sigs
       rbi = <<~RBI
         sig { void }

--- a/test/rbi/rbs_printer_test.rb
+++ b/test/rbi/rbs_printer_test.rb
@@ -320,6 +320,17 @@ module RBI
       RBI
     end
 
+    def test_print_methods_with_vararg_followed_by_positional_arg
+      rbi = parse_rbi(<<~RBI)
+        sig { params(a: Integer, b: String).void }
+        def foo(*a, b); end
+      RBI
+
+      assert_equal(<<~RBS, rbi.rbs_string)
+        def foo: (*Integer a, String b) -> void
+      RBS
+    end
+
     def test_print_methods_with_signature_params_mismatch_raises_error
       rbi = parse_rbi(<<~RBI)
         sig { params(a: A).returns(R) }


### PR DESCRIPTION
Before this PR, `RBI::Parser` was incorrectly parsing this:

```rb
def m1(*a, b); end
```

into this, notice the missing `b` parameter:

```rb
def m1(*a); end
```

because we did not consider `posts` parameters.