### PR TITLE
Remove dead method: `RBI::Type::eql?`

### DIFF
--- a/lib/rbi/type.rb
+++ b/lib/rbi/type.rb
@@ -734,11 +734,6 @@ module RBI
     #: (BasicObject) -> bool
     def ==(other); end
 
-    #: (BasicObject other) -> bool
-    def eql?(other)
-      self == other
-    end
-
     # @override
     #: -> Integer
     def hash


### PR DESCRIPTION
This method appears to be unused and could be removed.

Before approving this pull-request, please double-check that it is indeed unused.

  - [Search for `eql?` on GitHub for this repo](https://github.com/search?q=repo:shopify/rbi%20eql?&type=code)
  - [Search for `eql?` on GitHub for all Shopify repos](https://github.com/search?q=org:shopify%20eql?&type=code)

If this code is actually used, please add a comment explaining why and close this pull-request.

You can find more unused code in your project at: https://code.shopify.io/projects/shopify/rbi/code_removals/spoom

_Note: closing this pull-request will mark the code as ignored and exclude it from future dead code detection._

