### PR TITLE
Resolve scopes of referenced types when merging trees

### DIFF
--- a/lib/rbi/index.rb
+++ b/lib/rbi/index.rb
@@ -49,6 +49,7 @@ module RBI
       end
     end
 
+    #: -> String
     def to_s
       "#<RBI::Index #{@index.filter { |_, v| v.any? }.keys.sort}>"
     end

--- a/lib/rbi/index.rb
+++ b/lib/rbi/index.rb
@@ -49,6 +49,10 @@ module RBI
       end
     end
 
+    def to_s
+      "#<RBI::Index #{@index.filter { |_, v| v.any? }.keys.sort}>"
+    end
+
     private
 
     #: ((Indexable & Node) node) -> void

--- a/lib/rbi/model.rb
+++ b/lib/rbi/model.rb
@@ -297,7 +297,7 @@ module RBI
     attr_accessor :visibility
 
     #: Array[Sig]
-    attr_reader :sigs
+    attr_accessor :sigs
 
     #: (Symbol name, Array[Symbol] names, ?visibility: Visibility, ?sigs: Array[Sig], ?loc: Loc?, ?comments: Array[Comment]) -> void
     def initialize(name, names, visibility: Public.new, sigs: [], loc: nil, comments: [])

--- a/lib/rbi/rewriters/merge_trees.rb
+++ b/lib/rbi/rewriters/merge_trees.rb
@@ -39,6 +39,8 @@ module RBI
     class Merge
       ASSUME_GLOBAL_CLASS = ["String", "Symbol", "Integer", "Float", "NilClass", "TrueClass", "FalseClass"].freeze
 
+      class Error < RBI::Error; end
+
       class Keep
         NONE = new #: Keep
         LEFT = new #: Keep
@@ -301,7 +303,7 @@ module RBI
             if referent.is_a?(Scope) || referent.is_a?(Const)
               return referent
             elsif referent
-              raise "Unexpected type #{referent} for #{name} with referrer #{referrer}"
+              raise Error, "Unexpected type #{referent} for #{name} with referrer #{referrer}"
             else
               return
             end
@@ -314,7 +316,7 @@ module RBI
             if referent.is_a?(Scope) || referent.is_a?(Const)
               return referent
             elsif referent
-              raise "Unexpected type #{referent} for #{name} with referrer #{referrer}"
+              raise Error, "Unexpected type #{referent} for #{name} with referrer #{referrer}"
             end
             break unless referrer_scope
 

--- a/lib/rbi/rewriters/merge_trees.rb
+++ b/lib/rbi/rewriters/merge_trees.rb
@@ -342,7 +342,8 @@ module RBI
           when Type::Proc
             copy = Type.proc
             params = type.proc_params.transform_values { fully_qualify_type(_1, referrer:) }
-            copy.params(**params) # This should be **params but sorbet seems to get tripped up?
+            # Using unsafe below becauses splatting kwargs appears to trip up type checking
+            T.unsafe(copy).params(**params)
             copy.returns(fully_qualify_type(type.proc_returns, referrer:))
             copy.bind(fully_qualify_type(T.must(type.proc_bind), referrer:)) if type.proc_bind
             copy

--- a/lib/rbi/rewriters/merge_trees.rb
+++ b/lib/rbi/rewriters/merge_trees.rb
@@ -342,9 +342,10 @@ module RBI
           when Type::Proc
             copy = Type.proc
             params = type.proc_params.transform_values { fully_qualify_type(_1, referrer:) }
-            copy.params(*params) # This should be **params but sorbet seems to get tripped up?
+            copy.params(**params) # This should be **params but sorbet seems to get tripped up?
             copy.returns(fully_qualify_type(type.proc_returns, referrer:))
             copy.bind(fully_qualify_type(T.must(type.proc_bind), referrer:)) if type.proc_bind
+            copy
           else
             type
           end

--- a/lib/rbi/rewriters/merge_trees.rb
+++ b/lib/rbi/rewriters/merge_trees.rb
@@ -294,13 +294,13 @@ module RBI
         # when referenced from the given referrer Node. The referrer can be
         # in a different tree, but its scope chain names will be used to find
         # the referent in this merge tree.
-        #: (name: String?, referrer: Node) -> (Scope | Const)?
+        #: (name: String?, referrer: Node) -> (Scope | Const | TypeMember)?
         def lookup_type(name:, referrer:)
           return unless name
 
           if name.start_with?("::")
             referent = @index[name].last #: Node?
-            if referent.is_a?(Scope) || referent.is_a?(Const)
+            if referent.is_a?(Scope) || referent.is_a?(Const) || referent.is_a?(TypeMember)
               return referent
             elsif referent
               raise Error, "Unexpected type #{referent} for #{name} with referrer #{referrer}"
@@ -313,7 +313,7 @@ module RBI
           loop do
             scoped_name = "#{referrer_scope&.fully_qualified_name}::#{name}"
             referent = @index[scoped_name].last #: Node?
-            if referent.is_a?(Scope) || referent.is_a?(Const)
+            if referent.is_a?(Scope) || referent.is_a?(Const) || referent.is_a?(TypeMember)
               return referent
             elsif referent
               raise Error, "Unexpected type #{referent} for #{name} with referrer #{referrer}"

--- a/test/rbi/rewriters/merge_trees_test.rb
+++ b/test/rbi/rewriters/merge_trees_test.rb
@@ -1247,22 +1247,5 @@ module RBI
         class Foo::Bar; end
       RBI
     end
-
-    def test_merge_invalid_type_reference_error
-      lhs = parse_rbi(<<~RBI)
-        class Foo
-          extend T::Sig
-          extend T::Generic
-          Bar = type_member
-          class Baz; end
-        end
-      RBI
-      rhs = parse_rbi(<<~RBI)
-        class Foo::Baz < ::Foo::Bar; end
-      RBI
-      assert_raises(Rewriters::Merge::Error) do
-        lhs.merge(rhs)
-      end
-    end
   end
 end

--- a/test/rbi/rewriters/merge_trees_test.rb
+++ b/test/rbi/rewriters/merge_trees_test.rb
@@ -1247,5 +1247,22 @@ module RBI
         class Foo::Bar; end
       RBI
     end
+
+    def test_merge_invalid_type_reference_error
+      lhs = parse_rbi(<<~RBI)
+        class Foo
+          extend T::Sig
+          extend T::Generic
+          Bar = type_member
+          class Baz; end
+        end
+      RBI
+      rhs = parse_rbi(<<~RBI)
+        class Foo::Baz < ::Foo::Bar; end
+      RBI
+      assert_raises(Rewriters::Merge::Error) do
+        lhs.merge(rhs)
+      end
+    end
   end
 end

--- a/test/rbi/rewriters/merge_trees_test.rb
+++ b/test/rbi/rewriters/merge_trees_test.rb
@@ -1203,7 +1203,7 @@ module RBI
         class Foo::Bar; end
 
         class Foo::Baz < Foo::Bar
-          sig { returns(T.nilable(Foo::Bar)) }
+          sig { returns(T.nilable(::Foo::Bar)) }
           def a; end
 
           def b; end
@@ -1237,7 +1237,7 @@ module RBI
       assert_equal(<<~RBI, res.string)
         module Foo
           class Baz < Bar
-            sig { returns(T.nilable(Bar)) }
+            sig { returns(T.nilable(::Foo::Bar)) }
             def a; end
 
             def b; end

--- a/test/rbi/rewriters/merge_trees_test.rb
+++ b/test/rbi/rewriters/merge_trees_test.rb
@@ -1175,5 +1175,77 @@ module RBI
         end
       RBI
     end
+
+    def test_merge_rhs_referencing_type_in_lhs
+      lhs = parse_rbi(<<~RBI)
+        module Foo; end
+        class Foo::Bar; end
+
+        class Foo::Baz < Foo::Bar;
+          def a; end
+        end
+      RBI
+
+      rhs = parse_rbi(<<~RBI)
+        module Foo
+          class Baz < Bar
+            sig { returns(T.nilable(Bar)) }
+            def a; end
+            def b; end
+          end
+        end
+      RBI
+
+      res = lhs.merge(rhs)
+
+      assert_equal(<<~RBI, res.string)
+        module Foo; end
+        class Foo::Bar; end
+
+        class Foo::Baz < Foo::Bar
+          sig { returns(T.nilable(Foo::Bar)) }
+          def a; end
+
+          def b; end
+        end
+      RBI
+    end
+
+    def test_merge_lhs_referencing_type_in_rhs
+      # Note how lhs.merge(rhs) is a different result vs rhs.merge(lhs)
+      lhs = parse_rbi(<<~RBI)
+        module Foo
+          class Baz < Bar
+            sig { returns(T.nilable(Bar)) }
+            def a; end
+            def b; end
+          end
+        end
+      RBI
+
+      rhs = parse_rbi(<<~RBI)
+        module Foo; end
+        class Foo::Bar; end
+
+        class Foo::Baz < Foo::Bar;
+          def a; end
+        end
+      RBI
+
+      res = lhs.merge(rhs)
+
+      assert_equal(<<~RBI, res.string)
+        module Foo
+          class Baz < Bar
+            sig { returns(T.nilable(Bar)) }
+            def a; end
+
+            def b; end
+          end
+        end
+
+        class Foo::Bar; end
+      RBI
+    end
   end
 end


### PR DESCRIPTION
This is another attempt to fix tapioca's rbi incorrectly merging of the Stripe gem, as described here: https://github.com/Shopify/tapioca/issues/2248. Previous attempt: https://github.com/Shopify/rbi/pull/509

## Problem

When merging two trees that refer to the same scope using nested vs namespaced syntax, the merge algorithm was treating those as different scopes. For example:

```ruby
# lhs
module Foo; end
class Foo::Bar; end
class Foo::Baz < Foo::Bar; end

# rhs
module Foo
  class Bar; end; # See note 1
  class Baz < Bar; end
end
```

The two definitions of `Foo::Baz` were considered incompatible due to mismatched superclasses even though they technically both refer to `Foo::Bar`. *Note 1*: Additionally, in the case of the Stripe SDK, the superclass in right hand tree (the gem's exported rbi) could refer to a type only defined in the left hand tree (tapioca's generated rbi).

## This Solution

Wherever there's a type reference in the right hand tree during a merge, it is looked up in the left hand tree using rules mimicking Ruby's semantics. This is applied to the following places where types can be referenced:
* Class superclasses
* Mixins
* Signatures on Attrs and Methods

The output then uses fully-qualified names for those references.

Note that this makes the merge asymetric: the left-hand tree is expected to contain all the types that could be referenced by either tree.

## TODO
For further improvement, consider merging `Attr` and same-named `Method`. In the case of Stripe SDK, tapioca generates methods from source but the exported rbi defined attr accessors, which should be merged (along with their signatures). This is implemented in a second PR here: https://github.com/bandcampdotcom/rbi/pull/2