### PR TITLE
Support Prism::NoKeywordsParameterNode

### DIFF
--- a/lib/rbi/model.rb
+++ b/lib/rbi/model.rb
@@ -542,6 +542,11 @@ module RBI
       params << KwRestParam.new(name)
     end
 
+    #: -> void
+    def add_no_kw_param
+      params << NoKwParam.new
+    end
+
     #: (String name) -> void
     def add_block_param(name)
       params << BlockParam.new(name)
@@ -804,6 +809,31 @@ module RBI
     #: (Object? other) -> bool
     def ==(other)
       KwRestParam === other && (name == other.name || anonymous? || other.anonymous?)
+    end
+  end
+
+  class NoKwParam < Param
+    #: (?loc: Loc?, ?comments: Array[Comment]?) ?{ (NoKwParam node) -> void } -> void
+    def initialize(loc: nil, comments: nil, &block)
+      super(loc: loc, comments: comments)
+      block&.call(self)
+    end
+
+    # @override
+    #: -> String
+    def to_s
+      "**nil"
+    end
+
+    # @override
+    #: -> bool
+    def anonymous?
+      false
+    end
+
+    #: (Object? other) -> bool
+    def ==(other)
+      NoKwParam === other
     end
   end
 

--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -743,6 +743,11 @@ module RBI
               loc: node_loc(param),
               comments: node_comments(param),
             )
+          when Prism::NoKeywordsParameterNode
+            NoKwParam.new(
+              loc: node_loc(param),
+              comments: node_comments(param),
+            )
           when Prism::KeywordRestParameterNode
             KwRestParam.new(
               param.name&.to_s,

--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -397,6 +397,12 @@ module RBI
     end
 
     # @override
+    #: (NoKwParam node) -> void
+    def visit_no_kw_param(node)
+      self.print(node.to_s)
+    end
+
+    # @override
     #: (BlockParam node) -> void
     def visit_block_param(node)
       self.print(node.to_s)

--- a/lib/rbi/rbs/method_type_translator.rb
+++ b/lib/rbi/rbs/method_type_translator.rb
@@ -110,7 +110,7 @@ module RBI
         end
 
         rest_keyword = type.rest_keywords
-        if rest_keyword
+        if rest_keyword && !rest_keyword.type.is_a?(::RBS::Types::Bases::Nil)
           result.params << translate_function_param(rest_keyword, index)
         end
 

--- a/lib/rbi/rbs_printer.rb
+++ b/lib/rbi/rbs_printer.rb
@@ -428,13 +428,19 @@ module RBI
         print("[#{sig.type_params.join(", ")}] ")
       end
 
-      raise Error, "Arity mismatch between method and signature" if sig.params.size != node.params.size
+      no_kw_params, method_params = node.params.partition { |param| param.is_a?(NoKwParam) }
+      raise Error, "Multiple no-keywords parameters found" if no_kw_params.size > 1
+      raise Error, "Arity mismatch between method and signature" if sig.params.size != method_params.size
 
-      block_params, params = sig.params.zip(node.params).partition do |_sig_param, method_param|
+      params = sig.params.zip(method_params) #: Array[[SigParam?, Param?]]
+      block_params, params = params.partition do |_sig_param, method_param|
         method_param.is_a?(BlockParam)
       end
 
       raise Error, "Multiple block parameters found" if block_params.size > 1
+
+      no_kw_param = no_kw_params.first
+      params << [nil, no_kw_param] if no_kw_param
 
       unless params.empty?
         if multiline
@@ -450,10 +456,14 @@ module RBI
           elsif index > 0
             print(", ")
           end
-          print_sig_param(
-            sig_param,
-            method_param, #: as !nil
-          )
+          if method_param.is_a?(NoKwParam)
+            visit(method_param)
+          else
+            print_sig_param(
+              sig_param, #: as !nil
+              method_param, #: as !nil
+            )
+          end
           if multiline
             print(",") if index < params.size - 1
             printn
@@ -571,6 +581,12 @@ module RBI
     def visit_kw_rest_param(node)
       print("**untyped")
       print(" #{node.name}") unless node.anonymous?
+    end
+
+    # @override
+    #: (NoKwParam node) -> void
+    def visit_no_kw_param(node)
+      print("**nil")
     end
 
     # @override

--- a/lib/rbi/rewriters/add_sig_templates.rb
+++ b/lib/rbi/rewriters/add_sig_templates.rb
@@ -45,12 +45,14 @@ module RBI
         return unless method.sigs.empty?
 
         method.sigs << Sig.new(
-          params: method.params.map do |param|
+          params: method.params.filter_map do |param|
             case param
             when RBI::RestParam
               SigParam.new(param.name || "*", "::T.untyped")
             when RBI::KwRestParam
               SigParam.new(param.name || "**", "::T.untyped")
+            when RBI::NoKwParam
+              next
             when RBI::BlockParam
               SigParam.new(param.name || "&", "::T.untyped")
             else

--- a/lib/rbi/visitor.rb
+++ b/lib/rbi/visitor.rb
@@ -63,6 +63,8 @@ module RBI
         visit_kw_opt_param(node)
       when KwRestParam
         visit_kw_rest_param(node)
+      when NoKwParam
+        visit_no_kw_param(node)
       when BlockParam
         visit_block_param(node)
       when Include
@@ -172,6 +174,9 @@ module RBI
 
     #: (KwRestParam node) -> void
     def visit_kw_rest_param(node); end
+
+    #: (NoKwParam node) -> void
+    def visit_no_kw_param(node); end
 
     #: (BlockParam node) -> void
     def visit_block_param(node); end

--- a/rbi/rbi.rbi
+++ b/rbi/rbi.rbi
@@ -698,6 +698,9 @@ class RBI::Method < ::RBI::NodeWithComments
   sig { params(name: ::String).void }
   def add_kw_rest_param(name); end
 
+  sig { void }
+  def add_no_kw_param; end
+
   sig { params(name: ::String, default_value: ::String).void }
   def add_opt_param(name, default_value); end
 
@@ -837,6 +840,26 @@ class RBI::Module < ::RBI::Scope
 
   sig { returns(::String) }
   def name; end
+end
+
+class RBI::NoKwParam < ::RBI::Param
+  sig do
+    params(
+      loc: T.nilable(::RBI::Loc),
+      comments: T.nilable(T::Array[::RBI::Comment]),
+      block: T.nilable(T.proc.params(node: ::RBI::NoKwParam).void)
+    ).void
+  end
+  def initialize(loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
+
+  sig { params(other: T.nilable(::Object)).returns(T::Boolean) }
+  def ==(other); end
+
+  sig { override.returns(T::Boolean) }
+  def anonymous?; end
+
+  sig { override.returns(::String) }
+  def to_s; end
 end
 
 class RBI::Node
@@ -1316,6 +1339,9 @@ class RBI::Printer < ::RBI::Visitor
   sig { override.params(node: ::RBI::Module).void }
   def visit_module(node); end
 
+  sig { override.params(node: ::RBI::NoKwParam).void }
+  def visit_no_kw_param(node); end
+
   sig { override.params(node: ::RBI::OptParam).void }
   def visit_opt_param(node); end
 
@@ -1678,6 +1704,9 @@ class RBI::RBSPrinter < ::RBI::Visitor
 
   sig { override.params(node: ::RBI::Module).void }
   def visit_module(node); end
+
+  sig { override.params(node: ::RBI::NoKwParam).void }
+  def visit_no_kw_param(node); end
 
   sig { override.params(node: ::RBI::OptParam).void }
   def visit_opt_param(node); end
@@ -3457,6 +3486,9 @@ class RBI::Visitor
 
   sig { params(node: ::RBI::Module).void }
   def visit_module(node); end
+
+  sig { params(node: ::RBI::NoKwParam).void }
+  def visit_no_kw_param(node); end
 
   sig { params(node: ::RBI::OptParam).void }
   def visit_opt_param(node); end

--- a/test/rbi/model_test.rb
+++ b/test/rbi/model_test.rb
@@ -376,6 +376,11 @@ module RBI
       m3 << BlockParam.new("g")
       assert_equal("#m3(a, b = 42, *c, d:, e: 42, **f, &g)", m3.to_s)
 
+      m4 = Method.new("m4")
+      m4 << NoKwParam.new
+      assert_equal("#m4(**nil)", m4.to_s)
+      refute_predicate(m4.params.first, :anonymous?)
+
       a1 = AttrReader.new(:m1)
       assert_equal(".attr_reader(:m1)", a1.to_s)
 

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -179,10 +179,15 @@ module RBI
         def m1; end
         def self.m2; end
         def m3(a, b = 42, *c, d:, e: "bar", **f, &g); end
+        def m4(**nil); end
       RBI
 
       tree = parse_rbi(rbi)
       assert_equal(rbi, tree.string)
+
+      method = tree.nodes.last #: as Method
+      assert_instance_of(Method, method)
+      assert_instance_of(NoKwParam, method.params.last)
     end
 
     def test_parse_methods_with_vararg_followed_by_positional_arg

--- a/test/rbi/printer_test.rb
+++ b/test/rbi/printer_test.rb
@@ -156,6 +156,15 @@ module RBI
       RBI
     end
 
+    def test_print_method_with_no_keyword_parameter
+      method = Method.new("foo")
+      method << NoKwParam.new
+
+      assert_equal(<<~RBI, method.string)
+        def foo(**nil); end
+      RBI
+    end
+
     def test_print_attributes_with_signatures
       sig1 = Sig.new
 

--- a/test/rbi/rbs/method_type_translator_test.rb
+++ b/test/rbi/rbs/method_type_translator_test.rb
@@ -111,6 +111,23 @@ module RBI
         )
       end
 
+      def test_translate_no_keywords_param
+        sig = translate(
+          "(A a, **nil) -> Integer",
+          Method.new("foo", params: [
+            ReqParam.new("a"),
+            NoKwParam.new,
+          ]),
+        )
+
+        assert_equal(
+          [
+            SigParam.new("a", Type.simple("A")),
+          ],
+          sig.params,
+        )
+      end
+
       def test_translate_anonymous_params
         sig = translate(
           "(A a, *B, **C) { (D) -> E } -> void",

--- a/test/rbi/rbs_printer_test.rb
+++ b/test/rbi/rbs_printer_test.rb
@@ -365,6 +365,16 @@ module RBI
       end
     end
 
+    def test_print_method_with_multiple_no_keyword_params_raises_error
+      method = Method.new("foo", params: [NoKwParam.new, NoKwParam.new])
+      method.sigs << Sig.new
+
+      error = assert_raises(RBI::RBSPrinter::Error) do
+        method.rbs_string
+      end
+      assert_equal("Multiple no-keywords parameters found", error.message)
+    end
+
     def test_print_methods_with_signature
       rbi = parse_rbi(<<~RBI)
         sig { params(a: A, b: B, c: C, d: D, e: E, f: F, block: T.proc.void).returns(R) }
@@ -406,12 +416,22 @@ module RBI
         def foo(a, b = 10, *c, d:, e: 'bar', **f, &g); end
 
         def bar(**f); end
+
+        sig { params(x: String).void }
+        def baz(x, **nil); end
+
+        def qux(**nil); end
       RBI
+
 
       assert_equal(<<~RBI, rbi.rbs_string(positional_names: false))
         def foo: (A, ?B, *C, d: D, ?e: E, **F f) { -> void } -> R
 
         def bar: (**untyped f) -> untyped
+
+        def baz: (String, **nil) -> void
+
+        def qux: (**nil) -> untyped
       RBI
     end
 

--- a/test/rbi/rewriters/add_sig_templates_test.rb
+++ b/test/rbi/rewriters/add_sig_templates_test.rb
@@ -83,6 +83,7 @@ module RBI
         def m1; end
         def m2(x); end
         def self.m3(x, y = 42, **z); end
+        def m4(x, **nil); end
       RBI
 
       tree.add_sig_templates!(with_todo_comment: false)
@@ -96,6 +97,9 @@ module RBI
 
         sig { params(x: ::T.untyped, y: ::T.untyped, z: ::T.untyped).returns(::T.untyped) }
         def self.m3(x, y = 42, **z); end
+
+        sig { params(x: ::T.untyped).returns(::T.untyped) }
+        def m4(x, **nil); end
       RBI
     end
 


### PR DESCRIPTION
## Summary

Add support for methods that explicitly reject keyword arguments:

```ruby
def foo(**nil); end
```

Prism represents `**nil` as a `Prism::NoKeywordsParameterNode`, which the parser previously rejected as an unexpected parameter node.

## Implementation

- Add `RBI::NoKwParam` as a dedicated model node.
- Parse `Prism::NoKeywordsParameterNode` into `NoKwParam`.
- Preserve `**nil` when printing RBI and RBS.
- Exclude `NoKwParam` from generated Sorbet signature parameters because it does not bind a parameter.
- Ignore RBS `**nil` when translating method types into Sorbet signature parameters.
- Reject methods containing more than one `NoKwParam`.

A dedicated node avoids treating `nil` as the name of a keyword-rest parameter, which would produce incorrect signatures such as:

```ruby
sig { params(nil: T.untyped).void }
```

and incorrect RBS such as:

```rbs
**untyped nil
```

## Examples

Input RBI:

```ruby
sig { params(value: String).void }
def foo(value, **nil); end
```

Generated RBS:

```rbs
def foo: (String value, **nil) -> void
```

Generated signature templates retain `**nil` on the method without adding a signature parameter:

```ruby
sig { params(value: T.untyped).returns(T.untyped) }
def foo(value, **nil); end
```

## Dependency

Built on top of #638, which consolidates inline and multiline RBS method-signature rendering.