### PR TITLE
Fix RBS Record translation to include optional fields

### DIFF
--- a/lib/rbi/rbs/type_translator.rb
+++ b/lib/rbi/rbs/type_translator.rb
@@ -82,7 +82,10 @@ module RBI
             proc.bind(translate(type.self_type)) if type.self_type
             proc
           when ::RBS::Types::Record
-            Type.shape(type.fields.map { |name, type| [name, translate(type)] }.to_h)
+            Type.shape(type.all_fields.to_h do |name, (value, required)|
+              translated = translate(value)
+              [name, required ? translated : Type.nilable(translated)]
+            end)
           when ::RBS::Types::Tuple
             Type.tuple(type.types.map { |t| translate(t) })
           when ::RBS::Types::Union

--- a/test/rbi/rbs/type_translator_test.rb
+++ b/test/rbi/rbs/type_translator_test.rb
@@ -142,6 +142,17 @@ module RBI
         assert_equal(Type.shape(foo: Type.simple("String")), translate("{foo: String}"))
       end
 
+      def test_translate_record_with_optional_fields
+        assert_equal(
+          Type.shape(
+            a: Type.simple("Integer"),
+            b: Type.nilable(Type.simple("String")),
+            c: Type.nilable(Type.simple("Float")),
+          ),
+          translate("{ a: Integer, ?b: String, ?c: Float? }"),
+        )
+      end
+
       def test_translate_tuple
         assert_equal(Type.tuple([Type.simple("Foo"), Type.simple("Bar")]), translate("[Foo, Bar]"))
       end


### PR DESCRIPTION
## Summary

* RBS Record types with optional fields (e.g. `{ a: Integer, ?b: String }`) were silently dropped during translation to RBI
* The translator used `type.fields` which only returns required fields — switched to `type.all_fields` which includes both required and optional fields
* Optional fields are now wrapped in `T.nilable` to represent that they may not be present
* Already-nilable optional fields (e.g. `?c: Float?`) are not double-wrapped thanks to `Type.nilable` simplification