### PR TITLE
Fix anonymous parameter modeling and merging

### DIFF
--- a/lib/rbi/model.rb
+++ b/lib/rbi/model.rb
@@ -599,14 +599,36 @@ module RBI
 
   # @abstract
   class Param < NodeWithComments
+    #: (?loc: Loc?, ?comments: Array[Comment]?) -> void
+    def initialize(loc: nil, comments: nil)
+      super(loc: loc, comments: comments)
+    end
+
+    #: -> String?
+    def name
+      case self
+      when ReqParam, OptParam, KwParam, KwOptParam, RestParam, KwRestParam, BlockParam
+        name
+      end
+    end
+
+    # @abstract
+    #: -> bool
+    def anonymous?
+      raise NotImplementedError, "Abstract method called"
+    end
+  end
+
+  class ReqParam < Param
+    # @override
     #: String
     attr_reader :name
 
-    #: (String name, ?loc: Loc?, ?comments: Array[Comment]?) -> void
-    def initialize(name, loc: nil, comments: nil)
+    #: (String name, ?loc: Loc?, ?comments: Array[Comment]?) ?{ (ReqParam node) -> void } -> void
+    def initialize(name, loc: nil, comments: nil, &block)
       super(loc: loc, comments: comments)
       @name = name.to_s #: String
-      @anonymous = name.start_with?("_") #: bool
+      block&.call(self)
     end
 
     # @override
@@ -615,42 +637,61 @@ module RBI
       name
     end
 
+    # @override
     #: -> bool
     def anonymous?
-      @anonymous
+      false
     end
 
     #: (Object? other) -> bool
     def ==(other)
-      self.class === other &&
-        (name == other.name || anonymous? || other.anonymous?)
-    end
-  end
-
-  class ReqParam < Param
-    #: (String name, ?loc: Loc?, ?comments: Array[Comment]?) ?{ (ReqParam node) -> void } -> void
-    def initialize(name, loc: nil, comments: nil, &block)
-      super(name, loc: loc, comments: comments)
-      block&.call(self)
+      ReqParam === other && (name == other.name)
     end
   end
 
   class OptParam < Param
+    # @override
+    #: String
+    attr_reader :name
+
     #: String
     attr_reader :value
 
     #: (String name, String value, ?loc: Loc?, ?comments: Array[Comment]?) ?{ (OptParam node) -> void } -> void
     def initialize(name, value, loc: nil, comments: nil, &block)
-      super(name, loc: loc, comments: comments)
+      super(loc: loc, comments: comments)
+      @name = name.to_s #: String
       @value = value
       block&.call(self)
+    end
+
+    # @override
+    #: -> String
+    def to_s
+      "#{name} = #{value}"
+    end
+
+    # @override
+    #: -> bool
+    def anonymous?
+      false
+    end
+
+    #: (Object? other) -> bool
+    def ==(other)
+      OptParam === other && (name == other.name)
     end
   end
 
   class RestParam < Param
-    #: (String name, ?loc: Loc?, ?comments: Array[Comment]?) ?{ (RestParam node) -> void } -> void
+    # @override
+    #: String?
+    attr_reader :name
+
+    #: (String? name, ?loc: Loc?, ?comments: Array[Comment]?) ?{ (RestParam node) -> void } -> void
     def initialize(name, loc: nil, comments: nil, &block)
-      super(name, loc: loc, comments: comments)
+      super(loc: loc, comments: comments)
+      @name = name&.to_s #: String?
       block&.call(self)
     end
 
@@ -659,12 +700,28 @@ module RBI
     def to_s
       "*#{name}"
     end
+
+    # @override
+    #: -> bool
+    def anonymous?
+      name.nil?
+    end
+
+    #: (Object? other) -> bool
+    def ==(other)
+      RestParam === other && (name == other.name || anonymous? || other.anonymous?)
+    end
   end
 
   class KwParam < Param
+    # @override
+    #: String
+    attr_reader :name
+
     #: (String name, ?loc: Loc?, ?comments: Array[Comment]?) ?{ (KwParam node) -> void } -> void
     def initialize(name, loc: nil, comments: nil, &block)
-      super(name, loc: loc, comments: comments)
+      super(loc: loc, comments: comments)
+      @name = name.to_s #: String
       block&.call(self)
     end
 
@@ -673,15 +730,31 @@ module RBI
     def to_s
       "#{name}:"
     end
+
+    # @override
+    #: -> bool
+    def anonymous?
+      false
+    end
+
+    #: (Object? other) -> bool
+    def ==(other)
+      KwParam === other && (name == other.name)
+    end
   end
 
   class KwOptParam < Param
+    # @override
+    #: String
+    attr_reader :name
+
     #: String
     attr_reader :value
 
     #: (String name, String value, ?loc: Loc?, ?comments: Array[Comment]?) ?{ (KwOptParam node) -> void } -> void
     def initialize(name, value, loc: nil, comments: nil, &block)
-      super(name, loc: loc, comments: comments)
+      super(loc: loc, comments: comments)
+      @name = name.to_s #: String
       @value = value
       block&.call(self)
     end
@@ -689,28 +762,60 @@ module RBI
     # @override
     #: -> String
     def to_s
-      "#{name}:"
+      "#{name}: #{value}"
+    end
+
+    # @override
+    #: -> bool
+    def anonymous?
+      false
+    end
+
+    #: (Object? other) -> bool
+    def ==(other)
+      KwOptParam === other && (name == other.name)
     end
   end
 
   class KwRestParam < Param
-    #: (String name, ?loc: Loc?, ?comments: Array[Comment]?) ?{ (KwRestParam node) -> void } -> void
+    # @override
+    #: String?
+    attr_reader :name
+
+    #: (String? name, ?loc: Loc?, ?comments: Array[Comment]?) ?{ (KwRestParam node) -> void } -> void
     def initialize(name, loc: nil, comments: nil, &block)
-      super(name, loc: loc, comments: comments)
+      super(loc: loc, comments: comments)
+      @name = name&.to_s #: String?
       block&.call(self)
     end
 
     # @override
     #: -> String
     def to_s
-      "**#{name}:"
+      "**#{name}"
+    end
+
+    # @override
+    #: -> bool
+    def anonymous?
+      name.nil?
+    end
+
+    #: (Object? other) -> bool
+    def ==(other)
+      KwRestParam === other && (name == other.name || anonymous? || other.anonymous?)
     end
   end
 
   class BlockParam < Param
-    #: (String name, ?loc: Loc?, ?comments: Array[Comment]?) ?{ (BlockParam node) -> void } -> void
+    # @override
+    #: String?
+    attr_reader :name
+
+    #: (String? name, ?loc: Loc?, ?comments: Array[Comment]?) ?{ (BlockParam node) -> void } -> void
     def initialize(name, loc: nil, comments: nil, &block)
-      super(name, loc: loc, comments: comments)
+      super(loc: loc, comments: comments)
+      @name = name
       block&.call(self)
     end
 
@@ -718,6 +823,17 @@ module RBI
     #: -> String
     def to_s
       "&#{name}"
+    end
+
+    # @override
+    #: -> bool
+    def anonymous?
+      name.nil?
+    end
+
+    #: (Object? other) -> bool
+    def ==(other)
+      BlockParam === other && (name == other.name || anonymous? || other.anonymous?)
     end
   end
 
@@ -1023,9 +1139,15 @@ module RBI
     def initialize(name, type, loc: nil, comments: nil, &block)
       super(loc: loc, comments: comments)
       @name = name.to_s #: String
-      @anonymous = name.start_with?("_") #: bool
+      @anonymous = name == "*" || name == "**" || name == "&" #: bool
       @type = type
       block&.call(self)
+    end
+
+    # @override
+    #: -> String
+    def to_s
+      name
     end
 
     #: -> bool

--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -726,7 +726,7 @@ module RBI
             )
           when Prism::RestParameterNode
             RestParam.new(
-              param.name&.to_s || "*args",
+              param.name&.to_s,
               loc: node_loc(param),
               comments: node_comments(param),
             )
@@ -745,13 +745,13 @@ module RBI
             )
           when Prism::KeywordRestParameterNode
             KwRestParam.new(
-              param.name&.to_s || "**kwargs",
+              param.name&.to_s,
               loc: node_loc(param),
               comments: node_comments(param),
             )
           when Prism::BlockParameterNode
             BlockParam.new(
-              param.name&.to_s || "",
+              param.name&.to_s,
               loc: node_loc(param),
               comments: node_comments(param),
             )
@@ -977,9 +977,19 @@ module RBI
       #: (Prism::AssocNode node) -> void
       def visit_assoc_node(node)
         @current.params << SigParam.new(
-          node_string!(node.key).delete_suffix(":"),
+          sig_param_name(node.key),
           node_string!(node.value),
         )
+      end
+
+      #: (Prism::Node node) -> String
+      def sig_param_name(node)
+        case node
+        when Prism::SymbolNode
+          node.value.to_s
+        else
+          node_string!(node).delete_suffix(":")
+        end
       end
 
       #: (Prism::CallNode node, String value) -> bool

--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -363,51 +363,43 @@ module RBI
     # @override
     #: (ReqParam node) -> void
     def visit_req_param(node)
-      print(node.name)
+      self.print(node.to_s)
     end
 
     # @override
     #: (OptParam node) -> void
     def visit_opt_param(node)
-      print(node.name)
-      print(" = ")
-      print(node.value)
+      self.print(node.to_s)
     end
 
     # @override
     #: (RestParam node) -> void
     def visit_rest_param(node)
-      print("*")
-      print(node.name)
+      self.print(node.to_s)
     end
 
     # @override
     #: (KwParam node) -> void
     def visit_kw_param(node)
-      print(node.name)
-      print(":")
+      self.print(node.to_s)
     end
 
     # @override
     #: (KwOptParam node) -> void
     def visit_kw_opt_param(node)
-      print(node.name)
-      print(": ")
-      print(node.value)
+      self.print(node.to_s)
     end
 
     # @override
     #: (KwRestParam node) -> void
     def visit_kw_rest_param(node)
-      print("**")
-      print(node.name)
+      self.print(node.to_s)
     end
 
     # @override
     #: (BlockParam node) -> void
     def visit_block_param(node)
-      print("&")
-      print(node.name) unless node.name.empty?
+      self.print(node.to_s)
     end
 
     # @override
@@ -522,7 +514,7 @@ module RBI
     # @override
     #: (SigParam node) -> void
     def visit_sig_param(node)
-      print(node.name)
+      print(node.anonymous? ? node.name.inspect : node.name)
       print(": ")
       self.print(node.type.to_s)
     end
@@ -694,25 +686,15 @@ module RBI
     def print_param_comment_leading_space(node, last:)
       printn
       printt
-      print(" " * (node.name.size + 1))
+      print(" " * (node.to_s.size + 1))
       print(" ") unless last
-      case node
-      when OptParam
-        print(" " * (node.value.size + 3))
-      when RestParam, KwParam, BlockParam
-        print(" ")
-      when KwRestParam
-        print("  ")
-      when KwOptParam
-        print(" " * (node.value.size + 2))
-      end
     end
 
     #: (SigParam node, last: bool) -> void
     def print_sig_param_comment_leading_space(node, last:)
       printn
       printt
-      print(" " * (node.name.size + node.type.to_s.size + 3))
+      print(" " * (node.to_s.size + node.type.to_s.size + 3))
       print(" ") unless last
     end
 

--- a/lib/rbi/rbs/method_type_translator.rb
+++ b/lib/rbi/rbs/method_type_translator.rb
@@ -123,13 +123,25 @@ module RBI
         param_name = param.name&.to_s
 
         unless param_name
-          method_param_name = @method.params[index]
-          raise Error, "No method param name found for parameter ##{index}" unless method_param_name
+          method_param = @method.params[index]
+          raise Error, "No method param name found for parameter ##{index}" unless method_param
 
-          param_name = method_param_name.name
+          param_name = method_param.name || anonymous_param_name(method_param)
         end
 
         SigParam.new(param_name, param_type)
+      end
+
+      #: (Param) -> String?
+      def anonymous_param_name(param)
+        case param
+        when RestParam
+          "*"
+        when KwRestParam
+          "**"
+        when BlockParam
+          "&"
+        end
       end
 
       #: (untyped) -> Type

--- a/lib/rbi/rbs/method_type_translator.rb
+++ b/lib/rbi/rbs/method_type_translator.rb
@@ -64,7 +64,7 @@ module RBI
         block_param = @method.params.grep(RBI::BlockParam).first
         raise Error, "No block param found" unless block_param
 
-        block_name = block_param.name.empty? ? "block" : block_param.name
+        block_name = block_param.name || "&"
         block_type = translate_type(type.type) #: as RBI::Type::Proc
 
         bind = type.self_type

--- a/lib/rbi/rbs_printer.rb
+++ b/lib/rbi/rbs_printer.rb
@@ -613,7 +613,8 @@ module RBI
     # @override
     #: (KwRestParam node) -> void
     def visit_kw_rest_param(node)
-      print("**#{node.name}: untyped")
+      print("**untyped")
+      print(" #{node.name}") if node.name
     end
 
     # @override
@@ -912,25 +913,15 @@ module RBI
     def print_param_comment_leading_space(node, last:)
       printn
       printt
-      print(" " * (node.name.size + 1))
+      print(" " * (node.to_s.size + 1))
       print(" ") unless last
-      case node
-      when OptParam
-        print(" " * (node.value.size + 3))
-      when RestParam, KwParam, BlockParam
-        print(" ")
-      when KwRestParam
-        print("  ")
-      when KwOptParam
-        print(" " * (node.value.size + 2))
-      end
     end
 
     #: (SigParam node, last: bool) -> void
     def print_sig_param_comment_leading_space(node, last:)
       printn
       printt
-      print(" " * (node.name.size + node.type.to_s.size + 3))
+      print(" " * (node.to_s.size + node.type.to_s.size + 3))
       print(" ") unless last
     end
 

--- a/lib/rbi/rewriters/add_sig_templates.rb
+++ b/lib/rbi/rewriters/add_sig_templates.rb
@@ -45,7 +45,21 @@ module RBI
         return unless method.sigs.empty?
 
         method.sigs << Sig.new(
-          params: method.params.map { |param| SigParam.new(param.name, "::T.untyped") },
+          params: method.params.map do |param|
+            case param
+            when RBI::RestParam
+              SigParam.new(param.name || "*", "::T.untyped")
+            when RBI::KwRestParam
+              SigParam.new(param.name || "**", "::T.untyped")
+            when RBI::BlockParam
+              SigParam.new(param.name || "&", "::T.untyped")
+            else
+              SigParam.new(
+                param.name, #: as !nil
+                "::T.untyped",
+              )
+            end
+          end,
           return_type: "::T.untyped",
         )
         add_todo_comment(method)

--- a/lib/rbi/rewriters/merge_trees.rb
+++ b/lib/rbi/rewriters/merge_trees.rb
@@ -464,11 +464,17 @@ module RBI
     # @override
     #: (Node other) -> bool
     def compatible_with?(other)
-      other.is_a?(Method) &&
-        name == other.name &&
-        params == other.params &&
-        at_most_one_side_anonymous?(other) &&
-        (sigs.empty? || other.sigs.empty? || sigs == other.sigs)
+      return false unless other.is_a?(Method)
+      return false unless name == other.name
+      return false unless params.size == other.params.size
+
+      if sigs.empty? && other.sigs.empty?
+        compatible_params?(other)
+      elsif sigs.empty? || other.sigs.empty?
+        true
+      else
+        compatible_params?(other) && sigs == other.sigs
+      end
     end
 
     # @override
@@ -478,14 +484,14 @@ module RBI
 
       super
 
-      # If self is the all-anonymous side (since compatible_with? ensures
-      # at most one side is), or if self has no sigs but other does, adopt
-      # other's non-anonymous param names and sigs.
-      if params.all?(&:anonymous?) || (sigs.empty? && !other.sigs.empty?)
+      if sigs.empty? && !other.sigs.empty?
         @params = other.params.dup
-        @sigs = other.sigs.dup unless other.sigs.empty?
+        @sigs = other.sigs.dup
         return
       end
+
+      @params = merge_params(params, other.params)
+      rename_sigs_params(sigs, @params)
 
       other.sigs.each do |sig|
         sigs << sig unless sigs.include?(sig)
@@ -495,10 +501,47 @@ module RBI
     private
 
     #: (Method other) -> bool
-    def at_most_one_side_anonymous?(other)
-      (params.all?(&:anonymous?) && other.params.none?(&:anonymous?)) ||
-        (params.none?(&:anonymous?) && other.params.all?(&:anonymous?)) ||
-        (params.none?(&:anonymous?) && other.params.none?(&:anonymous?))
+    def compatible_params?(other)
+      return true if params == other.params
+
+      params.zip(other.params).all? do |p1, p2|
+        p1.compatible_with?(p2)
+      end
+    end
+
+    #: (Array[Param] preferred, Array[Param] fallback) -> Array[Param]
+    def merge_params(preferred, fallback)
+      preferred.zip(fallback).map do |p1, p2|
+        if p1.anonymous?
+          p2.dup #: as !nil
+        else
+          p1.dup
+        end
+      end
+    end
+
+    #: (Array[Sig] sigs, Array[Param] params) -> void
+    def rename_sigs_params(sigs, params)
+      sigs.each do |sig|
+        sig_params = sig.params.zip(params).map do |sig_param, param|
+          param = param #: as !nil
+          name = if sig_param.anonymous? && !param.anonymous?
+            param.name #: as !nil
+          else
+            sig_param.name
+          end
+          SigParam.new(name, sig_param.type)
+        end
+        sig.params.replace(sig_params)
+      end
+    end
+  end
+
+  class Param
+    # @override
+    #: (Node? other) -> bool
+    def compatible_with?(other)
+      self.class === other && (anonymous? || other.anonymous? || name == other.name)
     end
   end
 

--- a/rbi/rbi.rbi
+++ b/rbi/rbi.rbi
@@ -187,13 +187,22 @@ end
 class RBI::BlockParam < ::RBI::Param
   sig do
     params(
-      name: ::String,
+      name: T.nilable(::String),
       loc: T.nilable(::RBI::Loc),
       comments: T.nilable(T::Array[::RBI::Comment]),
       block: T.nilable(T.proc.params(node: ::RBI::BlockParam).void)
     ).void
   end
   def initialize(name, loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
+
+  sig { params(other: T.nilable(::Object)).returns(T::Boolean) }
+  def ==(other); end
+
+  sig { override.returns(T::Boolean) }
+  def anonymous?; end
+
+  sig { override.returns(T.nilable(::String)) }
+  def name; end
 
   sig { override.returns(::String) }
   def to_s; end
@@ -537,6 +546,15 @@ class RBI::KwOptParam < ::RBI::Param
   end
   def initialize(name, value, loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
 
+  sig { params(other: T.nilable(::Object)).returns(T::Boolean) }
+  def ==(other); end
+
+  sig { override.returns(T::Boolean) }
+  def anonymous?; end
+
+  sig { override.returns(::String) }
+  def name; end
+
   sig { override.returns(::String) }
   def to_s; end
 
@@ -555,6 +573,15 @@ class RBI::KwParam < ::RBI::Param
   end
   def initialize(name, loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
 
+  sig { params(other: T.nilable(::Object)).returns(T::Boolean) }
+  def ==(other); end
+
+  sig { override.returns(T::Boolean) }
+  def anonymous?; end
+
+  sig { override.returns(::String) }
+  def name; end
+
   sig { override.returns(::String) }
   def to_s; end
 end
@@ -562,13 +589,22 @@ end
 class RBI::KwRestParam < ::RBI::Param
   sig do
     params(
-      name: ::String,
+      name: T.nilable(::String),
       loc: T.nilable(::RBI::Loc),
       comments: T.nilable(T::Array[::RBI::Comment]),
       block: T.nilable(T.proc.params(node: ::RBI::KwRestParam).void)
     ).void
   end
   def initialize(name, loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
+
+  sig { params(other: T.nilable(::Object)).returns(T::Boolean) }
+  def ==(other); end
+
+  sig { override.returns(T::Boolean) }
+  def anonymous?; end
+
+  sig { override.returns(T.nilable(::String)) }
+  def name; end
 
   sig { override.returns(::String) }
   def to_s; end
@@ -729,7 +765,13 @@ class RBI::Method < ::RBI::NodeWithComments
   private
 
   sig { params(other: ::RBI::Method).returns(T::Boolean) }
-  def at_most_one_side_anonymous?(other); end
+  def compatible_params?(other); end
+
+  sig { params(preferred: T::Array[::RBI::Param], fallback: T::Array[::RBI::Param]).returns(T::Array[::RBI::Param]) }
+  def merge_params(preferred, fallback); end
+
+  sig { params(sigs: T::Array[::RBI::Sig], params: T::Array[::RBI::Param]).void }
+  def rename_sigs_params(sigs, params); end
 end
 
 class RBI::MixesInClassMethods < ::RBI::Mixin
@@ -898,6 +940,18 @@ class RBI::OptParam < ::RBI::Param
   end
   def initialize(name, value, loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
 
+  sig { params(other: T.nilable(::Object)).returns(T::Boolean) }
+  def ==(other); end
+
+  sig { override.returns(T::Boolean) }
+  def anonymous?; end
+
+  sig { override.returns(::String) }
+  def name; end
+
+  sig { override.returns(::String) }
+  def to_s; end
+
   sig { returns(::String) }
   def value; end
 end
@@ -905,20 +959,17 @@ end
 class RBI::Param < ::RBI::NodeWithComments
   abstract!
 
-  sig { params(name: ::String, loc: T.nilable(::RBI::Loc), comments: T.nilable(T::Array[::RBI::Comment])).void }
-  def initialize(name, loc: T.unsafe(nil), comments: T.unsafe(nil)); end
+  sig { params(loc: T.nilable(::RBI::Loc), comments: T.nilable(T::Array[::RBI::Comment])).void }
+  def initialize(loc: T.unsafe(nil), comments: T.unsafe(nil)); end
 
-  sig { params(other: T.nilable(::Object)).returns(T::Boolean) }
-  def ==(other); end
-
-  sig { returns(T::Boolean) }
+  sig { abstract.returns(T::Boolean) }
   def anonymous?; end
 
-  sig { returns(::String) }
-  def name; end
+  sig { override.params(other: T.nilable(::RBI::Node)).returns(T::Boolean) }
+  def compatible_with?(other); end
 
-  sig { override.returns(::String) }
-  def to_s; end
+  sig { returns(T.nilable(::String)) }
+  def name; end
 end
 
 class RBI::ParseError < ::RBI::Error
@@ -984,6 +1035,9 @@ class RBI::Parser::SigBuilder < ::RBI::Parser::Visitor
 
   sig { returns(::RBI::Sig) }
   def current; end
+
+  sig { params(node: ::Prism::Node).returns(::String) }
+  def sig_param_name(node); end
 
   sig { override.params(node: ::Prism::AssocNode).void }
   def visit_assoc_node(node); end
@@ -1400,6 +1454,9 @@ class RBI::RBS::MethodTypeTranslator
 
   private
 
+  sig { params(param: ::RBI::Param).returns(T.nilable(::String)) }
+  def anonymous_param_name(param); end
+
   sig { params(param: ::RBS::Types::Function::Param, index: ::Integer).returns(::RBI::SigParam) }
   def translate_function_param(param, index); end
 
@@ -1740,6 +1797,18 @@ class RBI::ReqParam < ::RBI::Param
     ).void
   end
   def initialize(name, loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
+
+  sig { params(other: T.nilable(::Object)).returns(T::Boolean) }
+  def ==(other); end
+
+  sig { override.returns(T::Boolean) }
+  def anonymous?; end
+
+  sig { override.returns(::String) }
+  def name; end
+
+  sig { override.returns(::String) }
+  def to_s; end
 end
 
 class RBI::RequiresAncestor < ::RBI::NodeWithComments
@@ -1761,13 +1830,22 @@ end
 class RBI::RestParam < ::RBI::Param
   sig do
     params(
-      name: ::String,
+      name: T.nilable(::String),
       loc: T.nilable(::RBI::Loc),
       comments: T.nilable(T::Array[::RBI::Comment]),
       block: T.nilable(T.proc.params(node: ::RBI::RestParam).void)
     ).void
   end
   def initialize(name, loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
+
+  sig { params(other: T.nilable(::Object)).returns(T::Boolean) }
+  def ==(other); end
+
+  sig { override.returns(T::Boolean) }
+  def anonymous?; end
+
+  sig { override.returns(T.nilable(::String)) }
+  def name; end
 
   sig { override.returns(::String) }
   def to_s; end
@@ -2251,6 +2329,9 @@ class RBI::SigParam < ::RBI::NodeWithComments
 
   sig { returns(::String) }
   def name; end
+
+  sig { override.returns(::String) }
+  def to_s; end
 
   sig { returns(T.any(::RBI::Type, ::String)) }
   def type; end

--- a/test/rbi/model_test.rb
+++ b/test/rbi/model_test.rb
@@ -374,7 +374,7 @@ module RBI
       m3 << KwOptParam.new("e", "42")
       m3 << KwRestParam.new("f")
       m3 << BlockParam.new("g")
-      assert_equal("#m3(a, b, *c, d:, e:, **f:, &g)", m3.to_s)
+      assert_equal("#m3(a, b = 42, *c, d:, e: 42, **f, &g)", m3.to_s)
 
       a1 = AttrReader.new(:m1)
       assert_equal(".attr_reader(:m1)", a1.to_s)

--- a/test/rbi/rbs/method_type_translator_test.rb
+++ b/test/rbi/rbs/method_type_translator_test.rb
@@ -111,6 +111,35 @@ module RBI
         )
       end
 
+      def test_translate_anonymous_params
+        sig = translate(
+          "(A a, *B, **C) { (D) -> E } -> void",
+          Method.new("foo", params: [
+            ReqParam.new("a"),
+            RestParam.new(nil),
+            KwRestParam.new(nil),
+            BlockParam.new(nil),
+          ]),
+        )
+
+        assert_equal(["a", "*", "**", "&"], sig.params.map(&:name))
+        assert_equal([false, true, true, true], sig.params.map(&:anonymous?))
+        assert_equal(
+          [
+            SigParam.new("a", Type.simple("A")),
+            SigParam.new("*", Type.simple("B")),
+            SigParam.new("**", Type.simple("C")),
+            SigParam.new(
+              "&",
+              Type.proc
+                .params(arg0: Type.simple("D"))
+                .returns(Type.simple("E")),
+            ),
+          ],
+          sig.params,
+        )
+      end
+
       def test_translate_block_param
         sig = translate(
           "() { (Integer) [self: Foo] -> String } -> void",

--- a/test/rbi/rbs_printer_test.rb
+++ b/test/rbi/rbs_printer_test.rb
@@ -316,8 +316,25 @@ module RBI
 
       # Actual method parameters are ignored, RBS translation relies on the RBI signature
       assert_equal(<<~RBI, rbi.rbs_string)
-        def foo: (untyped a, ?untyped b, *untyped c, d: untyped, ?e: untyped, **f: untyped) { (*untyped) -> untyped } -> untyped
+        def foo: (untyped a, ?untyped b, *untyped c, d: untyped, ?e: untyped, **untyped f) { (*untyped) -> untyped } -> untyped
       RBI
+    end
+
+    def test_print_methods_with_anonymous_keyword_rest_parameter
+      rbi = parse_rbi(<<~RBI)
+        class Foo
+          def foo(**); end
+        end
+      RBI
+
+      rbs = rbi.rbs_string
+
+      assert_equal(<<~RBS, rbs)
+        class Foo
+          def foo: (**untyped) -> untyped
+        end
+      RBS
+      ::RBS::Parser.parse_signature(rbs)
     end
 
     def test_print_methods_with_vararg_followed_by_positional_arg
@@ -1135,7 +1152,7 @@ module RBI
       # Comments are ignored when applied to RBS parameters
       assert_equal(<<~RBI, rbi.rbs_string)
         # comment
-        def foo: (untyped a, ?untyped b, *untyped c, d: untyped, ?e: untyped, **f: untyped) { (*untyped) -> untyped } -> untyped
+        def foo: (untyped a, ?untyped b, *untyped c, d: untyped, ?e: untyped, **untyped f) { (*untyped) -> untyped } -> untyped
       RBI
     end
 

--- a/test/rbi/rewriters/merge_trees_test.rb
+++ b/test/rbi/rewriters/merge_trees_test.rb
@@ -1185,23 +1185,23 @@ module RBI
 
     # When methods are structurally identical (same param types, count, and order) but differ only
     # in parameter names, they should be treated as compatible when at most one side has all
-    # anonymous params (names starting with `_`). In that case, we use the non-anonymous names.
+    # anonymous params (names being `nil`). In that case, we use the non-anonymous names.
 
     def test_merge_methods_with_anonymous_params
       tree1 = parse_rbi(<<~RBI)
         class Foo
-          def m1(a); end
-          def m2(_a); end
-          def m3(a, b); end
-          def m4(_a, _b = nil, *_c, _d:, _e: nil, **_f, &_g); end
+          def m1(*a); end
+          def m2(*); end
+          def m3(*a, **b); end
+          def m4(a, b = nil, *, d:, e: nil, **, &); end
         end
       RBI
 
       tree2 = parse_rbi(<<~RBI)
         class Foo
-          def m1(_a); end
-          def m2(a); end
-          def m3(_a, _b); end
+          def m1(*); end
+          def m2(*a); end
+          def m3(*, **); end
           def m4(a, b = nil, *c, d:, e: nil, **f, &g); end
         end
       RBI
@@ -1213,9 +1213,9 @@ module RBI
 
         assert_equal(<<~RBI, res.string)
           class Foo
-            def m1(a); end
-            def m2(a); end
-            def m3(a, b); end
+            def m1(*a); end
+            def m2(*a); end
+            def m3(*a, **b); end
             def m4(a, b = nil, *c, d:, e: nil, **f, &g); end
           end
         RBI
@@ -1226,39 +1226,39 @@ module RBI
     def test_merge_methods_with_anonymous_params_and_sigs
       tree1 = parse_rbi(<<~RBI)
         class Foo
-          sig { params(_a: Integer, _b: String).void }
-          def m1(_a, _b); end
+          sig { params("*": Integer, "**": String).void }
+          def m1(*, **); end
 
           sig { params(a: Integer).returns(String) }
-          def m2(a); end
+          def m2(*a); end
 
-          def m3(_a); end
+          def m3(*); end
 
           sig do
             params(
-              _a: Integer,
-              _b: String,
-              _c: Float,
-              _d: Symbol,
-              _e: T::Boolean,
-              _f: T::Hash[String, Integer],
-              _g: T.proc.void
+              a: Integer,
+              b: String,
+              "*": Float,
+              d: Symbol,
+              e: T::Boolean,
+              "**": T::Hash[String, Integer],
+              "&": T.proc.void
             ).void
           end
-          def m4(_a, _b = nil, *_c, _d:, _e: nil, **_f, &_g); end
+          def m4(a, b = nil, *, d:, e: nil, **, &); end
         end
       RBI
 
       tree2 = parse_rbi(<<~RBI)
         class Foo
           sig { params(a: Integer, b: String).void }
-          def m1(a, b); end
+          def m1(*a, **b); end
 
-          sig { params(_a: Integer).returns(String) }
-          def m2(_a); end
+          sig { params("*": Integer).returns(String) }
+          def m2(*); end
 
           sig { params(a: Integer).void }
-          def m3(a); end
+          def m3(*a); end
 
           sig do
             params(
@@ -1280,13 +1280,13 @@ module RBI
       assert_equal(<<~RBI, res.string)
         class Foo
           sig { params(a: Integer, b: String).void }
-          def m1(a, b); end
+          def m1(*a, **b); end
 
           sig { params(a: Integer).returns(String) }
-          def m2(a); end
+          def m2(*a); end
 
           sig { params(a: Integer).void }
-          def m3(a); end
+          def m3(*a); end
 
           sig { params(a: Integer, b: String, c: Float, d: Symbol, e: T::Boolean, f: T::Hash[String, Integer], g: T.proc.void).void }
           def m4(a, b = nil, *c, d:, e: nil, **f, &g); end
@@ -1337,14 +1337,18 @@ module RBI
     def test_merge_methods_without_sig_adopts_params_and_sig_from_other
       tree1 = parse_rbi(<<~RBI)
         class Foo
-          def expand=(value); end
+          def foo(value); end
+          def bar(value); end
         end
       RBI
 
       tree2 = parse_rbi(<<~RBI)
         class Foo
-          sig { params(_a_different_name: T.nilable(T::Array[String])).returns(T.nilable(T::Array[String])) }
-          def expand=(_a_different_name); end
+          sig { params(a_different_name: String).void }
+          def foo(a_different_name); end
+
+          sig { params("*": String).void }
+          def bar(*); end
         end
       RBI
 
@@ -1352,8 +1356,11 @@ module RBI
 
       assert_equal(<<~RBI, res.string)
         class Foo
-          sig { params(_a_different_name: T.nilable(T::Array[String])).returns(T.nilable(T::Array[String])) }
-          def expand=(_a_different_name); end
+          sig { params(a_different_name: String).void }
+          def foo(a_different_name); end
+
+          sig { params("*": String).void }
+          def bar(*); end
         end
       RBI
       assert_empty(res.conflicts)

--- a/test/rbi/rewriters/translate_rbs_sigs_test.rb
+++ b/test/rbi/rewriters/translate_rbs_sigs_test.rb
@@ -53,7 +53,7 @@ module RBI
       RBI
 
       assert_equal(<<~RBI, tree)
-        sig { params(block: ::T.proc.returns(::T.untyped)).returns(::T.untyped) }
+        sig { params("&": ::T.proc.returns(::T.untyped)).returns(::T.untyped) }
         def foo(&); end
       RBI
     end


### PR DESCRIPTION
## Summary

Fixes Shopify/spoom#928.

This updates RBI’s parameter model to represent Ruby anonymous parameters faithfully instead of approximating anonymity through parameter names.

Ruby supports anonymous rest, keyword rest, and block parameters:

```rb
def foo(*); end
def foo(**); end
def foo(&); end
```

Prism represents these with `name == nil`. RBI now preserves that information in the model instead of assigning synthetic names.

## Previous behavior

Before this change, every `RBI::Param` had a non-nil `name`, and anonymity was tracked through an `@anonymous` ivar derived from the name:

```rb
@anonymous = name.start_with?("_")
```

That meant names starting with `_` were treated as anonymous, even though they are still real Ruby parameter names.

However, this was name-based, not syntax-based. True Ruby anonymous parameters could not be represented directly because the model required a string name. The parser had to synthesize names instead:

```rb
def foo(*); end   # RestParam name became "*args"
def foo(**); end  # KwRestParam name became "**kwargs"
def foo(&); end   # BlockParam name became ""
```

Merge behavior was also somewhat surprising:

* `_`-prefixed names acted as wildcards for parameters of the same kind.
* Anonymous compatibility was all-or-nothing at the method level.
* Mixed anonymous/named parameter lists could conflict even when individual params were otherwise compatible.
* Merge could prefer/adopt parameter names from the other side depending on which side had signatures.
* The result could be asymmetric depending on which tree was merged into which.

## What changed

* `RBI::Param` is now more abstract and no longer stores a required `name`.
* Named parameter classes own non-nil names:
  * `ReqParam`
  * `OptParam`
  * `KwParam`
  * `KwOptParam`
* Optionally-anonymous parameter classes own nilable names:
  * `RestParam`
  * `KwRestParam`
  * `BlockParam`
* Anonymous params no longer carry an `@anonymous` ivar.
  * Anonymous-ness is derived from the parameter shape and whether the name is `nil`.
* Parser preserves `nil` names for anonymous Ruby params:
  * `*`
  * `**`
  * `&`
* Sig generation still uses printable projection names for anonymous params:
  * anonymous rest → `"*"`
  * anonymous kwrest → `"**"`
  * anonymous block → `"&"`
* Sig parsing/printing handles those quoted projection names correctly.

## Merge behavior

Method merging now treats anonymous params as compatible with named params only when the parameter kind is compatible.

Anonymous params are not a wildcard for arbitrary parameter shapes. They only mean “this parameter has no name.”

For example:

* `RestParam(nil)` is compatible with `RestParam("args")`
* `KwRestParam(nil)` is compatible with `KwRestParam("kwargs")`
* `BlockParam(nil)` is compatible with `BlockParam("block")`
* `RestParam(nil)` is not compatible with `ReqParam("arg")`

When one side has an anonymous parameter and the other side has a named parameter of the same kind, merge prefers the non-anonymous name.

Example:

```rb
sig { params("*": Integer, "**": T::Hash[Symbol, String], "&": T.proc.void).void }
def foo(*, **, &); end
```

merged with:

```rb
sig { params(args: Integer, kwargs: T::Hash[Symbol, String], block: T.proc.void).void }
def foo(*args, **kwargs, &block); end
```

produces:

```rb
sig { params(args: Integer, kwargs: T::Hash[Symbol, String], block: T.proc.void).void }
def foo(*args, **kwargs, &block); end
```

This also updates sig merging so anonymous sig projection names are renamed to match the final merged method parameters.

## Breaking changes

This is a breaking API change for consumers of the RBI model.

Previously, callers could generally assume every parameter had a non-nil name-like value. That is no longer true:

* `RBI::Param` itself no longer stores a required `name`.
* `RestParam#name`, `KwRestParam#name`, and `BlockParam#name` can now be `nil`.
* Anonymous parameters are no longer represented by synthesized names.
* `_`-prefixed parameter names are no longer considered anonymous by default.
* Code that previously compared anonymous params by placeholder names must now handle `nil` names or call `anonymous?`.

Merge behavior changed as well:

* anonymous-vs-named params of the same kind can now merge
* the merged method prefers the non-anonymous name
* anonymous params are not considered compatible across different parameter kinds
* `_`-prefixed named params no longer act as anonymous wildcards

This makes the model more accurate, but downstream code assuming anonymous params have stable synthetic names, or assuming `_`-prefixed names are anonymous, will need to be updated.
