### PR TITLE
Add `Options` object

### DIFF
--- a/lib/rbi/rbs/method_type_translator.rb
+++ b/lib/rbi/rbs/method_type_translator.rb
@@ -15,14 +15,32 @@ module RBI
         end
       end
 
+      class Options
+        #: bool
+        attr_reader :erase_generic_types
+
+        #: (?erase_generic_types: bool) -> void
+        def initialize(erase_generic_types: false)
+          @erase_generic_types = erase_generic_types
+        end
+
+        @default = new.freeze #: Options
+        class << self
+          #: Options
+          attr_reader :default
+        end
+      end
+
       #: Sig
       attr_reader :result
 
-      #: (Method) -> void
-      def initialize(method)
+      #: (Method, ?options: Options) -> void
+      def initialize(method, options: Options.default)
         @method = method
+        @options = options
+
         @result = Sig.new #: Sig
-        @type_translator = TypeTranslator.new #: TypeTranslator
+        @type_translator = TypeTranslator.new(options: @options) #: TypeTranslator
       end
 
       #: (::RBS::MethodType) -> void

--- a/lib/rbi/rbs/type_translator.rb
+++ b/lib/rbi/rbs/type_translator.rb
@@ -35,6 +35,13 @@ module RBI
         end
       end
 
+      Options = MethodTypeTranslator::Options
+
+      #: (?options: Options) -> void
+      def initialize(options: Options.default)
+        @options = options
+      end
+
       #: (rbs_type) -> Type
       def translate(type)
         case type

--- a/rbi/rbi.rbi
+++ b/rbi/rbi.rbi
@@ -1386,8 +1386,8 @@ RBI::Public::DEFAULT = T.let(T.unsafe(nil), RBI::Public)
 module RBI::RBS; end
 
 class RBI::RBS::MethodTypeTranslator
-  sig { params(method: ::RBI::Method).void }
-  def initialize(method); end
+  sig { params(method: ::RBI::Method, options: ::RBI::RBS::MethodTypeTranslator::Options).void }
+  def initialize(method, options: T.unsafe(nil)); end
 
   sig { returns(::RBI::Sig) }
   def result; end
@@ -1417,7 +1417,23 @@ end
 
 class RBI::RBS::MethodTypeTranslator::Error < ::RBI::Error; end
 
+class RBI::RBS::MethodTypeTranslator::Options
+  sig { params(erase_generic_types: T::Boolean).void }
+  def initialize(erase_generic_types: T.unsafe(nil)); end
+
+  sig { returns(T::Boolean) }
+  def erase_generic_types; end
+
+  class << self
+    sig { returns(::RBI::RBS::MethodTypeTranslator::Options) }
+    def default; end
+  end
+end
+
 class RBI::RBS::TypeTranslator
+  sig { params(options: ::RBI::RBS::MethodTypeTranslator::Options).void }
+  def initialize(options: T.unsafe(nil)); end
+
   sig do
     params(
       type: T.any(::RBS::Types::Alias, ::RBS::Types::Bases::Any, ::RBS::Types::Bases::Bool, ::RBS::Types::Bases::Bottom, ::RBS::Types::Bases::Class, ::RBS::Types::Bases::Instance, ::RBS::Types::Bases::Nil, ::RBS::Types::Bases::Self, ::RBS::Types::Bases::Top, ::RBS::Types::Bases::Void, ::RBS::Types::ClassInstance, ::RBS::Types::ClassSingleton, ::RBS::Types::Function, ::RBS::Types::Interface, ::RBS::Types::Intersection, ::RBS::Types::Literal, ::RBS::Types::Optional, ::RBS::Types::Proc, ::RBS::Types::Record, ::RBS::Types::Tuple, ::RBS::Types::Union, ::RBS::Types::UntypedFunction, ::RBS::Types::Variable)
@@ -1449,6 +1465,7 @@ class RBI::RBS::TypeTranslator
   end
 end
 
+RBI::RBS::TypeTranslator::Options = RBI::RBS::MethodTypeTranslator::Options
 RBI::RBS::TypeTranslator::RbsType = T.type_alias { T.any(::RBS::Types::Alias, ::RBS::Types::Bases::Any, ::RBS::Types::Bases::Bool, ::RBS::Types::Bases::Bottom, ::RBS::Types::Bases::Class, ::RBS::Types::Bases::Instance, ::RBS::Types::Bases::Nil, ::RBS::Types::Bases::Self, ::RBS::Types::Bases::Top, ::RBS::Types::Bases::Void, ::RBS::Types::ClassInstance, ::RBS::Types::ClassSingleton, ::RBS::Types::Function, ::RBS::Types::Interface, ::RBS::Types::Intersection, ::RBS::Types::Literal, ::RBS::Types::Optional, ::RBS::Types::Proc, ::RBS::Types::Record, ::RBS::Types::Tuple, ::RBS::Types::Union, ::RBS::Types::UntypedFunction, ::RBS::Types::Variable) }
 
 class RBI::RBSComment < ::RBI::Comment

--- a/test/rbi/rbs/method_type_translator_test.rb
+++ b/test/rbi/rbs/method_type_translator_test.rb
@@ -200,7 +200,12 @@ module RBI
       #: (String, Method) -> RBI::Sig
       def translate(rbs_string, method)
         node = ::RBS::Parser.parse_method_type(rbs_string, require_eof: true)
-        RBS::MethodTypeTranslator.translate(method, node)
+
+        options = MethodTypeTranslator::Options.new
+
+        translator = RBS::MethodTypeTranslator.new(method, options:)
+        translator.visit(node)
+        translator.result
       end
     end
   end

--- a/test/rbi/rbs/type_translator_test.rb
+++ b/test/rbi/rbs/type_translator_test.rb
@@ -173,7 +173,8 @@ module RBI
       #: (String) -> RBI::Type
       def translate(rbs_string)
         node = ::RBS::Parser.parse_type(rbs_string, require_eof: true)
-        RBS::TypeTranslator.new.translate(node)
+        options = MethodTypeTranslator::Options.new
+        RBS::TypeTranslator.new(options:).translate(node)
       end
     end
   end


### PR DESCRIPTION
- counterpart to https://github.com/Shopify/spoom/pull/954

This PR an Options object which will hold the shape of type translation config, including the soon to be added [`erase_generic_types` option](https://github.com/Shopify/spoom/issues/924)