### PR TITLE
Preserve string-ness of string keys in Shape#to_rbi

### DIFF
--- a/lib/rbi/type.rb
+++ b/lib/rbi/type.rb
@@ -720,7 +720,14 @@ module RBI
         if @types.empty?
           "{}"
         else
-          "{ " + @types.map { |name, type| "#{name}: #{type.to_rbi}" }.join(", ") + " }"
+          "{ " + @types.map do |name, type|
+            case name
+            when Symbol
+              "#{name}: #{type.to_rbi}"
+            when String
+              "#{name.inspect} => #{type.to_rbi}"
+            end
+          end.join(", ") + " }"
         end
       end
 

--- a/test/rbi/type_test.rb
+++ b/test/rbi/type_test.rb
@@ -259,7 +259,7 @@ module RBI
         :qux => Type.simple("String"),
       )
       refute_predicate(type, :nilable?)
-      assert_equal("{ foo: String, bar: String, baz: String, qux: String }", type.to_rbi)
+      assert_equal("{ foo: String, bar: String, \"baz\" => String, qux: String }", type.to_rbi)
 
       type = Type.shape(
         "\"foo\"": Type.simple("String"),
@@ -267,7 +267,16 @@ module RBI
         :"\"baz\"" => Type.simple("String"),
       )
       refute_predicate(type, :nilable?)
-      assert_equal("{ \"foo\": String, \"bar\": String, \"baz\": String }", type.to_rbi)
+      assert_equal("{ \"foo\": String, \"\\\"bar\\\"\" => String, \"baz\": String }", type.to_rbi)
+    end
+
+    def test_build_type_shape_preserves_string_keys
+      type = Type.shape(
+        foo: Type.simple("Integer"),
+        "foo" => Type.simple("String"),
+      )
+      assert_equal("{ foo: Integer, \"foo\" => String }", type.to_rbi)
+      assert_equal(type, Type.parse_string(type.to_rbi))
     end
 
     def test_build_type_void_proc


### PR DESCRIPTION
`RBI::Type::Shape#to_rbi` rendered shapes like `key: Value`
unconditionally, which turned string keys into symbol keys.  Fix it by
checking for string keys and rendering those like `"key" => Value`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
