### PR TITLE
Support multiple type parameters on T.class_of

### DIFF
--- a/lib/rbi/rbs/type_translator.rb
+++ b/lib/rbi/rbs/type_translator.rb
@@ -66,9 +66,12 @@ module RBI
         when ::RBS::Types::Bases::Void
           Type.void
         when ::RBS::Types::ClassSingleton
-          type_arg = type.args.first
-          type_parameter = translate(type_arg) if type_arg && !@options.erase_generic_types
-          Type.class_of(Type.simple(type.name.to_s), type_parameter)
+          type_parameters = if @options.erase_generic_types
+            []
+          else
+            type.args.map { |type_arg| translate(type_arg) }
+          end
+          Type.class_of(Type.simple(type.name.to_s), *type_parameters)
         when ::RBS::Types::ClassInstance
           translate_class_instance(type)
         when ::RBS::Types::Function

--- a/lib/rbi/rbs_printer.rb
+++ b/lib/rbi/rbs_printer.rb
@@ -1069,9 +1069,12 @@ module RBI
       @string << "singleton("
       visit(type.type)
       @string << ")"
-      if (type_parameter = type.type_parameter)
+      unless type.type_parameters.empty?
         @string << "["
-        visit(type_parameter)
+        type.type_parameters.each_with_index do |type_parameter, index|
+          visit(type_parameter)
+          @string << ", " if index < type.type_parameters.size - 1
+        end
         @string << "]"
       end
     end

--- a/lib/rbi/type.rb
+++ b/lib/rbi/type.rb
@@ -913,9 +913,9 @@ module RBI
       end
 
       # Builds a type that represents the singleton class of another type like `T.class_of(Foo)`.
-      #: (Simple type, *Type type_parameters) -> ClassOf
+      #: (Simple type, *(Type | Array[Type]) type_parameters) -> ClassOf
       def class_of(type, *type_parameters)
-        ClassOf.new(type, *type_parameters)
+        ClassOf.new(type, *type_parameters.flatten)
       end
 
       # Builds a type that represents a nilable of another type like `T.nilable(String)`.

--- a/lib/rbi/type.rb
+++ b/lib/rbi/type.rb
@@ -315,29 +315,29 @@ module RBI
       #: Simple
       attr_reader :type
 
-      #: Type?
-      attr_reader :type_parameter
+      #: Array[Type]
+      attr_reader :type_parameters
 
-      #: (Simple type, ?Type? type_parameter) -> void
-      def initialize(type, type_parameter = nil)
+      #: (Simple type, *Type type_parameters) -> void
+      def initialize(type, *type_parameters)
         super()
         @type = type
-        @type_parameter = type_parameter
+        @type_parameters = type_parameters #: Array[Type]
       end
 
       # @override
       #: (BasicObject other) -> bool
       def ==(other)
-        ClassOf === other && @type == other.type && @type_parameter == other.type_parameter
+        ClassOf === other && @type == other.type && @type_parameters == other.type_parameters
       end
 
       # @override
       #: -> String
       def to_rbi
-        if @type_parameter
-          "::T.class_of(#{@type.to_rbi})[#{@type_parameter.to_rbi}]"
-        else
+        if @type_parameters.empty?
           "::T.class_of(#{@type.to_rbi})"
+        else
+          "::T.class_of(#{@type.to_rbi})[#{@type_parameters.map(&:to_rbi).join(", ")}]"
         end
       end
 
@@ -913,9 +913,9 @@ module RBI
       end
 
       # Builds a type that represents the singleton class of another type like `T.class_of(Foo)`.
-      #: (Simple type, ?Type? type_parameter) -> ClassOf
-      def class_of(type, type_parameter = nil)
-        ClassOf.new(type, type_parameter)
+      #: (Simple type, *Type type_parameters) -> ClassOf
+      def class_of(type, *type_parameters)
+        ClassOf.new(type, *type_parameters)
       end
 
       # Builds a type that represents a nilable of another type like `T.nilable(String)`.

--- a/lib/rbi/type_parser.rb
+++ b/lib/rbi/type_parser.rb
@@ -130,7 +130,7 @@ module RBI
               return Type::Generic.new(recv.slice, *args.map { |arg| parse_node(arg) })
             end
           when Prism::CallNode
-            # `T.class_of(Foo)[Bar]`
+            # `T.class_of(Foo)[Foo]` or `T.class_of(Foo)[Foo, Bar]`
             if t_class_of?(recv)
               type_args = check_arguments_exactly!(recv, 1)
               type = parse_node(
@@ -138,11 +138,9 @@ module RBI
               )
               raise Error, "Expected a simple type, got `#{type}`" unless type.is_a?(Type::Simple)
 
-              type_param_args = check_arguments_exactly!(node, 1)
-              type_param = parse_node(
-                type_param_args.first, #: as !nil
-              )
-              return Type::ClassOf.new(type, type_param)
+              type_parameter_args = check_arguments_at_least!(node, 1)
+              type_parameters = type_parameter_args.map { |arg| parse_node(arg) }
+              return Type::ClassOf.new(type, *type_parameters)
             end
           end
 

--- a/rbi/rbi.rbi
+++ b/rbi/rbi.rbi
@@ -2671,7 +2671,12 @@ class RBI::Type
     sig { returns(::RBI::Type::Boolean) }
     def boolean; end
 
-    sig { params(type: ::RBI::Type::Simple, type_parameters: ::RBI::Type).returns(::RBI::Type::ClassOf) }
+    sig do
+      params(
+        type: ::RBI::Type::Simple,
+        type_parameters: T.any(::RBI::Type, T::Array[::RBI::Type])
+      ).returns(::RBI::Type::ClassOf)
+    end
     def class_of(type, *type_parameters); end
 
     sig { params(name: ::String, params: T.any(::RBI::Type, T::Array[::RBI::Type])).returns(::RBI::Type::Generic) }

--- a/rbi/rbi.rbi
+++ b/rbi/rbi.rbi
@@ -2671,8 +2671,8 @@ class RBI::Type
     sig { returns(::RBI::Type::Boolean) }
     def boolean; end
 
-    sig { params(type: ::RBI::Type::Simple, type_parameter: T.nilable(::RBI::Type)).returns(::RBI::Type::ClassOf) }
-    def class_of(type, type_parameter = T.unsafe(nil)); end
+    sig { params(type: ::RBI::Type::Simple, type_parameters: ::RBI::Type).returns(::RBI::Type::ClassOf) }
+    def class_of(type, *type_parameters); end
 
     sig { params(name: ::String, params: T.any(::RBI::Type, T::Array[::RBI::Type])).returns(::RBI::Type::Generic) }
     def generic(name, *params); end
@@ -2865,8 +2865,8 @@ class RBI::Type::Class < ::RBI::Type
 end
 
 class RBI::Type::ClassOf < ::RBI::Type
-  sig { params(type: ::RBI::Type::Simple, type_parameter: T.nilable(::RBI::Type)).void }
-  def initialize(type, type_parameter = T.unsafe(nil)); end
+  sig { params(type: ::RBI::Type::Simple, type_parameters: ::RBI::Type).void }
+  def initialize(type, *type_parameters); end
 
   sig { override.params(other: ::BasicObject).returns(T::Boolean) }
   def ==(other); end
@@ -2883,8 +2883,8 @@ class RBI::Type::ClassOf < ::RBI::Type
   sig { returns(::RBI::Type::Simple) }
   def type; end
 
-  sig { returns(T.nilable(::RBI::Type)) }
-  def type_parameter; end
+  sig { returns(T::Array[::RBI::Type]) }
+  def type_parameters; end
 end
 
 class RBI::Type::Composite < ::RBI::Type

--- a/test/rbi/rbs/type_translator_test.rb
+++ b/test/rbi/rbs/type_translator_test.rb
@@ -92,6 +92,10 @@ module RBI
         assert_equal(Type.class_of(Type.simple("Foo::Bar")), translate("singleton(Foo::Bar)"))
         assert_equal(Type.class_of(Type.simple("::Foo::Bar")), translate("singleton(::Foo::Bar)"))
         assert_equal(Type.class_of(Type.simple("Foo"), Type.simple("Bar")), translate("singleton(Foo)[Bar]"))
+        assert_equal(
+          Type.class_of(Type.simple("Foo"), Type.simple("Foo"), Type.simple("Bar")),
+          translate("singleton(Foo)[Foo, Bar]"),
+        )
       end
 
       def test_erase_generic_types_keeps_non_generics
@@ -107,7 +111,7 @@ module RBI
         assert_equal(simple_foo, translate("Foo[Bar]", erase_generic_types: true))
         assert_equal(simple_foo, translate("Foo[Bar, ::Baz]", erase_generic_types: true))
         assert_equal(class_foo, translate("singleton(Foo)", erase_generic_types: true))
-        assert_equal(class_foo, translate("singleton(Foo)[Bar]", erase_generic_types: true))
+        assert_equal(class_foo, translate("singleton(Foo)[Foo, Bar]", erase_generic_types: true))
         assert_equal(root_array, translate("Array[Foo]", erase_generic_types: true))
         assert_equal(root_array, translate("T::Array[Foo]", erase_generic_types: true))
         assert_equal(root_array, translate("::T::Array[Foo]", erase_generic_types: true))

--- a/test/rbi/rbs_printer_test.rb
+++ b/test/rbi/rbs_printer_test.rb
@@ -748,7 +748,7 @@ module RBI
         sig { returns(T::Class[T.untyped]) }
         def e; end
 
-        sig { returns(T.class_of(Foo)[Bar]) }
+        sig { returns(T.class_of(Foo)[Foo, Bar]) }
         def f; end
       RBI
 
@@ -763,7 +763,7 @@ module RBI
 
         def e: -> Class[untyped]
 
-        def f: -> singleton(Foo)[Bar]
+        def f: -> singleton(Foo)[Foo, Bar]
       RBI
     end
 

--- a/test/rbi/type_parser_test.rb
+++ b/test/rbi/type_parser_test.rb
@@ -167,6 +167,12 @@ module RBI
       type = Type.parse_string("T.class_of(Foo)[Bar]")
       assert_equal(Type.class_of(Type.simple("Foo"), Type.simple("Bar")), type)
 
+      type = Type.parse_string("T.class_of(Foo)[Bar, Baz]")
+      assert_equal(
+        Type.class_of(Type.simple("Foo"), Type.simple("Bar"), Type.simple("Baz")),
+        type,
+      )
+
       e = assert_raises(RBI::Type::Error) do
         Type.parse_string("T.class_of(T.nilable(Foo))")
       end
@@ -175,7 +181,7 @@ module RBI
       e = assert_raises(RBI::Type::Error) do
         Type.parse_string("T.class_of(Foo)[]")
       end
-      assert_equal("Expected exactly 1 argument, got 0", e.message)
+      assert_equal("Expected at least 1 argument, got 0", e.message)
     end
 
     def test_parse_all

--- a/test/rbi/type_test.rb
+++ b/test/rbi/type_test.rb
@@ -462,6 +462,9 @@ module RBI
     def test_build_type_class_of_generic
       type = Type.class_of(Type.simple("String"), Type.simple("String"), Type.simple("Integer"))
       assert_equal("::T.class_of(String)[String, Integer]", type.to_rbi)
+
+      type = Type.class_of(Type.simple("String"), [Type.simple("String"), Type.simple("Integer")])
+      assert_equal("::T.class_of(String)[String, Integer]", type.to_rbi)
     end
 
     def test_buid_type_t_class

--- a/test/rbi/type_test.rb
+++ b/test/rbi/type_test.rb
@@ -460,8 +460,8 @@ module RBI
     end
 
     def test_build_type_class_of_generic
-      type = Type.class_of(Type.simple("String"), Type.simple("Integer"))
-      assert_equal("::T.class_of(String)[Integer]", type.to_rbi)
+      type = Type.class_of(Type.simple("String"), Type.simple("String"), Type.simple("Integer"))
+      assert_equal("::T.class_of(String)[String, Integer]", type.to_rbi)
     end
 
     def test_buid_type_t_class


### PR DESCRIPTION
Fixes #642.

- allow `T.class_of(Foo)[...]` to parse more than one type parameter
- preserve all singleton type parameters in RBI and RBS output
- translate multiple RBS singleton type parameters back to RBI