### PR TITLE
Fix RBS translation of braceless shape return types

### DIFF
--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -956,7 +956,11 @@ module RBI
           args = node.arguments
           if args.is_a?(Prism::ArgumentsNode)
             first = args.arguments.first
-            @current.return_type = node_string!(first) if first
+            if first
+              return_type = node_string!(first)
+              return_type = "{#{return_type}}" if braceless_shape?(first)
+              @current.return_type = return_type
+            end
           end
         when "type_parameters"
           args = node.arguments
@@ -980,6 +984,15 @@ module RBI
           sig_param_name(node.key),
           node_string!(node.value),
         )
+      end
+
+      #: (Prism::Node node) -> bool
+      def braceless_shape?(node)
+        return false unless node.is_a?(Prism::KeywordHashNode)
+
+        node.elements.all? do |element|
+          element.is_a?(Prism::AssocNode) && element.operator_loc
+        end
       end
 
       #: (Prism::Node node) -> String

--- a/rbi/rbi.rbi
+++ b/rbi/rbi.rbi
@@ -1033,6 +1033,9 @@ class RBI::Parser::SigBuilder < ::RBI::Parser::Visitor
   sig { params(node: ::Prism::CallNode, value: ::String).returns(T::Boolean) }
   def allow_incompatible_override?(node, value); end
 
+  sig { params(node: ::Prism::Node).returns(T::Boolean) }
+  def braceless_shape?(node); end
+
   sig { returns(::RBI::Sig) }
   def current; end
 

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -237,6 +237,50 @@ module RBI
       RBI
     end
 
+    def test_parse_sigs_with_braceless_shape_return_type
+      rbi = <<~RBI
+        sig { returns("foo" => Integer) }
+        def single; end
+
+        sig { returns(:foo => Integer) }
+        def symbol; end
+
+        sig { returns("foo" => Integer, :bar => String) }
+        def mixed_keys; end
+
+        sig { returns("foo" => Integer, "bar" => String) }
+        def multiple; end
+      RBI
+
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string)
+        sig { returns({"foo" => Integer}) }
+        def single; end
+
+        sig { returns({:foo => Integer}) }
+        def symbol; end
+
+        sig { returns({"foo" => Integer, :bar => String}) }
+        def mixed_keys; end
+
+        sig { returns({"foo" => Integer, "bar" => String}) }
+        def multiple; end
+      RBI
+    end
+
+    def test_parse_sig_preserves_invalid_keyword_return_argument_syntax
+      rbi = <<~RBI
+        sig { returns(foo: Integer) }
+        def keyword; end
+
+        sig { returns("foo" => Integer, bar: String) }
+        def mixed; end
+      RBI
+
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
+    end
+
     def test_parse_ignore_sig_not_on_self
       rbi = <<~RBI
         sig { void }

--- a/test/rbi/rbs_printer_test.rb
+++ b/test/rbi/rbs_printer_test.rb
@@ -278,6 +278,47 @@ module RBI
       RBI
     end
 
+    def test_print_signature_with_braceless_shape_return_type
+      rbi = parse_rbi(<<~RBI)
+        sig { returns("foo" => Integer) }
+        def single; end
+
+        sig { returns(:foo => Integer) }
+        def symbol; end
+
+        sig { returns("foo" => Integer, "bar" => String) }
+        def multiple; end
+      RBI
+
+      assert_equal(<<~RBS, rbi.rbs_string)
+        def single: -> {"foo" => Integer}
+
+        def symbol: -> {foo: Integer}
+
+        def multiple: -> {"foo" => Integer, "bar" => String}
+      RBS
+    end
+
+    def test_reject_signature_with_keyword_return_argument
+      keyword = parse_rbi(<<~RBI)
+        sig { returns(foo: Integer) }
+        def keyword; end
+      RBI
+
+      mixed = parse_rbi(<<~RBI)
+        sig { returns("foo" => Integer, bar: String) }
+        def mixed; end
+      RBI
+
+      assert_raises(RBI::RBSPrinter::Error) do
+        keyword.rbs_string
+      end
+
+      assert_raises(RBI::RBSPrinter::Error) do
+        mixed.rbs_string
+      end
+    end
+
     def test_print_methods_without_signature
       rbi = parse_rbi(<<~RBI)
         def foo; end


### PR DESCRIPTION
Fixes #641

- preserve braceless hash-rocket return shapes by restoring braces around Prism keyword hash nodes
- distinguish hash rockets from keyword arguments using association operator locations
- cover string, symbol, mixed-key, single-key, and multi-key shapes
- keep invalid keyword-argument forms rejected during RBS translation
