### PR TITLE
Preserve type resolution when erasing runtime generics

### DIFF
--- a/lib/rbi/rbs/type_translator.rb
+++ b/lib/rbi/rbs/type_translator.rb
@@ -136,10 +136,12 @@ module RBI
         type_name = type.name.to_s
         return Type.simple(type_name) if type.args.empty?
 
+        translated_type_name = translate_t_generic_type(type_name)
+
         if @options.erase_generic_types
-          Type.simple(erase_t_generic_type(type_name))
+          Type.simple(erase_t_generic_type(translated_type_name))
         else
-          Type.generic(translate_t_generic_type(type_name), *type.args.map { |arg| translate(arg) })
+          Type.generic(translated_type_name, *type.args.map { |arg| translate(arg) })
         end
       end
 

--- a/test/rbi/rbs/method_type_translator_test.rb
+++ b/test/rbi/rbs/method_type_translator_test.rb
@@ -241,7 +241,7 @@ module RBI
         assert_empty(sig.type_params)
         assert_equal(
           [
-            SigParam.new("array", Type.simple("Array")),
+            SigParam.new("array", Type.simple("::Array")),
             SigParam.new("value", Type.nilable(Type.anything)),
             SigParam.new("fallback", Type.any(Type.anything, Type.simple("Integer"))),
             SigParam.new("pair", Type.tuple([Type.anything, Type.simple("Integer")])),

--- a/test/rbi/rbs/type_translator_test.rb
+++ b/test/rbi/rbs/type_translator_test.rb
@@ -102,18 +102,19 @@ module RBI
       def test_erase_generic_types_removes_generic_types
         simple_foo = Type.simple("Foo")
         class_foo = Type.class_of(simple_foo)
-        simple_array = Type.simple("Array")
         root_array = Type.simple("::Array")
 
         assert_equal(simple_foo, translate("Foo[Bar]", erase_generic_types: true))
         assert_equal(simple_foo, translate("Foo[Bar, ::Baz]", erase_generic_types: true))
         assert_equal(class_foo, translate("singleton(Foo)", erase_generic_types: true))
         assert_equal(class_foo, translate("singleton(Foo)[Bar]", erase_generic_types: true))
-        assert_equal(simple_array, translate("Array[Foo]", erase_generic_types: true))
+        assert_equal(root_array, translate("Array[Foo]", erase_generic_types: true))
         assert_equal(root_array, translate("T::Array[Foo]", erase_generic_types: true))
         assert_equal(root_array, translate("::T::Array[Foo]", erase_generic_types: true))
         assert_equal(root_array, translate("::Array[Bar]", erase_generic_types: true))
         assert_equal(Type.simple("::Hash"), translate("::Hash[Foo, Bar]", erase_generic_types: true))
+        assert_equal(Type.simple("::Enumerator::Chain"),
+          translate("Enumerator::Chain[Foo]", erase_generic_types: true))
         assert_equal(Type.simple("::Foo"), translate("::Foo[Bar]", erase_generic_types: true))
         assert_equal(Type.simple("::Types::Foo"), translate("::Types::Foo[Bar]", erase_generic_types: true))
       end


### PR DESCRIPTION
During normal RBS to Sig translation, recognized [runtime generic types](https://github.com/Shopify/rbi/blob/main/lib/rbi/rbs/type_translator.rb#L193) normalize to Sorbet's `::T::`. For example,`Set[Foo]` becomes `::T::Set[Foo]`. Previously, when erasing generic types during translation (#611) this was skipped so `Set[Foo]` would remain `Set` causing errors when a namespace defined their own `Set`

This PR fixes that by normalizing the name first: `Set[Foo]` -> `::T::Set[Foo]` -> `::Set`