### PR TITLE
Refactor `RBS::TypeTranslator` to provide instance methods

### DIFF
--- a/lib/rbi/rbs/method_type_translator.rb
+++ b/lib/rbi/rbs/method_type_translator.rb
@@ -22,6 +22,7 @@ module RBI
       def initialize(method)
         @method = method
         @result = Sig.new #: Sig
+        @type_translator = TypeTranslator.new #: TypeTranslator
       end
 
       #: (::RBS::MethodType) -> void
@@ -113,7 +114,7 @@ module RBI
 
       #: (untyped) -> Type
       def translate_type(type)
-        TypeTranslator.translate(type)
+        @type_translator.translate(type)
       end
     end
   end

--- a/lib/rbi/rbs/type_translator.rb
+++ b/lib/rbi/rbs/type_translator.rb
@@ -4,196 +4,201 @@
 module RBI
   module RBS
     class TypeTranslator
+      #: type rbs_type = ::RBS::Types::Alias
+      #| | ::RBS::Types::Bases::Any
+      #| | ::RBS::Types::Bases::Bool
+      #| | ::RBS::Types::Bases::Bottom
+      #| | ::RBS::Types::Bases::Class
+      #| | ::RBS::Types::Bases::Instance
+      #| | ::RBS::Types::Bases::Nil
+      #| | ::RBS::Types::Bases::Self
+      #| | ::RBS::Types::Bases::Top
+      #| | ::RBS::Types::Bases::Void
+      #| | ::RBS::Types::ClassSingleton
+      #| | ::RBS::Types::ClassInstance
+      #| | ::RBS::Types::Function
+      #| | ::RBS::Types::Interface
+      #| | ::RBS::Types::Intersection
+      #| | ::RBS::Types::Literal
+      #| | ::RBS::Types::Optional
+      #| | ::RBS::Types::Proc
+      #| | ::RBS::Types::Record
+      #| | ::RBS::Types::Tuple
+      #| | ::RBS::Types::Union
+      #| | ::RBS::Types::UntypedFunction
+      #| | ::RBS::Types::Variable
+
       class << self
-        #: (
-        #|   ::RBS::Types::Alias |
-        #|   ::RBS::Types::Bases::Any |
-        #|   ::RBS::Types::Bases::Bool |
-        #|   ::RBS::Types::Bases::Bottom |
-        #|   ::RBS::Types::Bases::Class |
-        #|   ::RBS::Types::Bases::Instance |
-        #|   ::RBS::Types::Bases::Nil |
-        #|   ::RBS::Types::Bases::Self |
-        #|   ::RBS::Types::Bases::Top |
-        #|   ::RBS::Types::Bases::Void |
-        #|   ::RBS::Types::ClassSingleton |
-        #|   ::RBS::Types::ClassInstance |
-        #|   ::RBS::Types::Function |
-        #|   ::RBS::Types::Interface |
-        #|   ::RBS::Types::Intersection |
-        #|   ::RBS::Types::Literal |
-        #|   ::RBS::Types::Optional |
-        #|   ::RBS::Types::Proc |
-        #|   ::RBS::Types::Record |
-        #|   ::RBS::Types::Tuple |
-        #|   ::RBS::Types::Union |
-        #|   ::RBS::Types::UntypedFunction |
-        #|   ::RBS::Types::Variable
-        #| ) -> Type
+        #: (rbs_type) -> Type
         def translate(type)
-          case type
-          when ::RBS::Types::Alias
-            translate_type_alias(type)
-          when ::RBS::Types::Bases::Any
-            Type.untyped
-          when ::RBS::Types::Bases::Bool
-            Type.boolean
-          when ::RBS::Types::Bases::Bottom
-            Type.noreturn
-          when ::RBS::Types::Bases::Class
-            Type.simple("Class")
-          when ::RBS::Types::Bases::Instance
-            Type.attached_class
-          when ::RBS::Types::Bases::Nil
-            Type.simple("NilClass")
-          when ::RBS::Types::Bases::Self
-            Type.self_type
-          when ::RBS::Types::Bases::Top
-            Type.anything
-          when ::RBS::Types::Bases::Void
-            Type.void
-          when ::RBS::Types::ClassSingleton
-            type_parameter = type.args.first ? translate(type.args.first) : nil
-            Type.class_of(Type.simple(type.name.to_s), type_parameter)
-          when ::RBS::Types::ClassInstance
-            translate_class_instance(type)
-          when ::RBS::Types::Function
-            translate_function(type)
-          when ::RBS::Types::Interface
-            # TODO: unsupported yet
-            # RBS interfaces (like _Foo) don't have a direct Sorbet equivalent
-            # and the names aren't valid Ruby identifiers
-            Type.untyped
-          when ::RBS::Types::Intersection
-            Type.all(*type.types.map { |t| translate(t) })
-          when ::RBS::Types::Literal
-            # Sorbet doesn't support literal types, so map to their base type
-            case type.literal
-            when nil then Type.simple("NilClass")
-            when true then Type.simple("TrueClass")
-            when false then Type.simple("FalseClass")
-            else
-              Type.simple(type.literal.class.to_s)
-            end
-          when ::RBS::Types::Optional
-            Type.nilable(translate(type.type))
-          when ::RBS::Types::Proc
-            proc = translate(type.type) #: as Type::Proc
-            proc.bind(translate(type.self_type)) if type.self_type
-            proc
-          when ::RBS::Types::Record
-            Type.shape(type.all_fields.to_h do |name, (value, required)|
-              translated = translate(value)
-              [name, required ? translated : Type.nilable(translated)]
-            end)
-          when ::RBS::Types::Tuple
-            Type.tuple(type.types.map { |t| translate(t) })
-          when ::RBS::Types::Union
-            Type.any(*type.types.map { |t| translate(t) })
-          when ::RBS::Types::UntypedFunction
-            Type.proc.params(arg0: Type.untyped).returns(Type.untyped)
-          when ::RBS::Types::Variable
-            Type.type_parameter(type.name)
+          new.translate(type)
+        end
+      end
+
+      #: (rbs_type) -> Type
+      def translate(type)
+        case type
+        when ::RBS::Types::Alias
+          translate_type_alias(type)
+        when ::RBS::Types::Bases::Any
+          Type.untyped
+        when ::RBS::Types::Bases::Bool
+          Type.boolean
+        when ::RBS::Types::Bases::Bottom
+          Type.noreturn
+        when ::RBS::Types::Bases::Class
+          Type.simple("Class")
+        when ::RBS::Types::Bases::Instance
+          Type.attached_class
+        when ::RBS::Types::Bases::Nil
+          Type.simple("NilClass")
+        when ::RBS::Types::Bases::Self
+          Type.self_type
+        when ::RBS::Types::Bases::Top
+          Type.anything
+        when ::RBS::Types::Bases::Void
+          Type.void
+        when ::RBS::Types::ClassSingleton
+          type_parameter = type.args.first ? translate(type.args.first) : nil
+          Type.class_of(Type.simple(type.name.to_s), type_parameter)
+        when ::RBS::Types::ClassInstance
+          translate_class_instance(type)
+        when ::RBS::Types::Function
+          translate_function(type)
+        when ::RBS::Types::Interface
+          # TODO: unsupported yet
+          # RBS interfaces (like _Foo) don't have a direct Sorbet equivalent
+          # and the names aren't valid Ruby identifiers
+          Type.untyped
+        when ::RBS::Types::Intersection
+          Type.all(*type.types.map { |t| translate(t) })
+        when ::RBS::Types::Literal
+          # Sorbet doesn't support literal types, so map to their base type
+          case type.literal
+          when nil then Type.simple("NilClass")
+          when true then Type.simple("TrueClass")
+          when false then Type.simple("FalseClass")
           else
-            type #: absurd
+            Type.simple(type.literal.class.to_s)
           end
-        end
-
-        private
-
-        #: (::RBS::Types::Alias) -> Type
-        def translate_type_alias(type)
-          name = ::RBS::TypeName.new(
-            namespace: type.name.namespace,
-            name: type.name.name.to_s.gsub(/(?:^|_)([a-z\d]*)/i) do |match|
-              match = match.delete_prefix("_")
-              !match.empty? ? match[0].upcase.concat(match[1..-1]) : +""
-            end,
-          )
-          Type.simple(name.to_s)
-        end
-
-        #: (::RBS::Types::ClassInstance) -> Type
-        def translate_class_instance(type)
-          return Type.simple(type.name.to_s) if type.args.empty?
-
-          type_name = translate_t_generic_type(type.name.to_s)
-          Type.generic(type_name, *type.args.map { |arg| translate(arg) })
-        end
-
-        #: (::RBS::Types::Function) -> Type
-        def translate_function(type)
-          proc = Type.proc
-
-          index = 0
-
-          type.required_positionals.each do |param|
-            proc.proc_params[param.name || :"arg#{index}"] = translate(param.type)
-            index += 1
-          end
-
-          type.optional_positionals.each do |param|
-            proc.proc_params[param.name || :"arg#{index}"] = translate(param.type)
-            index += 1
-          end
-
-          rest_positional = type.rest_positionals
-          if rest_positional
-            proc.proc_params[rest_positional.name || :"arg#{index}"] = translate(rest_positional.type)
-            index += 1
-          end
-
-          type.trailing_positionals.each do |param|
-            proc.proc_params[param.name || :"arg#{index}"] = translate(param.type)
-            index += 1
-          end
-
-          type.required_keywords.each do |name, param|
-            proc.proc_params[name.to_sym] = translate(param.type)
-            index += 1
-          end
-
-          type.optional_keywords.each do |name, param|
-            proc.proc_params[name.to_sym] = translate(param.type)
-            index += 1
-          end
-
-          rest_keyword = type.rest_keywords
-          if rest_keyword
-            proc.proc_params[rest_keyword.name || :"arg_#{index}"] = translate(rest_keyword.type)
-            index += 1
-          end
-
-          proc.returns(translate(type.return_type))
+        when ::RBS::Types::Optional
+          Type.nilable(translate(type.type))
+        when ::RBS::Types::Proc
+          proc = translate(type.type) #: as Type::Proc
+          proc.bind(translate(type.self_type)) if type.self_type
           proc
+        when ::RBS::Types::Record
+          Type.shape(type.all_fields.to_h do |name, (value, required)|
+            translated = translate(value)
+            [name, required ? translated : Type.nilable(translated)]
+          end)
+        when ::RBS::Types::Tuple
+          Type.tuple(type.types.map { |t| translate(t) })
+        when ::RBS::Types::Union
+          Type.any(*type.types.map { |t| translate(t) })
+        when ::RBS::Types::UntypedFunction
+          Type.proc.params(arg0: Type.untyped).returns(Type.untyped)
+        when ::RBS::Types::Variable
+          Type.type_parameter(type.name)
+        else
+          type #: absurd
+        end
+      end
+
+      private
+
+      #: (::RBS::Types::Alias) -> Type
+      def translate_type_alias(type)
+        name = ::RBS::TypeName.new(
+          namespace: type.name.namespace,
+          name: type.name.name.to_s.gsub(/(?:^|_)([a-z\d]*)/i) do |match|
+            match = match.delete_prefix("_")
+            !match.empty? ? match[0].upcase.concat(match[1..-1]) : +""
+          end,
+        )
+        Type.simple(name.to_s)
+      end
+
+      #: (::RBS::Types::ClassInstance) -> Type
+      def translate_class_instance(type)
+        return Type.simple(type.name.to_s) if type.args.empty?
+
+        type_name = translate_t_generic_type(type.name.to_s)
+        Type.generic(type_name, *type.args.map { |arg| translate(arg) })
+      end
+
+      #: (::RBS::Types::Function) -> Type
+      def translate_function(type)
+        proc = Type.proc
+
+        index = 0
+
+        type.required_positionals.each do |param|
+          proc.proc_params[param.name || :"arg#{index}"] = translate(param.type)
+          index += 1
         end
 
-        #: (String type_name) -> String
-        def translate_t_generic_type(type_name)
-          case type_name.delete_prefix("::")
-          when "Array"
-            "::T::Array"
-          when "Class"
-            "::T::Class"
-          when "Enumerable"
-            "::T::Enumerable"
-          when "Enumerator"
-            "::T::Enumerator"
-          when "Enumerator::Chain"
-            "::T::Enumerator::Chain"
-          when "Enumerator::Lazy"
-            "::T::Enumerator::Lazy"
-          when "Hash"
-            "::T::Hash"
-          when "Module"
-            "::T::Module"
-          when "Set"
-            "::T::Set"
-          when "Range"
-            "::T::Range"
-          else
-            type_name
-          end
+        type.optional_positionals.each do |param|
+          proc.proc_params[param.name || :"arg#{index}"] = translate(param.type)
+          index += 1
+        end
+
+        rest_positional = type.rest_positionals
+        if rest_positional
+          proc.proc_params[rest_positional.name || :"arg#{index}"] = translate(rest_positional.type)
+          index += 1
+        end
+
+        type.trailing_positionals.each do |param|
+          proc.proc_params[param.name || :"arg#{index}"] = translate(param.type)
+          index += 1
+        end
+
+        type.required_keywords.each do |name, param|
+          proc.proc_params[name.to_sym] = translate(param.type)
+          index += 1
+        end
+
+        type.optional_keywords.each do |name, param|
+          proc.proc_params[name.to_sym] = translate(param.type)
+          index += 1
+        end
+
+        rest_keyword = type.rest_keywords
+        if rest_keyword
+          proc.proc_params[rest_keyword.name || :"arg_#{index}"] = translate(rest_keyword.type)
+          index += 1
+        end
+
+        proc.returns(translate(type.return_type))
+        proc
+      end
+
+      #: (String type_name) -> String
+      def translate_t_generic_type(type_name)
+        case type_name.delete_prefix("::")
+        when "Array"
+          "::T::Array"
+        when "Class"
+          "::T::Class"
+        when "Enumerable"
+          "::T::Enumerable"
+        when "Enumerator"
+          "::T::Enumerator"
+        when "Enumerator::Chain"
+          "::T::Enumerator::Chain"
+        when "Enumerator::Lazy"
+          "::T::Enumerator::Lazy"
+        when "Hash"
+          "::T::Hash"
+        when "Module"
+          "::T::Module"
+        when "Set"
+          "::T::Set"
+        when "Range"
+          "::T::Range"
+        else
+          type_name
         end
       end
     end

--- a/lib/rbi/rewriters/translate_rbs_sigs.rb
+++ b/lib/rbi/rewriters/translate_rbs_sigs.rb
@@ -7,6 +7,12 @@ module RBI
     class TranslateRBSSigs < Visitor
       class Error < RBI::Error; end
 
+      #: -> void
+      def initialize
+        super
+        @type_translator = RBS::TypeTranslator.new #: RBS::TypeTranslator
+      end
+
       # @override
       #: (Node? node) -> void
       def visit(node)
@@ -68,10 +74,10 @@ module RBI
           end
 
           name = node.names.first #: as !nil
-          sig.params << SigParam.new(name.to_s, RBS::TypeTranslator.translate(attr_type))
+          sig.params << SigParam.new(name.to_s, @type_translator.translate(attr_type))
         end
 
-        sig.return_type = RBS::TypeTranslator.translate(attr_type)
+        sig.return_type = @type_translator.translate(attr_type)
         sig
       end
     end

--- a/rbi/rbi.rbi
+++ b/rbi/rbi.rbi
@@ -1418,6 +1418,27 @@ end
 class RBI::RBS::MethodTypeTranslator::Error < ::RBI::Error; end
 
 class RBI::RBS::TypeTranslator
+  sig do
+    params(
+      type: T.any(::RBS::Types::Alias, ::RBS::Types::Bases::Any, ::RBS::Types::Bases::Bool, ::RBS::Types::Bases::Bottom, ::RBS::Types::Bases::Class, ::RBS::Types::Bases::Instance, ::RBS::Types::Bases::Nil, ::RBS::Types::Bases::Self, ::RBS::Types::Bases::Top, ::RBS::Types::Bases::Void, ::RBS::Types::ClassInstance, ::RBS::Types::ClassSingleton, ::RBS::Types::Function, ::RBS::Types::Interface, ::RBS::Types::Intersection, ::RBS::Types::Literal, ::RBS::Types::Optional, ::RBS::Types::Proc, ::RBS::Types::Record, ::RBS::Types::Tuple, ::RBS::Types::Union, ::RBS::Types::UntypedFunction, ::RBS::Types::Variable)
+    ).returns(::RBI::Type)
+  end
+  def translate(type); end
+
+  private
+
+  sig { params(type: ::RBS::Types::ClassInstance).returns(::RBI::Type) }
+  def translate_class_instance(type); end
+
+  sig { params(type: ::RBS::Types::Function).returns(::RBI::Type) }
+  def translate_function(type); end
+
+  sig { params(type_name: ::String).returns(::String) }
+  def translate_t_generic_type(type_name); end
+
+  sig { params(type: ::RBS::Types::Alias).returns(::RBI::Type) }
+  def translate_type_alias(type); end
+
   class << self
     sig do
       params(
@@ -1425,22 +1446,10 @@ class RBI::RBS::TypeTranslator
       ).returns(::RBI::Type)
     end
     def translate(type); end
-
-    private
-
-    sig { params(type: ::RBS::Types::ClassInstance).returns(::RBI::Type) }
-    def translate_class_instance(type); end
-
-    sig { params(type: ::RBS::Types::Function).returns(::RBI::Type) }
-    def translate_function(type); end
-
-    sig { params(type_name: ::String).returns(::String) }
-    def translate_t_generic_type(type_name); end
-
-    sig { params(type: ::RBS::Types::Alias).returns(::RBI::Type) }
-    def translate_type_alias(type); end
   end
 end
+
+RBI::RBS::TypeTranslator::RbsType = T.type_alias { T.any(::RBS::Types::Alias, ::RBS::Types::Bases::Any, ::RBS::Types::Bases::Bool, ::RBS::Types::Bases::Bottom, ::RBS::Types::Bases::Class, ::RBS::Types::Bases::Instance, ::RBS::Types::Bases::Nil, ::RBS::Types::Bases::Self, ::RBS::Types::Bases::Top, ::RBS::Types::Bases::Void, ::RBS::Types::ClassInstance, ::RBS::Types::ClassSingleton, ::RBS::Types::Function, ::RBS::Types::Interface, ::RBS::Types::Intersection, ::RBS::Types::Literal, ::RBS::Types::Optional, ::RBS::Types::Proc, ::RBS::Types::Record, ::RBS::Types::Tuple, ::RBS::Types::Union, ::RBS::Types::UntypedFunction, ::RBS::Types::Variable) }
 
 class RBI::RBSComment < ::RBI::Comment
   sig { params(other: ::Object).returns(T::Boolean) }
@@ -2022,6 +2031,9 @@ class RBI::Rewriters::SortNodes < ::RBI::Visitor
 end
 
 class RBI::Rewriters::TranslateRBSSigs < ::RBI::Visitor
+  sig { void }
+  def initialize; end
+
   sig { override.params(node: T.nilable(::RBI::Node)).void }
   def visit(node); end
 

--- a/test/rbi/rbs/type_translator_test.rb
+++ b/test/rbi/rbs/type_translator_test.rb
@@ -173,7 +173,7 @@ module RBI
       #: (String) -> RBI::Type
       def translate(rbs_string)
         node = ::RBS::Parser.parse_type(rbs_string, require_eof: true)
-        RBS::TypeTranslator.translate(node)
+        RBS::TypeTranslator.new.translate(node)
       end
     end
   end


### PR DESCRIPTION
- Part of https://github.com/Shopify/spoom/issues/924

Previously, `RBS::TypeTranslator` methods lived on the class (ex. `TypeTranslator.translate(type)`)
In order to be able to support translation configuration, like the in-progress `erase_generic_types` option,
this PR converts `TypeTranslator`'s singleton methods to instance methods and updates it's callers

> If reviewing diff on Github, consider using Hide Whitespace setting