### PR TITLE
Fix `sort_nodes` crash on nodes with symbol names

### DIFF
--- a/lib/rbi/model.rb
+++ b/lib/rbi/model.rb
@@ -196,12 +196,12 @@ module RBI
 
   class Module < Scope
     #: String
-    attr_accessor :name
+    attr_reader :name
 
     #: (String name, ?loc: Loc?, ?comments: Array[Comment]?) ?{ (Module node) -> void } -> void
     def initialize(name, loc: nil, comments: nil, &block)
       super(loc: loc, comments: comments) {}
-      @name = name
+      @name = name.to_s #: String
       block&.call(self)
     end
 
@@ -216,7 +216,7 @@ module RBI
 
   class Class < Scope
     #: String
-    attr_accessor :name
+    attr_reader :name
 
     #: String?
     attr_accessor :superclass_name
@@ -229,7 +229,7 @@ module RBI
     #| ) ?{ (Class node) -> void } -> void
     def initialize(name, superclass_name: nil, loc: nil, comments: nil, &block)
       super(loc: loc, comments: comments) {}
-      @name = name
+      @name = name.to_s #: String
       @superclass_name = superclass_name
       block&.call(self)
     end
@@ -259,7 +259,7 @@ module RBI
 
   class Struct < Scope
     #: String
-    attr_accessor :name
+    attr_reader :name
 
     #: Array[Symbol]
     attr_accessor :members
@@ -276,7 +276,7 @@ module RBI
     #| ) ?{ (Struct struct) -> void } -> void
     def initialize(name, members: [], keyword_init: false, loc: nil, comments: nil, &block)
       super(loc: loc, comments: comments) {}
-      @name = name
+      @name = name.to_s #: String
       @members = members
       @keyword_init = keyword_init
       block&.call(self)
@@ -300,7 +300,7 @@ module RBI
     #: (String name, String value, ?loc: Loc?, ?comments: Array[Comment]?) ?{ (Const node) -> void } -> void
     def initialize(name, value, loc: nil, comments: nil, &block)
       super(loc: loc, comments: comments)
-      @name = name
+      @name = name.to_s #: String
       @value = value
       block&.call(self)
     end
@@ -453,7 +453,7 @@ module RBI
 
   class Method < NodeWithComments
     #: String
-    attr_accessor :name
+    attr_reader :name
 
     #: -> Array[Param]
     def params
@@ -499,7 +499,7 @@ module RBI
       &block
     )
       super(loc: loc, comments: comments)
-      @name = name
+      @name = name.to_s #: String
       @params = params #: Array[Param]?
       @is_singleton = is_singleton
       @visibility = visibility
@@ -605,7 +605,7 @@ module RBI
     #: (String name, ?loc: Loc?, ?comments: Array[Comment]?) -> void
     def initialize(name, loc: nil, comments: nil)
       super(loc: loc, comments: comments)
-      @name = name
+      @name = name.to_s #: String
       @anonymous = name.start_with?("_") #: bool
     end
 
@@ -731,7 +731,7 @@ module RBI
     #: (String name, Array[String] names, ?loc: Loc?, ?comments: Array[Comment]?) -> void
     def initialize(name, names, loc: nil, comments: nil)
       super(loc: loc, comments: comments)
-      @names = [name, *names] #: Array[String]
+      @names = [name, *names].map(&:to_s) #: Array[String]
     end
   end
 
@@ -1022,7 +1022,7 @@ module RBI
     #: (String name, (Type | String) type, ?loc: Loc?, ?comments: Array[Comment]?) ?{ (SigParam node) -> void } -> void
     def initialize(name, type, loc: nil, comments: nil, &block)
       super(loc: loc, comments: comments)
-      @name = name
+      @name = name.to_s #: String
       @anonymous = name.start_with?("_") #: bool
       @type = type
       block&.call(self)
@@ -1054,7 +1054,7 @@ module RBI
   # @abstract
   class TStructField < NodeWithComments
     #: String
-    attr_accessor :name
+    attr_reader :name
 
     #: (Type | String)
     attr_accessor :type
@@ -1065,7 +1065,7 @@ module RBI
     #: (String name, (Type | String) type, ?default: String?, ?loc: Loc?, ?comments: Array[Comment]?) -> void
     def initialize(name, type, default: nil, loc: nil, comments: nil)
       super(loc: loc, comments: comments)
-      @name = name
+      @name = name.to_s #: String
       @type = type
       @default = default
     end
@@ -1166,7 +1166,7 @@ module RBI
     #: (String name, ?loc: Loc?, ?comments: Array[Comment]?) ?{ (TEnumValue node) -> void } -> void
     def initialize(name, loc: nil, comments: nil, &block)
       super(loc: loc, comments: comments)
-      @name = name
+      @name = name.to_s #: String
       block&.call(self)
     end
 
@@ -1191,7 +1191,7 @@ module RBI
     #: (String name, ?loc: Loc?, ?comments: Array[Comment]?) ?{ (Helper node) -> void } -> void
     def initialize(name, loc: nil, comments: nil, &block)
       super(loc: loc, comments: comments)
-      @name = name
+      @name = name.to_s #: String
       block&.call(self)
     end
 
@@ -1209,7 +1209,7 @@ module RBI
     #: (String name, String value, ?loc: Loc?, ?comments: Array[Comment]?) ?{ (TypeMember node) -> void } -> void
     def initialize(name, value, loc: nil, comments: nil, &block)
       super(loc: loc, comments: comments)
-      @name = name
+      @name = name.to_s #: String
       @value = value
       block&.call(self)
     end
@@ -1254,7 +1254,7 @@ module RBI
     #: (String name, ?loc: Loc?, ?comments: Array[Comment]?) -> void
     def initialize(name, loc: nil, comments: nil)
       super(loc: loc, comments: comments)
-      @name = name
+      @name = name.to_s #: String
     end
 
     # @override

--- a/rbi/rbi.rbi
+++ b/rbi/rbi.rbi
@@ -220,8 +220,6 @@ class RBI::Class < ::RBI::Scope
   sig { returns(::String) }
   def name; end
 
-  def name=(_arg0); end
-
   sig { returns(T.nilable(::String)) }
   def superclass_name; end
 
@@ -705,8 +703,6 @@ class RBI::Method < ::RBI::NodeWithComments
   sig { returns(::String) }
   def name; end
 
-  def name=(_arg0); end
-
   sig { returns(T::Array[::RBI::Param]) }
   def params; end
 
@@ -796,8 +792,6 @@ class RBI::Module < ::RBI::Scope
 
   sig { returns(::String) }
   def name; end
-
-  def name=(_arg0); end
 end
 
 class RBI::Node
@@ -2268,8 +2262,6 @@ class RBI::Struct < ::RBI::Scope
 
   sig { returns(::String) }
   def name; end
-
-  def name=(_arg0); end
 end
 
 class RBI::TEnum < ::RBI::Class
@@ -2397,8 +2389,6 @@ class RBI::TStructField < ::RBI::NodeWithComments
 
   sig { returns(::String) }
   def name; end
-
-  def name=(_arg0); end
 
   sig { returns(T.any(::RBI::Type, ::String)) }
   def type; end

--- a/test/rbi/model_test.rb
+++ b/test/rbi/model_test.rb
@@ -476,5 +476,27 @@ module RBI
         end
       RBI
     end
+
+    def test_model_coerces_symbol_names_to_strings
+      sym = :sym_name #: as untyped
+
+      assert_equal("sym_name", Module.new(sym).name)
+      assert_equal("sym_name", Class.new(sym).name)
+      assert_equal("sym_name", Struct.new(sym).name)
+      assert_equal("sym_name", Const.new(sym, "42").name)
+      assert_equal("sym_name", Method.new(sym).name)
+      assert_equal("sym_name", Helper.new(sym).name)
+      assert_equal("sym_name", TypeMember.new(sym, "X").name)
+      assert_equal("sym_name", RequiresAncestor.new(sym).name)
+      assert_equal("sym_name", TEnumValue.new(sym).name)
+      assert_equal("sym_name", TStructConst.new(sym, "T").name)
+      assert_equal("sym_name", TStructProp.new(sym, "T").name)
+
+      sym_a = :a #: as untyped
+      sym_b = :b #: as untyped
+      assert_equal(["a", "b"], Include.new(sym_a, sym_b).names)
+      assert_equal(["a", "b"], Extend.new(sym_a, sym_b).names)
+      assert_equal(["a", "b"], MixesInClassMethods.new(sym_a, sym_b).names)
+    end
   end
 end

--- a/test/rbi/rewriters/sort_nodes_test.rb
+++ b/test/rbi/rewriters/sort_nodes_test.rb
@@ -328,9 +328,6 @@ module RBI
     end
 
     def test_sort_handles_symbol_names
-      # Regression test for #593: DSL compilers sometimes pass Symbols to
-      # constructors declared as String. Node constructors now coerce to
-      # String, so sort sees uniform String keys and orders correctly.
       sym = :mmm_method #: as untyped
 
       tree = Tree.new
@@ -371,6 +368,52 @@ module RBI
         public
         def aa; end
       RBI
+    end
+
+    def test_all_rewriters_tolerate_symbol_named_nodes
+      sym = :sym_name #: as untyped
+
+      build_tree = -> do
+        tree = Tree.new
+        tree << Method.new(sym)
+        tree << Method.new("a_method")
+        tree << Method.new("with_params") do |m|
+          m << ReqParam.new(sym)
+          m << ReqParam.new("a_param")
+        end
+        tree << Module.new(sym) { |mod| mod << Method.new(sym) }
+        tree << Module.new("A_Module")
+        tree << Class.new(sym)
+        tree << Class.new("A_Class")
+        tree << Const.new(sym, "42")
+        tree << Const.new("A_Const", "42")
+        tree << Helper.new(sym)
+        tree << Helper.new("a_helper")
+        tree << RequiresAncestor.new(sym)
+        tree << RequiresAncestor.new("A_Req")
+        tree << Struct.new(sym)
+        tree << Struct.new("A_Struct")
+        tree
+      end
+
+      # rubocop:disable Sorbet/ConstantsFromStrings
+      rewriter_classes = Rewriters.constants.filter_map do |c|
+        const = Rewriters.const_get(c)
+        next unless const.is_a?(::Class) && const < Visitor
+        # Skip rewriters needing constructor args (Annotate, Deannotate, FilterVersions, Merge).
+        next if const.instance_method(:initialize).parameters.any? { |type, _| type == :req || type == :keyreq }
+
+        const
+      end
+      # rubocop:enable Sorbet/ConstantsFromStrings
+
+      refute_empty(rewriter_classes, "expected to discover at least one no-arg rewriter")
+
+      rewriter_classes.each do |klass|
+        tree = build_tree.call
+        klass.new.visit(tree)
+        refute_empty(tree.string, "#{klass} produced empty output after visiting a tree with Symbol-named nodes")
+      end
     end
   end
 end

--- a/test/rbi/rewriters/sort_nodes_test.rb
+++ b/test/rbi/rewriters/sort_nodes_test.rb
@@ -327,6 +327,26 @@ module RBI
       RBI
     end
 
+    def test_sort_handles_symbol_names
+      # Regression test for #593: DSL compilers sometimes pass Symbols to
+      # constructors declared as String. Node constructors now coerce to
+      # String, so sort sees uniform String keys and orders correctly.
+      sym = :mmm_method #: as untyped
+
+      tree = Tree.new
+      tree << Method.new("zzz")
+      tree << Method.new(sym)
+      tree << Method.new("aaa")
+
+      tree.sort_nodes!
+
+      assert_equal(<<~RBI, tree.string)
+        def aaa; end
+        def mmm_method; end
+        def zzz; end
+      RBI
+    end
+
     def test_sort_doesnt_change_privacy
       tree = parse_rbi(<<~RBI)
         public


### PR DESCRIPTION
Resolves #593.

DSL compilers pass `Symbol` values to node constructors declared as `String`, which flows through and crashes `sort_nodes!` (Schwartzian sort can't compare String with Symbol) and `Printer` (`String#<<`).

Fix by coercing the type in the constructors using `name.to_s`.

Remove `attr_accessor :name` to prevent callers from passing symbol.

Second commit adds a contract test that auto-discovers every `Rewriters::*` class and runs each against a tree with Symbol-named nodes to guard against future regressions.
