### PR TITLE
Translate a leftover `T.absurd`

### DIFF
--- a/lib/rbi/rbs/type_translator.rb
+++ b/lib/rbi/rbs/type_translator.rb
@@ -85,7 +85,7 @@ module RBI
           when ::RBS::Types::Variable
             Type.type_parameter(type.name)
           else
-            T.absurd(type)
+            type #: absurd
           end
         end
 


### PR DESCRIPTION
This case should never happen since we ensure statically that all branches are covered.