### PR TITLE
Add `erase_generic_types` option to RBS translators

### DIFF
--- a/lib/rbi/rbs/method_type_translator.rb
+++ b/lib/rbi/rbs/method_type_translator.rb
@@ -45,8 +45,10 @@ module RBI
 
       #: (::RBS::MethodType) -> void
       def visit(type)
-        type.type_params.each do |param|
-          result.type_params << param.name
+        unless @options.erase_generic_types
+          type.type_params.each do |param|
+            result.type_params << param.name
+          end
         end
 
         visit_function_type(type.type)

--- a/lib/rbi/rbs/type_translator.rb
+++ b/lib/rbi/rbs/type_translator.rb
@@ -66,7 +66,8 @@ module RBI
         when ::RBS::Types::Bases::Void
           Type.void
         when ::RBS::Types::ClassSingleton
-          type_parameter = type.args.first ? translate(type.args.first) : nil
+          type_arg = type.args.first
+          type_parameter = translate(type_arg) if type_arg && !@options.erase_generic_types
           Type.class_of(Type.simple(type.name.to_s), type_parameter)
         when ::RBS::Types::ClassInstance
           translate_class_instance(type)
@@ -106,7 +107,11 @@ module RBI
         when ::RBS::Types::UntypedFunction
           Type.proc.params(arg0: Type.untyped).returns(Type.untyped)
         when ::RBS::Types::Variable
-          Type.type_parameter(type.name)
+          if @options.erase_generic_types
+            Type.anything
+          else
+            Type.type_parameter(type.name)
+          end
         else
           type #: absurd
         end
@@ -128,10 +133,14 @@ module RBI
 
       #: (::RBS::Types::ClassInstance) -> Type
       def translate_class_instance(type)
-        return Type.simple(type.name.to_s) if type.args.empty?
+        type_name = type.name.to_s
+        return Type.simple(type_name) if type.args.empty?
 
-        type_name = translate_t_generic_type(type.name.to_s)
-        Type.generic(type_name, *type.args.map { |arg| translate(arg) })
+        if @options.erase_generic_types
+          Type.simple(erase_t_generic_type(type_name))
+        else
+          Type.generic(translate_t_generic_type(type_name), *type.args.map { |arg| translate(arg) })
+        end
       end
 
       #: (::RBS::Types::Function) -> Type
@@ -181,32 +190,35 @@ module RBI
         proc
       end
 
+      RUNTIME_GENERIC_TYPES = [
+        "Array",
+        "Class",
+        "Enumerable",
+        "Enumerator",
+        "Enumerator::Chain",
+        "Enumerator::Lazy",
+        "Hash",
+        "Module",
+        "Set",
+        "Range",
+      ].freeze #: Array[String]
+
+      GENERIC_TYPE_TO_SORBET_GENERIC_TYPE = RUNTIME_GENERIC_TYPES.flat_map do |type|
+        [[type, "::T::#{type}"], ["::#{type}", "::T::#{type}"]]
+      end.to_h.freeze #: Hash[String, String]
+
+      SORBET_GENERIC_TYPE_TO_GENERIC_TYPE = RUNTIME_GENERIC_TYPES.flat_map do |type|
+        [["T::#{type}", "::#{type}"], ["::T::#{type}", "::#{type}"]]
+      end.to_h.freeze #: Hash[String, String]
+
       #: (String type_name) -> String
       def translate_t_generic_type(type_name)
-        case type_name.delete_prefix("::")
-        when "Array"
-          "::T::Array"
-        when "Class"
-          "::T::Class"
-        when "Enumerable"
-          "::T::Enumerable"
-        when "Enumerator"
-          "::T::Enumerator"
-        when "Enumerator::Chain"
-          "::T::Enumerator::Chain"
-        when "Enumerator::Lazy"
-          "::T::Enumerator::Lazy"
-        when "Hash"
-          "::T::Hash"
-        when "Module"
-          "::T::Module"
-        when "Set"
-          "::T::Set"
-        when "Range"
-          "::T::Range"
-        else
-          type_name
-        end
+        GENERIC_TYPE_TO_SORBET_GENERIC_TYPE.fetch(type_name, type_name)
+      end
+
+      #: (String type_name) -> String
+      def erase_t_generic_type(type_name)
+        SORBET_GENERIC_TYPE_TO_GENERIC_TYPE.fetch(type_name, type_name)
       end
     end
   end

--- a/rbi/rbi.rbi
+++ b/rbi/rbi.rbi
@@ -1443,6 +1443,9 @@ class RBI::RBS::TypeTranslator
 
   private
 
+  sig { params(type_name: ::String).returns(::String) }
+  def erase_t_generic_type(type_name); end
+
   sig { params(type: ::RBS::Types::ClassInstance).returns(::RBI::Type) }
   def translate_class_instance(type); end
 
@@ -1465,8 +1468,11 @@ class RBI::RBS::TypeTranslator
   end
 end
 
+RBI::RBS::TypeTranslator::GENERIC_TYPE_TO_SORBET_GENERIC_TYPE = T.let(T.unsafe(nil), Hash)
 RBI::RBS::TypeTranslator::Options = RBI::RBS::MethodTypeTranslator::Options
+RBI::RBS::TypeTranslator::RUNTIME_GENERIC_TYPES = T.let(T.unsafe(nil), Array)
 RBI::RBS::TypeTranslator::RbsType = T.type_alias { T.any(::RBS::Types::Alias, ::RBS::Types::Bases::Any, ::RBS::Types::Bases::Bool, ::RBS::Types::Bases::Bottom, ::RBS::Types::Bases::Class, ::RBS::Types::Bases::Instance, ::RBS::Types::Bases::Nil, ::RBS::Types::Bases::Self, ::RBS::Types::Bases::Top, ::RBS::Types::Bases::Void, ::RBS::Types::ClassInstance, ::RBS::Types::ClassSingleton, ::RBS::Types::Function, ::RBS::Types::Interface, ::RBS::Types::Intersection, ::RBS::Types::Literal, ::RBS::Types::Optional, ::RBS::Types::Proc, ::RBS::Types::Record, ::RBS::Types::Tuple, ::RBS::Types::Union, ::RBS::Types::UntypedFunction, ::RBS::Types::Variable) }
+RBI::RBS::TypeTranslator::SORBET_GENERIC_TYPE_TO_GENERIC_TYPE = T.let(T.unsafe(nil), Hash)
 
 class RBI::RBSComment < ::RBI::Comment
   sig { params(other: ::Object).returns(T::Boolean) }

--- a/test/rbi/rbs/method_type_translator_test.rb
+++ b/test/rbi/rbs/method_type_translator_test.rb
@@ -195,13 +195,47 @@ module RBI
         assert_equal(Type.class_of(Type.simple("Foo"), Type.simple("Bar")), sig.return_type)
       end
 
+      def test_erase_generic_types_replaces_method_type_parameters
+        sig = translate(
+          "[T, U] (Array[T], T?, T | Integer, [T, Integer], singleton(Foo)[T]) { (T) -> U } -> U?",
+          Method.new("foo", params: [
+            ReqParam.new("array"),
+            ReqParam.new("value"),
+            ReqParam.new("fallback"),
+            ReqParam.new("pair"),
+            ReqParam.new("klass"),
+            BlockParam.new("block"),
+          ]),
+          erase_generic_types: true,
+        )
+
+        assert_empty(sig.type_params)
+        assert_equal(
+          [
+            SigParam.new("array", Type.simple("Array")),
+            SigParam.new("value", Type.nilable(Type.anything)),
+            SigParam.new("fallback", Type.any(Type.anything, Type.simple("Integer"))),
+            SigParam.new("pair", Type.tuple([Type.anything, Type.simple("Integer")])),
+            SigParam.new("klass", Type.class_of(Type.simple("Foo"))),
+            SigParam.new(
+              "block",
+              Type.proc
+                .params(arg0: Type.anything)
+                .returns(Type.anything),
+            ),
+          ],
+          sig.params,
+        )
+        assert_equal(Type.nilable(Type.anything), sig.return_type)
+      end
+
       private
 
-      #: (String, Method) -> RBI::Sig
-      def translate(rbs_string, method)
+      #: (String, Method, ?erase_generic_types: bool) -> RBI::Sig
+      def translate(rbs_string, method, erase_generic_types: false)
         node = ::RBS::Parser.parse_method_type(rbs_string, require_eof: true)
 
-        options = MethodTypeTranslator::Options.new
+        options = MethodTypeTranslator::Options.new(erase_generic_types:)
 
         translator = RBS::MethodTypeTranslator.new(method, options:)
         translator.visit(node)

--- a/test/rbi/rbs/type_translator_test.rb
+++ b/test/rbi/rbs/type_translator_test.rb
@@ -94,6 +94,30 @@ module RBI
         assert_equal(Type.class_of(Type.simple("Foo"), Type.simple("Bar")), translate("singleton(Foo)[Bar]"))
       end
 
+      def test_erase_generic_types_keeps_non_generics
+        assert_equal(Type.simple("Foo"), translate("Foo", erase_generic_types: true))
+        assert_equal(Type.simple("::Foo::Bar"), translate("::Foo::Bar", erase_generic_types: true))
+      end
+
+      def test_erase_generic_types_removes_generic_types
+        simple_foo = Type.simple("Foo")
+        class_foo = Type.class_of(simple_foo)
+        simple_array = Type.simple("Array")
+        root_array = Type.simple("::Array")
+
+        assert_equal(simple_foo, translate("Foo[Bar]", erase_generic_types: true))
+        assert_equal(simple_foo, translate("Foo[Bar, ::Baz]", erase_generic_types: true))
+        assert_equal(class_foo, translate("singleton(Foo)", erase_generic_types: true))
+        assert_equal(class_foo, translate("singleton(Foo)[Bar]", erase_generic_types: true))
+        assert_equal(simple_array, translate("Array[Foo]", erase_generic_types: true))
+        assert_equal(root_array, translate("T::Array[Foo]", erase_generic_types: true))
+        assert_equal(root_array, translate("::T::Array[Foo]", erase_generic_types: true))
+        assert_equal(root_array, translate("::Array[Bar]", erase_generic_types: true))
+        assert_equal(Type.simple("::Hash"), translate("::Hash[Foo, Bar]", erase_generic_types: true))
+        assert_equal(Type.simple("::Foo"), translate("::Foo[Bar]", erase_generic_types: true))
+        assert_equal(Type.simple("::Types::Foo"), translate("::Types::Foo[Bar]", erase_generic_types: true))
+      end
+
       def test_translate_interface
         assert_equal(Type.untyped, translate("_Foo"))
       end
@@ -170,10 +194,10 @@ module RBI
 
       private
 
-      #: (String) -> RBI::Type
-      def translate(rbs_string)
+      #: (String, ?erase_generic_types: bool) -> RBI::Type
+      def translate(rbs_string, erase_generic_types: false)
         node = ::RBS::Parser.parse_type(rbs_string, require_eof: true)
-        options = MethodTypeTranslator::Options.new
+        options = MethodTypeTranslator::Options.new(erase_generic_types:)
         RBS::TypeTranslator.new(options:).translate(node)
       end
     end


### PR DESCRIPTION
- part of https://github.com/Shopify/spoom/issues/924

Previously, `RBS::TypeTranslator` and `RBS::MethodTypeTranslator` always translated generic types. However, as [`sorbet-runtime` is unable to enforce them](https://sorbet.org/docs/stdlib-generics#generics-and-runtime-checks), they are superfluous in runtime contexts

This PR adds a default `false` `erase_generic_types` kwarg to both translator's constructors. When set to `true` generic types are dropped (`Foo[Bar]` to `Foo`) and type params are treated as `T.anything`