### PR TITLE
Remove dead attr_writer: `RBI::RBSPrinter::positional_names=`

### DIFF
--- a/lib/rbi/rbs_printer.rb
+++ b/lib/rbi/rbs_printer.rb
@@ -14,10 +14,8 @@ module RBI
     #: Integer
     attr_reader :current_indent
 
-    #: bool
-    attr_accessor :positional_names
-
     #: Integer?
+    attr_reader :positional_names
     attr_reader :max_line_length
 
     #: (


### PR DESCRIPTION
This attr_writer appears to be unused and could be removed.

Before approving this pull-request, please double-check that it is indeed unused.

  - [Search for `positional_names=` on GitHub for this repo](https://github.com/search?q=repo:shopify/rbi%20positional_names=&type=code)
  - [Search for `positional_names=` on GitHub for all Shopify repos](https://github.com/search?q=org:shopify%20positional_names=&type=code)

If this code is actually used, please add a comment explaining why and close this pull-request.

You can find more unused code in your project at: https://code.shopify.io/projects/shopify/rbi/code_removals/spoom

_Note: closing this pull-request will mark the code as ignored and exclude it from future dead code detection._

