### PR TITLE
Remove dead method: `RBI::Visibility::private?`

### DIFF
--- a/lib/rbi/model.rb
+++ b/lib/rbi/model.rb
@@ -716,11 +716,6 @@ module RBI
     def protected?
       visibility == :protected
     end
-
-    #: -> bool
-    def private?
-      visibility == :private
-    end
   end
 
   class Public < Visibility


### PR DESCRIPTION
This method appears to be unused and could be removed.

Before approving this pull-request, please double-check that it is indeed unused.

  - [Search for `private?` on GitHub for this repo](https://github.com/search?q=repo:shopify/rbi%20private?&type=code)
  - [Search for `private?` on GitHub for all Shopify repos](https://github.com/search?q=org:shopify%20private?&type=code)

If this code is actually used, please add a comment explaining why and close this pull-request.

You can find more unused code in your project at: https://code.shopify.io/projects/shopify/rbi/code_removals/spoom

_Note: closing this pull-request will mark the code as ignored and exclude it from future dead code detection._

