### PR TITLE
Introduce ForwardingParam for argument forwarding

### DIFF
--- a/lib/rbi/model.rb
+++ b/lib/rbi/model.rb
@@ -547,6 +547,11 @@ module RBI
       params << BlockParam.new(name)
     end
 
+    #: -> void
+    def add_forwarding_param
+      params << ForwardingParam.new
+    end
+
     #: (
     #|   ?params: Array[SigParam]?,
     #|   ?return_type: (String | Type),
@@ -607,7 +612,7 @@ module RBI
     #: -> String?
     def name
       case self
-      when ReqParam, OptParam, KwParam, KwOptParam, RestParam, KwRestParam, BlockParam
+      when ReqParam, OptParam, KwParam, KwOptParam, RestParam, KwRestParam, BlockParam, ForwardingParam
         name
       end
     end
@@ -834,6 +839,38 @@ module RBI
     #: (Object? other) -> bool
     def ==(other)
       BlockParam === other && (name == other.name || anonymous? || other.anonymous?)
+    end
+  end
+
+  # The `...` in `def m(...)`
+  class ForwardingParam < Param
+    # @override
+    #: -> nil
+    def name
+      nil
+    end
+
+    #: (?loc: Loc?, ?comments: Array[Comment]?) ?{ (ForwardingParam node) -> void } -> void
+    def initialize(loc: nil, comments: nil, &block)
+      super(loc: loc, comments: comments)
+      block&.call(self)
+    end
+
+    # @override
+    #: -> String
+    def to_s
+      "..."
+    end
+
+    # @override
+    #: -> bool
+    def anonymous?
+      false
+    end
+
+    #: (Object? other) -> bool
+    def ==(other)
+      ForwardingParam === other
     end
   end
 

--- a/lib/rbi/model.rb
+++ b/lib/rbi/model.rb
@@ -552,6 +552,11 @@ module RBI
       params << BlockParam.new(name)
     end
 
+    #: -> void
+    def add_forwarding_param
+      params << ForwardingParam.new
+    end
+
     #: (
     #|   ?params: Array[SigParam]?,
     #|   ?return_type: (String | Type),
@@ -615,7 +620,7 @@ module RBI
     #: -> String?
     def name
       case self
-      when ReqParam, OptParam, KwParam, KwOptParam, RestParam, KwRestParam, BlockParam
+      when ReqParam, OptParam, KwParam, KwOptParam, RestParam, KwRestParam, BlockParam, ForwardingParam
         name
       end
     end
@@ -867,6 +872,38 @@ module RBI
     #: (Object? other) -> bool
     def ==(other)
       BlockParam === other && (name == other.name || anonymous? || other.anonymous?)
+    end
+  end
+
+  # The `...` in `def m(...)`
+  class ForwardingParam < Param
+    # @override
+    #: -> nil
+    def name
+      nil
+    end
+
+    #: (?loc: Loc?, ?comments: Array[Comment]?) ?{ (ForwardingParam node) -> void } -> void
+    def initialize(loc: nil, comments: nil, &block)
+      super(loc: loc, comments: comments)
+      block&.call(self)
+    end
+
+    # @override
+    #: -> String
+    def to_s
+      "..."
+    end
+
+    # @override
+    #: -> bool
+    def anonymous?
+      false
+    end
+
+    #: (Object? other) -> bool
+    def ==(other)
+      ForwardingParam === other
     end
   end
 

--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -755,6 +755,11 @@ module RBI
               loc: node_loc(param),
               comments: node_comments(param),
             )
+          when Prism::ForwardingParameterNode
+            ForwardingParam.new(
+              loc: node_loc(param),
+              comments: node_comments(param),
+            )
           else
             raise ParseError.new("Unexpected parameter node `#{param.class}`", node_loc(param))
           end

--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -775,6 +775,11 @@ module RBI
               loc: node_loc(param),
               comments: node_comments(param),
             )
+          when Prism::ForwardingParameterNode
+            ForwardingParam.new(
+              loc: node_loc(param),
+              comments: node_comments(param),
+            )
           else
             raise ParseError.new("Unexpected parameter node `#{param.class}`", node_loc(param))
           end

--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -403,6 +403,12 @@ module RBI
     end
 
     # @override
+    #: (ForwardingParam node) -> void
+    def visit_forwarding_param(node)
+      self.print(node.to_s)
+    end
+
+    # @override
     #: (Include node) -> void
     def visit_include(node)
       visit_mixin(node)

--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -409,6 +409,12 @@ module RBI
     end
 
     # @override
+    #: (ForwardingParam node) -> void
+    def visit_forwarding_param(node)
+      self.print(node.to_s)
+    end
+
+    # @override
     #: (Include node) -> void
     def visit_include(node)
       visit_mixin(node)

--- a/lib/rbi/rbs_printer.rb
+++ b/lib/rbi/rbs_printer.rb
@@ -624,6 +624,12 @@ module RBI
     end
 
     # @override
+    #: (ForwardingParam node) -> void
+    def visit_forwarding_param(node)
+      print("...")
+    end
+
+    # @override
     #: (Include node) -> void
     def visit_include(node)
       visit_mixin(node)

--- a/lib/rbi/rbs_printer.rb
+++ b/lib/rbi/rbs_printer.rb
@@ -596,6 +596,12 @@ module RBI
     end
 
     # @override
+    #: (ForwardingParam node) -> void
+    def visit_forwarding_param(node)
+      print("...")
+    end
+
+    # @override
     #: (Include node) -> void
     def visit_include(node)
       visit_mixin(node)

--- a/lib/rbi/rewriters/add_sig_templates.rb
+++ b/lib/rbi/rewriters/add_sig_templates.rb
@@ -44,7 +44,10 @@ module RBI
       def add_method_sig(method)
         return unless method.sigs.empty?
 
-        method.sigs << Sig.new(
+        # Sorbet doesn't support signatures on methods using argument forwarding.
+        return if method.params.any?(RBI::ForwardingParam)
+
+        method.add_sig(
           params: method.params.map do |param|
             case param
             when RBI::RestParam

--- a/lib/rbi/rewriters/add_sig_templates.rb
+++ b/lib/rbi/rewriters/add_sig_templates.rb
@@ -44,6 +44,9 @@ module RBI
       def add_method_sig(method)
         return unless method.sigs.empty?
 
+        # Sorbet doesn't support signatures on methods using argument forwarding.
+        return if method.params.any?(RBI::ForwardingParam)
+
         method.sigs << Sig.new(
           params: method.params.filter_map do |param|
             case param

--- a/lib/rbi/rewriters/merge_trees.rb
+++ b/lib/rbi/rewriters/merge_trees.rb
@@ -467,6 +467,9 @@ module RBI
       return false unless other.is_a?(Method)
       return false unless name == other.name
       return false unless params.size == other.params.size
+      if (params_have_forwarding?(params) || params_have_forwarding?(other.params)) && params != other.params
+        return false
+      end
 
       if sigs.empty? && other.sigs.empty?
         compatible_params?(other)
@@ -485,8 +488,9 @@ module RBI
       super
 
       if sigs.empty? && !other.sigs.empty?
-        @params = other.params.dup
+        @params = other.params.map(&:dup)
         @sigs = other.sigs.dup
+        rename_sigs_params(@sigs, @params)
         return
       end
 
@@ -503,8 +507,10 @@ module RBI
     #: (Method other) -> bool
     def compatible_params?(other)
       return true if params == other.params
+      return false unless params.size == other.params.size
 
       params.zip(other.params).all? do |p1, p2|
+        p2 = p2 #: as !nil
         p1.compatible_with?(p2)
       end
     end
@@ -512,20 +518,26 @@ module RBI
     #: (Array[Param] preferred, Array[Param] fallback) -> Array[Param]
     def merge_params(preferred, fallback)
       preferred.zip(fallback).map do |p1, p2|
+        p2 = p2 #: as !nil
         if p1.anonymous?
-          p2.dup #: as !nil
+          p2.dup
         else
           p1.dup
         end
       end
     end
 
+    #: (Array[Param] params) -> bool
+    def params_have_forwarding?(params)
+      params.any?(ForwardingParam)
+    end
+
     #: (Array[Sig] sigs, Array[Param] params) -> void
     def rename_sigs_params(sigs, params)
       sigs.each do |sig|
-        sig_params = sig.params.zip(params).map do |sig_param, param|
-          param = param #: as !nil
-          name = if sig_param.anonymous? && !param.anonymous?
+        sig_params = sig.params.each_with_index.map do |sig_param, index|
+          param = params[index]
+          name = if param && sig_param.anonymous? && !param.anonymous?
             param.name #: as !nil
           else
             sig_param.name

--- a/lib/rbi/visitor.rb
+++ b/lib/rbi/visitor.rb
@@ -65,6 +65,8 @@ module RBI
         visit_kw_rest_param(node)
       when BlockParam
         visit_block_param(node)
+      when ForwardingParam
+        visit_forwarding_param(node)
       when Include
         visit_include(node)
       when Extend
@@ -175,6 +177,9 @@ module RBI
 
     #: (BlockParam node) -> void
     def visit_block_param(node); end
+
+    #: (ForwardingParam node) -> void
+    def visit_forwarding_param(node); end
 
     #: (Include node) -> void
     def visit_include(node); end

--- a/lib/rbi/visitor.rb
+++ b/lib/rbi/visitor.rb
@@ -67,6 +67,8 @@ module RBI
         visit_no_kw_param(node)
       when BlockParam
         visit_block_param(node)
+      when ForwardingParam
+        visit_forwarding_param(node)
       when Include
         visit_include(node)
       when Extend
@@ -180,6 +182,9 @@ module RBI
 
     #: (BlockParam node) -> void
     def visit_block_param(node); end
+
+    #: (ForwardingParam node) -> void
+    def visit_forwarding_param(node); end
 
     #: (Include node) -> void
     def visit_include(node); end

--- a/rbi/rbi.rbi
+++ b/rbi/rbi.rbi
@@ -405,6 +405,29 @@ class RBI::Formatter
   def print_file(file); end
 end
 
+class RBI::ForwardingParam < ::RBI::Param
+  sig do
+    params(
+      loc: T.nilable(::RBI::Loc),
+      comments: T.nilable(T::Array[::RBI::Comment]),
+      block: T.nilable(T.proc.params(node: ::RBI::ForwardingParam).void)
+    ).void
+  end
+  def initialize(loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
+
+  sig { params(other: T.nilable(::Object)).returns(T::Boolean) }
+  def ==(other); end
+
+  sig { override.returns(T::Boolean) }
+  def anonymous?; end
+
+  sig { override.returns(::NilClass) }
+  def name; end
+
+  sig { override.returns(::String) }
+  def to_s; end
+end
+
 class RBI::Group < ::RBI::Tree
   sig { params(kind: ::RBI::Group::Kind).void }
   def initialize(kind); end
@@ -689,6 +712,9 @@ class RBI::Method < ::RBI::NodeWithComments
   sig { params(name: ::String).void }
   def add_block_param(name); end
 
+  sig { void }
+  def add_forwarding_param; end
+
   sig { params(name: ::String, default_value: ::String).void }
   def add_kw_opt_param(name, default_value); end
 
@@ -769,6 +795,9 @@ class RBI::Method < ::RBI::NodeWithComments
 
   sig { params(preferred: T::Array[::RBI::Param], fallback: T::Array[::RBI::Param]).returns(T::Array[::RBI::Param]) }
   def merge_params(preferred, fallback); end
+
+  sig { params(params: T::Array[::RBI::Param]).returns(T::Boolean) }
+  def params_have_forwarding?(params); end
 
   sig { params(sigs: T::Array[::RBI::Sig], params: T::Array[::RBI::Param]).void }
   def rename_sigs_params(sigs, params); end
@@ -1283,6 +1312,9 @@ class RBI::Printer < ::RBI::Visitor
   sig { override.params(node: ::RBI::Extend).void }
   def visit_extend(node); end
 
+  sig { override.params(node: ::RBI::ForwardingParam).void }
+  def visit_forwarding_param(node); end
+
   sig { override.params(node: ::RBI::Group).void }
   def visit_group(node); end
 
@@ -1645,6 +1677,9 @@ class RBI::RBSPrinter < ::RBI::Visitor
 
   sig { override.params(file: ::RBI::File).void }
   def visit_file(file); end
+
+  sig { override.params(node: ::RBI::ForwardingParam).void }
+  def visit_forwarding_param(node); end
 
   sig { override.params(node: ::RBI::Group).void }
   def visit_group(node); end
@@ -3427,6 +3462,9 @@ class RBI::Visitor
 
   sig { params(node: ::RBI::Extend).void }
   def visit_extend(node); end
+
+  sig { params(node: ::RBI::ForwardingParam).void }
+  def visit_forwarding_param(node); end
 
   sig { params(node: ::RBI::Group).void }
   def visit_group(node); end

--- a/rbi/rbi.rbi
+++ b/rbi/rbi.rbi
@@ -405,6 +405,29 @@ class RBI::Formatter
   def print_file(file); end
 end
 
+class RBI::ForwardingParam < ::RBI::Param
+  sig do
+    params(
+      loc: T.nilable(::RBI::Loc),
+      comments: T.nilable(T::Array[::RBI::Comment]),
+      block: T.nilable(T.proc.params(node: ::RBI::ForwardingParam).void)
+    ).void
+  end
+  def initialize(loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
+
+  sig { params(other: T.nilable(::Object)).returns(T::Boolean) }
+  def ==(other); end
+
+  sig { override.returns(T::Boolean) }
+  def anonymous?; end
+
+  sig { override.returns(::NilClass) }
+  def name; end
+
+  sig { override.returns(::String) }
+  def to_s; end
+end
+
 class RBI::Group < ::RBI::Tree
   sig { params(kind: ::RBI::Group::Kind).void }
   def initialize(kind); end
@@ -689,6 +712,9 @@ class RBI::Method < ::RBI::NodeWithComments
   sig { params(name: ::String).void }
   def add_block_param(name); end
 
+  sig { void }
+  def add_forwarding_param; end
+
   sig { params(name: ::String, default_value: ::String).void }
   def add_kw_opt_param(name, default_value); end
 
@@ -773,6 +799,9 @@ class RBI::Method < ::RBI::NodeWithComments
 
   sig { params(preferred: T::Array[::RBI::Param], fallback: T::Array[::RBI::Param]).returns(T::Array[::RBI::Param]) }
   def merge_params(preferred, fallback); end
+
+  sig { params(params: T::Array[::RBI::Param]).returns(T::Boolean) }
+  def params_have_forwarding?(params); end
 
   sig { params(sigs: T::Array[::RBI::Sig], params: T::Array[::RBI::Param]).void }
   def rename_sigs_params(sigs, params); end
@@ -1316,6 +1345,9 @@ class RBI::Printer < ::RBI::Visitor
   sig { override.params(node: ::RBI::Extend).void }
   def visit_extend(node); end
 
+  sig { override.params(node: ::RBI::ForwardingParam).void }
+  def visit_forwarding_param(node); end
+
   sig { override.params(node: ::RBI::Group).void }
   def visit_group(node); end
 
@@ -1681,6 +1713,9 @@ class RBI::RBSPrinter < ::RBI::Visitor
 
   sig { override.params(file: ::RBI::File).void }
   def visit_file(file); end
+
+  sig { override.params(node: ::RBI::ForwardingParam).void }
+  def visit_forwarding_param(node); end
 
   sig { override.params(node: ::RBI::Group).void }
   def visit_group(node); end
@@ -3477,6 +3512,9 @@ class RBI::Visitor
 
   sig { params(node: ::RBI::Extend).void }
   def visit_extend(node); end
+
+  sig { params(node: ::RBI::ForwardingParam).void }
+  def visit_forwarding_param(node); end
 
   sig { params(node: ::RBI::Group).void }
   def visit_group(node); end

--- a/test/rbi/model_test.rb
+++ b/test/rbi/model_test.rb
@@ -464,6 +464,14 @@ module RBI
       RBI
     end
 
+    def test_model_allows_forwarding_params_with_sigs
+      method = Method.new("foo", params: [ForwardingParam.new])
+
+      assert_equal(<<~RBI, method.string)
+        def foo(...); end
+      RBI
+    end
+
     def test_t_struct_with_types
       node = TStruct.new("MyStruct")
       node << TStructConst.new("foo", Type.simple("Foo"))

--- a/test/rbi/model_test.rb
+++ b/test/rbi/model_test.rb
@@ -481,6 +481,14 @@ module RBI
       RBI
     end
 
+    def test_model_allows_forwarding_params_with_sigs
+      method = Method.new("foo", params: [ForwardingParam.new])
+
+      assert_equal(<<~RBI, method.string)
+        def foo(...); end
+      RBI
+    end
+
     def test_t_struct_with_types
       node = TStruct.new("MyStruct")
       node << TStructConst.new("foo", Type.simple("Foo"))

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -185,6 +185,16 @@ module RBI
       assert_equal(rbi, tree.string)
     end
 
+    def test_parse_methods_with_forwarding
+      rbi = <<~RBI
+        def m1(...); end
+        def m2(a, ...); end
+      RBI
+
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
+    end
+
     def test_parse_methods_with_vararg_followed_by_positional_arg
       rbi = <<~RBI
         def m1(*a, b); end

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -190,6 +190,16 @@ module RBI
       assert_instance_of(NoKwParam, method.params.last)
     end
 
+    def test_parse_methods_with_forwarding
+      rbi = <<~RBI
+        def m1(...); end
+        def m2(a, ...); end
+      RBI
+
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
+    end
+
     def test_parse_methods_with_vararg_followed_by_positional_arg
       rbi = <<~RBI
         def m1(*a, b); end

--- a/test/rbi/printer_test.rb
+++ b/test/rbi/printer_test.rb
@@ -156,6 +156,16 @@ module RBI
       RBI
     end
 
+    def test_print_methods_with_forwarding_parameter
+      method = Method.new("foo")
+      method << ReqParam.new("a")
+      method << ForwardingParam.new
+
+      assert_equal(<<~RBI, method.string)
+        def foo(a, ...); end
+      RBI
+    end
+
     def test_print_attributes_with_signatures
       sig1 = Sig.new
 

--- a/test/rbi/printer_test.rb
+++ b/test/rbi/printer_test.rb
@@ -165,6 +165,16 @@ module RBI
       RBI
     end
 
+    def test_print_methods_with_forwarding_parameter
+      method = Method.new("foo")
+      method << ReqParam.new("a")
+      method << ForwardingParam.new
+
+      assert_equal(<<~RBI, method.string)
+        def foo(a, ...); end
+      RBI
+    end
+
     def test_print_attributes_with_signatures
       sig1 = Sig.new
 

--- a/test/rbi/rbs_printer_test.rb
+++ b/test/rbi/rbs_printer_test.rb
@@ -337,6 +337,16 @@ module RBI
       ::RBS::Parser.parse_signature(rbs)
     end
 
+    def test_print_methods_with_forwarding_parameter
+      rbi = parse_rbi(<<~RBI)
+        def foo(a, ...); end
+      RBI
+
+      assert_equal(<<~RBI, rbi.rbs_string)
+        def foo: (untyped a, ...) -> untyped
+      RBI
+    end
+
     def test_print_methods_with_vararg_followed_by_positional_arg
       rbi = parse_rbi(<<~RBI)
         sig { params(a: Integer, b: String).void }

--- a/test/rbi/rbs_printer_test.rb
+++ b/test/rbi/rbs_printer_test.rb
@@ -383,6 +383,16 @@ module RBI
       ::RBS::Parser.parse_signature(rbs)
     end
 
+    def test_print_methods_with_forwarding_parameter
+      rbi = parse_rbi(<<~RBI)
+        def foo(a, ...); end
+      RBI
+
+      assert_equal(<<~RBI, rbi.rbs_string)
+        def foo: (untyped a, ...) -> untyped
+      RBI
+    end
+
     def test_print_methods_with_vararg_followed_by_positional_arg
       rbi = parse_rbi(<<~RBI)
         sig { params(a: Integer, b: String).void }

--- a/test/rbi/rewriters/add_sig_templates_test.rb
+++ b/test/rbi/rewriters/add_sig_templates_test.rb
@@ -122,5 +122,19 @@ module RBI
         def self.m3(x, y = 42, **z); end
       RBI
     end
+
+    def test_does_not_add_empty_sigs_to_forwarding_parameters
+      tree = parse_rbi(<<~RBI)
+        def m1(...); end
+        def m2(a, ...); end
+      RBI
+
+      tree.add_sig_templates!(with_todo_comment: true)
+
+      assert_equal(<<~RBI, tree.string)
+        def m1(...); end
+        def m2(a, ...); end
+      RBI
+    end
   end
 end

--- a/test/rbi/rewriters/add_sig_templates_test.rb
+++ b/test/rbi/rewriters/add_sig_templates_test.rb
@@ -126,5 +126,19 @@ module RBI
         def self.m3(x, y = 42, **z); end
       RBI
     end
+
+    def test_does_not_add_empty_sigs_to_forwarding_parameters
+      tree = parse_rbi(<<~RBI)
+        def m1(...); end
+        def m2(a, ...); end
+      RBI
+
+      tree.add_sig_templates!(with_todo_comment: true)
+
+      assert_equal(<<~RBI, tree.string)
+        def m1(...); end
+        def m2(a, ...); end
+      RBI
+    end
   end
 end

--- a/test/rbi/rewriters/merge_trees_test.rb
+++ b/test/rbi/rewriters/merge_trees_test.rb
@@ -1223,6 +1223,97 @@ module RBI
       end
     end
 
+    def test_merge_methods_with_same_forwarding_params
+      tree1 = parse_rbi(<<~RBI)
+        class Foo
+          def m1(...); end
+        end
+      RBI
+
+      tree2 = parse_rbi(<<~RBI)
+        class Foo
+          def m1(...); end
+        end
+      RBI
+
+      res = tree1.merge(tree2)
+
+      assert_equal(<<~RBI, res.string)
+        class Foo
+          def m1(...); end
+        end
+      RBI
+      assert_empty(res.conflicts)
+    end
+
+    def test_merge_methods_with_forwarding_params_and_same_arity
+      tree1 = parse_rbi(<<~RBI)
+        class Foo
+          def foo(a, ...); end
+        end
+      RBI
+
+      tree2 = parse_rbi(<<~RBI)
+        class Foo
+          sig { params(a: Integer, rest: T.untyped).void }
+          def foo(a, *rest); end
+        end
+      RBI
+
+      res = tree1.merge(tree2)
+
+      assert_equal(<<~RBI, res.string)
+        class Foo
+          <<<<<<< left
+          def foo(a, ...); end
+          =======
+          sig { params(a: Integer, rest: T.untyped).void }
+          def foo(a, *rest); end
+          >>>>>>> right
+        end
+      RBI
+      refute_empty(res.conflicts)
+    end
+
+    def test_merge_methods_with_forwarding_params
+      tree1 = parse_rbi(<<~RBI)
+        class Foo
+          def m1(...); end
+          def m2(*args, **kwargs, &block); end
+          def m3(...); end
+        end
+      RBI
+
+      tree2 = parse_rbi(<<~RBI)
+        class Foo
+          def m1(*args, **kwargs, &block); end
+          def m2(...); end
+
+          sig { params(rest: Integer, opts: String, blk: T.proc.void).void }
+          def m3(*rest, **opts, &blk); end
+        end
+      RBI
+
+      res = tree1.merge(tree2)
+
+      assert_equal(<<~RBI, res.string)
+        class Foo
+          <<<<<<< left
+          def m1(...); end
+          def m2(*args, **kwargs, &block); end
+          def m3(...); end
+          =======
+          def m1(*args, **kwargs, &block); end
+          def m2(...); end
+
+          sig { params(rest: Integer, opts: String, blk: T.proc.void).void }
+          def m3(*rest, **opts, &blk); end
+          >>>>>>> right
+        end
+      RBI
+      refute_empty(res.conflicts)
+    end
+
     def test_merge_methods_with_anonymous_params_and_sigs
       tree1 = parse_rbi(<<~RBI)
         class Foo


### PR DESCRIPTION
Depends on https://github.com/Shopify/rbi/pull/624.

Ruby argument forwarding (`...`) is a distinct parameter form; expanding it to `*args, **kwargs, &block` loses source fidelity and makes round-tripping impossible.

This PR:

* Adds `RBI::ForwardingParam` and wires it through parsing, visitors, RBI/RBS printing, and generated RBI signatures.
* Skips `AddSigTemplates` for methods containing `...`, since Sorbet does not support signatures on argument-forwarding methods.
* Treats forwarding params conservatively during merge: `foo(...)` is compatible with `foo(...)`, but incompatible with expanded `*args, **kwargs, &block` shapes.

Closes https://github.com/Shopify/rbi/pull/562.
Closes https://github.com/Shopify/rbi/pull/578.
