### PR TITLE
Remove outdated field in `dev.yml`

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -22,7 +22,6 @@ commands:
   typecheck:
     desc: 'run Sorbet typechecking'
     aliases: ['tc']
-    depends-isogun: false
     run: bundle exec srb tc
   sanity: 'bin/typecheck; bin/test; bin/style'
   rbi:


### PR DESCRIPTION
Resolves 
```
failed to install daemon: Invalid value in dev.yml for
commands.typecheck: {"desc" => "run Sorbet typechecking", "aliases" =>
["tc"], "depends-isogun" => false, "run" => "bundle exec srb tc"}. Unexpected key(s): depends-isogun.
```