### PR TITLE
Allow forcing RBS printer multiline signatures

### DIFF
--- a/lib/rbi/loc.rb
+++ b/lib/rbi/loc.rb
@@ -48,6 +48,13 @@ module RBI
       )
     end
 
+    #: -> bool
+    def multiline?
+      begin_line = self.begin_line
+      end_line = self.end_line
+      !!(begin_line && end_line && end_line > begin_line)
+    end
+
     #: -> String
     def to_s
       if end_line && end_column

--- a/lib/rbi/rbs_printer.rb
+++ b/lib/rbi/rbs_printer.rb
@@ -25,9 +25,17 @@ module RBI
     #|   ?indent: Integer,
     #|   ?print_locs: bool,
     #|   ?positional_names: bool,
-    #|   ?max_line_length: Integer?
+    #|   ?max_line_length: Integer?,
+    #|   ?force_multiline_signatures: bool
     #| ) -> void
-    def initialize(out: $stdout, indent: 0, print_locs: false, positional_names: true, max_line_length: nil)
+    def initialize(
+      out: $stdout,
+      indent: 0,
+      print_locs: false,
+      positional_names: true,
+      max_line_length: nil,
+      force_multiline_signatures: false
+    )
       super()
       @out = out
       @current_indent = indent
@@ -36,6 +44,7 @@ module RBI
       @previous_node = nil #: Node?
       @positional_names = positional_names #: bool
       @max_line_length = max_line_length #: Integer?
+      @force_multiline_signatures = force_multiline_signatures #: bool
     end
 
     # Printing
@@ -406,10 +415,10 @@ module RBI
       @out = old_out
 
       max_line_length = @max_line_length
-      if max_line_length.nil? || new_out.string.size <= max_line_length
-        print(new_out.string)
-      else
+      if @force_multiline_signatures || (max_line_length && new_out.string.size > max_line_length)
         print_method_sig_multiline(node, sig)
+      else
+        print(new_out.string)
       end
     end
 

--- a/rbi/rbi.rbi
+++ b/rbi/rbi.rbi
@@ -600,6 +600,9 @@ class RBI::Loc
   sig { params(other: ::RBI::Loc).returns(::RBI::Loc) }
   def join(other); end
 
+  sig { returns(T::Boolean) }
+  def multiline?; end
+
   sig { returns(T.nilable(::String)) }
   def source; end
 
@@ -1463,10 +1466,11 @@ class RBI::RBSPrinter < ::RBI::Visitor
       indent: ::Integer,
       print_locs: T::Boolean,
       positional_names: T::Boolean,
-      max_line_length: T.nilable(::Integer)
+      max_line_length: T.nilable(::Integer),
+      force_multiline_signatures: T::Boolean
     ).void
   end
-  def initialize(out: T.unsafe(nil), indent: T.unsafe(nil), print_locs: T.unsafe(nil), positional_names: T.unsafe(nil), max_line_length: T.unsafe(nil)); end
+  def initialize(out: T.unsafe(nil), indent: T.unsafe(nil), print_locs: T.unsafe(nil), positional_names: T.unsafe(nil), max_line_length: T.unsafe(nil), force_multiline_signatures: T.unsafe(nil)); end
 
   sig { returns(::Integer) }
   def current_indent; end

--- a/test/rbi/loc_test.rb
+++ b/test/rbi/loc_test.rb
@@ -79,5 +79,25 @@ module RBI
       loc = Loc.new(file: TEST_FILE_PATH, begin_line: -10, end_line: 100)
       assert_equal(TEST_FILE_CONTENT, loc.source)
     end
+
+    def test_loc_multiline
+      loc = Loc.new
+      refute(loc.multiline?)
+
+      loc = Loc.new(file: "foo.rb")
+      refute(loc.multiline?)
+
+      loc = Loc.new(file: "foo.rb", begin_line: 1)
+      refute(loc.multiline?)
+
+      loc = Loc.new(file: "foo.rb", end_line: 1)
+      refute(loc.multiline?)
+
+      loc = Loc.new(file: "foo.rb", begin_line: 1, end_line: 1)
+      refute(loc.multiline?)
+
+      loc = Loc.new(file: "foo.rb", begin_line: 1, end_line: 2)
+      assert(loc.multiline?)
+    end
   end
 end

--- a/test/rbi/rbs_printer_test.rb
+++ b/test/rbi/rbs_printer_test.rb
@@ -560,6 +560,41 @@ module RBI
       RBI
     end
 
+    def test_print_force_multiline_signatures
+      rbi_def = Method.new("foo") do |node|
+        node.params << ReqParam.new("a")
+        node.params << ReqParam.new("b")
+      end
+
+      rbi_sig = Sig.new do |sig|
+        sig.params << SigParam.new("a", "A")
+        sig.params << SigParam.new("b", "B")
+        sig.return_type = "R"
+      end
+
+      out = StringIO.new
+      printer = RBI::RBSPrinter.new(out: out, force_multiline_signatures: true)
+      printer.print_method_sig(rbi_def, rbi_sig)
+
+      assert_equal(<<~RBI.strip, out.string)
+        (
+          A a,
+          B b
+        ) -> R
+      RBI
+
+      out = StringIO.new
+      printer = RBI::RBSPrinter.new(out: out, force_multiline_signatures: true, max_line_length: 1000)
+      printer.print_method_sig(rbi_def, rbi_sig)
+
+      assert_equal(<<~RBI.strip, out.string)
+        (
+          A a,
+          B b
+        ) -> R
+      RBI
+    end
+
     def test_print_simplified_types
       rbi = parse_rbi(<<~RBI)
         sig { returns(T.any(String, String, NilClass, T.nilable(T.nilable(Integer)), TrueClass, FalseClass)) }


### PR DESCRIPTION
## Summary

Adds a `force_multiline_signatures` option to `RBI::RBSPrinter` so signatures can be printed in multiline form regardless of `max_line_length`.

Also adds `Loc#multiline?` and updates the generated RBI signatures.

## Notes

The working tree has unrelated untracked files (`PR_DESCRIPTION.md`, `count.sh`) that were not included in this PR.