### PR TITLE
Adopt `params` and `sig` from other when merging a `Method` with no sig

### DIFF
--- a/lib/rbi/rewriters/merge_trees.rb
+++ b/lib/rbi/rewriters/merge_trees.rb
@@ -479,10 +479,12 @@ module RBI
       super
 
       # If self is the all-anonymous side (since compatible_with? ensures
-      # at most one side is), adopt other's non-anonymous param names and sigs.
-      if params.all?(&:anonymous?)
+      # at most one side is), or if self has no sigs but other does, adopt
+      # other's non-anonymous param names and sigs.
+      if params.all?(&:anonymous?) || (sigs.empty? && !other.sigs.empty?)
         @params = other.params.dup
         @sigs = other.sigs.dup unless other.sigs.empty?
+        return
       end
 
       other.sigs.each do |sig|

--- a/test/rbi/rewriters/merge_trees_test.rb
+++ b/test/rbi/rewriters/merge_trees_test.rb
@@ -1333,5 +1333,30 @@ module RBI
       RBI
       refute_empty(res.conflicts)
     end
+
+    def test_merge_methods_without_sig_adopts_params_and_sig_from_other
+      tree1 = parse_rbi(<<~RBI)
+        class Foo
+          def expand=(value); end
+        end
+      RBI
+
+      tree2 = parse_rbi(<<~RBI)
+        class Foo
+          sig { params(_a_different_name: T.nilable(T::Array[String])).returns(T.nilable(T::Array[String])) }
+          def expand=(_a_different_name); end
+        end
+      RBI
+
+      res = tree1.merge(tree2)
+
+      assert_equal(<<~RBI, res.string)
+        class Foo
+          sig { params(_a_different_name: T.nilable(T::Array[String])).returns(T.nilable(T::Array[String])) }
+          def expand=(_a_different_name); end
+        end
+      RBI
+      assert_empty(res.conflicts)
+    end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/Shopify/tapioca/issues/2589

When merging two method definitions where the left has no sig but the right does, adopt the right's param names alongside its sigs. Previously only the sigs were adopted, causing a mismatch between the method's param names and the sig's param names.