### PR TITLE
Handle forwarding parameters

### DIFF
--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -709,52 +709,74 @@ module RBI
           *node.block,
         ].flatten
 
-        node_params.map do |param|
+        node_params.flat_map do |param|
           case param
           when Prism::RequiredParameterNode
-            ReqParam.new(
-              param.name.to_s,
-              loc: node_loc(param),
-              comments: node_comments(param),
-            )
+            [
+              ReqParam.new(
+                param.name.to_s,
+                loc: node_loc(param),
+                comments: node_comments(param),
+              )
+            ]
           when Prism::OptionalParameterNode
-            OptParam.new(
-              param.name.to_s,
-              node_string!(param.value),
-              loc: node_loc(param),
-              comments: node_comments(param),
-            )
+            [
+              OptParam.new(
+                param.name.to_s,
+                node_string!(param.value),
+                loc: node_loc(param),
+                comments: node_comments(param),
+              )
+            ]
           when Prism::RestParameterNode
-            RestParam.new(
-              param.name&.to_s || "*args",
-              loc: node_loc(param),
-              comments: node_comments(param),
-            )
+            [
+              RestParam.new(
+                param.name&.to_s || "args",
+                loc: node_loc(param),
+                comments: node_comments(param),
+              )
+            ]
           when Prism::RequiredKeywordParameterNode
-            KwParam.new(
-              param.name.to_s.delete_suffix(":"),
-              loc: node_loc(param),
-              comments: node_comments(param),
-            )
+            [
+              KwParam.new(
+                param.name.to_s.delete_suffix(":"),
+                loc: node_loc(param),
+                comments: node_comments(param),
+              )
+            ]
           when Prism::OptionalKeywordParameterNode
-            KwOptParam.new(
-              param.name.to_s.delete_suffix(":"),
-              node_string!(param.value),
-              loc: node_loc(param),
-              comments: node_comments(param),
-            )
+            [
+              KwOptParam.new(
+                param.name.to_s.delete_suffix(":"),
+                node_string!(param.value),
+                loc: node_loc(param),
+                comments: node_comments(param),
+              )
+            ]
           when Prism::KeywordRestParameterNode
-            KwRestParam.new(
-              param.name&.to_s || "**kwargs",
-              loc: node_loc(param),
-              comments: node_comments(param),
-            )
+            [
+              KwRestParam.new(
+                param.name&.to_s || "kwargs",
+                loc: node_loc(param),
+                comments: node_comments(param),
+              )
+            ]
           when Prism::BlockParameterNode
-            BlockParam.new(
-              param.name&.to_s || "&block",
-              loc: node_loc(param),
-              comments: node_comments(param),
-            )
+            [
+              BlockParam.new(
+                param.name&.to_s || "block",
+                loc: node_loc(param),
+                comments: node_comments(param),
+              )
+            ]
+          when Prism::ForwardingParameterNode
+            loc = node_loc(param)
+
+            [
+              RestParam.new("args", loc: loc, comments: []),
+              KwRestParam.new("kwargs", loc: loc, comments: []),
+              BlockParam.new("block", loc: loc, comments: node_comments(param)),
+            ]
           else
             raise ParseError.new("Unexpected parameter node `#{param.class}`", node_loc(param))
           end

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -185,6 +185,17 @@ module RBI
       assert_equal(rbi, tree.string)
     end
 
+    def test_parse_methods_with_forwarding
+      rbi = <<~RBI
+        def m1(...); end
+      RBI
+
+      tree = parse_rbi(rbi)
+      assert_equal(<<~EXP, tree.string)
+        def m1(*args, **kwargs, &block); end
+      EXP
+    end
+
     def test_parse_methods_with_vararg_followed_by_positional_arg
       rbi = <<~RBI
         def m1(*a, b); end


### PR DESCRIPTION
In the parser it currently crashes when it encounters a forwarding parameter. Instead, handle it by explicitly adding each of the three types of forwarded params.

It would be fine if you wanted to add an explicit type for this as well, but seeing as RBI doesn't have support for it, I figured this was the most explicit.