### PR TITLE
Handle forwarding parameters in parser

### DIFF
--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -709,7 +709,7 @@ module RBI
           *node.block,
         ].flatten
 
-        node_params.map do |param|
+        node_params.flat_map do |param|
           case param
           when Prism::RequiredParameterNode
             ReqParam.new(
@@ -755,6 +755,13 @@ module RBI
               loc: node_loc(param),
               comments: node_comments(param),
             )
+          when Prism::ForwardingParameterNode
+            loc = node_loc(param)
+            [
+              RestParam.new("args", loc: loc, comments: []),
+              KwRestParam.new("kwargs", loc: loc, comments: []),
+              BlockParam.new("block", loc: loc, comments: node_comments(param)),
+            ]
           else
             raise ParseError.new("Unexpected parameter node `#{param.class}`", node_loc(param))
           end

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -185,6 +185,19 @@ module RBI
       assert_equal(rbi, tree.string)
     end
 
+    def test_parse_methods_with_forwarding
+      rbi = <<~RBI
+        def m1(...); end
+        def m2(a, ...); end
+      RBI
+
+      tree = parse_rbi(rbi)
+      assert_equal(<<~EXP, tree.string)
+        def m1(*args, **kwargs, &block); end
+        def m2(a, *args, **kwargs, &block); end
+      EXP
+    end
+
     def test_parse_methods_with_vararg_followed_by_positional_arg
       rbi = <<~RBI
         def m1(*a, b); end


### PR DESCRIPTION
## Summary

Expand `...` (`ForwardingParameterNode`) into `*args, **kwargs, &block` instead of crashing with an unexpected parameter error.

Based on #562 by @kddnewton — simplified the approach to avoid wrapping every case in arrays: just `map` → `flat_map` and a single new `when` branch.

Includes test for both `def m1(...)` and `def m2(a, ...)`.

Closes #562