### PR TITLE
Add support for top-level `bind` in sigs

### DIFF
--- a/lib/rbi/model.rb
+++ b/lib/rbi/model.rb
@@ -555,6 +555,7 @@ module RBI
     #: (
     #|   ?params: Array[SigParam]?,
     #|   ?return_type: (String | Type),
+    #|   ?bind_type: (String | Type)?,
     #|   ?is_abstract: bool,
     #|   ?is_override: bool,
     #|   ?is_overridable: bool,
@@ -564,6 +565,7 @@ module RBI
     def add_sig(
       params: [],
       return_type: "void",
+      bind_type: nil,
       is_abstract: false,
       is_override: false,
       is_overridable: false,
@@ -575,6 +577,7 @@ module RBI
       sig = Sig.new(
         params: params,
         return_type: return_type,
+        bind_type: bind_type,
         is_abstract: is_abstract,
         is_override: is_override,
         is_overridable: is_overridable,
@@ -1058,6 +1061,9 @@ module RBI
     #: (Type | String)
     attr_accessor :return_type
 
+    #: (Type | String)?
+    attr_accessor :bind_type
+
     #: bool
     attr_accessor :is_abstract
 
@@ -1095,6 +1101,7 @@ module RBI
     #: (
     #|   ?params: Array[SigParam]?,
     #|   ?return_type: (Type | String),
+    #|   ?bind_type: (Type | String)?,
     #|   ?is_abstract: bool,
     #|   ?is_override: bool,
     #|   ?is_overridable: bool,
@@ -1110,6 +1117,7 @@ module RBI
     def initialize(
       params: nil,
       return_type: "void",
+      bind_type: nil,
       is_abstract: false,
       is_override: false,
       is_overridable: false,
@@ -1126,6 +1134,7 @@ module RBI
       super(loc: loc, comments: comments)
       @params = params #: Array[SigParam]?
       @return_type = return_type
+      @bind_type = bind_type
       @is_abstract = is_abstract
       @is_override = is_override
       @is_overridable = is_overridable
@@ -1152,7 +1161,8 @@ module RBI
     def ==(other)
       return false unless other.is_a?(Sig)
 
-      params == other.params && return_type.to_s == other.return_type.to_s && is_abstract == other.is_abstract &&
+      params == other.params && return_type.to_s == other.return_type.to_s &&
+        bind_type&.to_s == other.bind_type&.to_s && is_abstract == other.is_abstract &&
         is_override == other.is_override && is_overridable == other.is_overridable && is_final == other.is_final &&
         without_runtime == other.without_runtime && type_params == other.type_params && checked == other.checked
     end

--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -139,6 +139,21 @@ module RBI
         node_string(node) #: as !nil
       end
 
+      #: (Prism::Node node) -> String
+      def type_string(node)
+        type = node_string!(node)
+        braceless_shape?(node) ? "{#{type}}" : type
+      end
+
+      #: (Prism::Node node) -> bool
+      def braceless_shape?(node)
+        return false unless node.is_a?(Prism::KeywordHashNode)
+
+        node.elements.all? do |element|
+          element.is_a?(Prism::AssocNode) && element.operator_loc
+        end
+      end
+
       #: (Prism::Node node) -> Prism::Location
       def adjust_prism_location_for_heredoc(node)
         visitor = HeredocLocationVisitor.new(
@@ -833,7 +848,7 @@ module RBI
         return unless type_arg
 
         name = node_string!(name_arg).delete_prefix(":")
-        type = node_string!(type_arg)
+        type = type_string(type_arg)
         loc = node_loc(send)
         comments = node_comments(send)
         default_value = nil #: String?
@@ -995,17 +1010,7 @@ module RBI
         type_node = args.arguments.first
         return unless type_node
 
-        type = node_string!(type_node)
-        braceless_shape?(type_node) ? "{#{type}}" : type
-      end
-
-      #: (Prism::Node node) -> bool
-      def braceless_shape?(node)
-        return false unless node.is_a?(Prism::KeywordHashNode)
-
-        node.elements.all? do |element|
-          element.is_a?(Prism::AssocNode) && element.operator_loc
-        end
+        type_string(type_node)
       end
 
       #: (Prism::Node node) -> String

--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -941,6 +941,9 @@ module RBI
               @current.is_final = node_string(arg) == ":final"
             end
           end
+        when "bind"
+          bind_type = sig_type_argument(node)
+          @current.bind_type = bind_type if bind_type
         when "abstract"
           @current.is_abstract = true
         when "checked"
@@ -958,15 +961,8 @@ module RBI
         when "params"
           visit(node.arguments)
         when "returns"
-          args = node.arguments
-          if args.is_a?(Prism::ArgumentsNode)
-            first = args.arguments.first
-            if first
-              return_type = node_string!(first)
-              return_type = "{#{return_type}}" if braceless_shape?(first)
-              @current.return_type = return_type
-            end
-          end
+          return_type = sig_type_argument(node)
+          @current.return_type = return_type if return_type
         when "type_parameters"
           args = node.arguments
           if args.is_a?(Prism::ArgumentsNode)
@@ -989,6 +985,18 @@ module RBI
           sig_param_name(node.key),
           node_string!(node.value),
         )
+      end
+
+      #: (Prism::CallNode node) -> String?
+      def sig_type_argument(node)
+        args = node.arguments
+        return unless args.is_a?(Prism::ArgumentsNode)
+
+        type_node = args.arguments.first
+        return unless type_node
+
+        type = node_string!(type_node)
+        braceless_shape?(type_node) ? "{#{type}}" : type
       end
 
       #: (Prism::Node node) -> bool

--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -835,7 +835,7 @@ module RBI
 
     #: (Sig node) -> Array[String]
     def sig_modifiers(node)
-      return EMPTY_MODIFIERS unless node.is_abstract || node.is_override || node.is_overridable ||
+      return EMPTY_MODIFIERS unless node.is_abstract || node.is_override || node.is_overridable || node.bind_type ||
         node.type_params? || node.checked
 
       modifiers = [] #: Array[String]
@@ -852,6 +852,7 @@ module RBI
       end
 
       modifiers << "overridable" if node.is_overridable
+      modifiers << "bind(#{node.bind_type})" if node.bind_type
       if node.type_params?
         modifiers << "type_parameters(#{node.type_params.map { |type| ":#{type}" }.join(", ")})"
       end

--- a/lib/rbi/rewriters/attr_to_methods.rb
+++ b/lib/rbi/rewriters/attr_to_methods.rb
@@ -103,6 +103,7 @@ module RBI
         Sig.new(
           params: params,
           return_type: "void",
+          bind_type: sig.bind_type,
           is_abstract: sig.is_abstract,
           is_override: sig.is_override,
           is_overridable: sig.is_overridable,

--- a/rbi/rbi.rbi
+++ b/rbi/rbi.rbi
@@ -714,6 +714,7 @@ class RBI::Method < ::RBI::NodeWithComments
     params(
       params: T.nilable(T::Array[::RBI::SigParam]),
       return_type: T.any(::RBI::Type, ::String),
+      bind_type: T.nilable(T.any(::RBI::Type, ::String)),
       is_abstract: T::Boolean,
       is_override: T::Boolean,
       is_overridable: T::Boolean,
@@ -723,7 +724,7 @@ class RBI::Method < ::RBI::NodeWithComments
       block: T.nilable(T.proc.params(node: ::RBI::Sig).void)
     ).void
   end
-  def add_sig(params: T.unsafe(nil), return_type: T.unsafe(nil), is_abstract: T.unsafe(nil), is_override: T.unsafe(nil), is_overridable: T.unsafe(nil), is_final: T.unsafe(nil), type_params: T.unsafe(nil), checked: T.unsafe(nil), &block); end
+  def add_sig(params: T.unsafe(nil), return_type: T.unsafe(nil), bind_type: T.unsafe(nil), is_abstract: T.unsafe(nil), is_override: T.unsafe(nil), is_overridable: T.unsafe(nil), is_final: T.unsafe(nil), type_params: T.unsafe(nil), checked: T.unsafe(nil), &block); end
 
   sig { override.params(other: ::RBI::Node).returns(T::Boolean) }
   def compatible_with?(other); end
@@ -1064,6 +1065,9 @@ class RBI::Parser::SigBuilder < ::RBI::Parser::Visitor
 
   sig { params(node: ::Prism::Node).returns(::String) }
   def sig_param_name(node); end
+
+  sig { params(node: ::Prism::CallNode).returns(T.nilable(::String)) }
+  def sig_type_argument(node); end
 
   sig { override.params(node: ::Prism::AssocNode).void }
   def visit_assoc_node(node); end
@@ -2261,6 +2265,7 @@ class RBI::Sig < ::RBI::NodeWithComments
     params(
       params: T.nilable(T::Array[::RBI::SigParam]),
       return_type: T.any(::RBI::Type, ::String),
+      bind_type: T.nilable(T.any(::RBI::Type, ::String)),
       is_abstract: T::Boolean,
       is_override: T::Boolean,
       is_overridable: T::Boolean,
@@ -2275,7 +2280,7 @@ class RBI::Sig < ::RBI::NodeWithComments
       block: T.nilable(T.proc.params(node: ::RBI::Sig).void)
     ).void
   end
-  def initialize(params: T.unsafe(nil), return_type: T.unsafe(nil), is_abstract: T.unsafe(nil), is_override: T.unsafe(nil), is_overridable: T.unsafe(nil), is_final: T.unsafe(nil), allow_incompatible_override: T.unsafe(nil), allow_incompatible_override_visibility: T.unsafe(nil), without_runtime: T.unsafe(nil), type_params: T.unsafe(nil), checked: T.unsafe(nil), loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
+  def initialize(params: T.unsafe(nil), return_type: T.unsafe(nil), bind_type: T.unsafe(nil), is_abstract: T.unsafe(nil), is_override: T.unsafe(nil), is_overridable: T.unsafe(nil), is_final: T.unsafe(nil), allow_incompatible_override: T.unsafe(nil), allow_incompatible_override_visibility: T.unsafe(nil), without_runtime: T.unsafe(nil), type_params: T.unsafe(nil), checked: T.unsafe(nil), loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
 
   sig { params(param: ::RBI::SigParam).void }
   def <<(param); end
@@ -2295,6 +2300,11 @@ class RBI::Sig < ::RBI::NodeWithComments
   def allow_incompatible_override_visibility; end
 
   def allow_incompatible_override_visibility=(_arg0); end
+
+  sig { returns(T.nilable(T.any(::RBI::Type, ::String))) }
+  def bind_type; end
+
+  def bind_type=(_arg0); end
 
   sig { returns(T.nilable(::Symbol)) }
   def checked; end

--- a/rbi/rbi.rbi
+++ b/rbi/rbi.rbi
@@ -1057,9 +1057,6 @@ class RBI::Parser::SigBuilder < ::RBI::Parser::Visitor
   sig { params(node: ::Prism::CallNode, value: ::String).returns(T::Boolean) }
   def allow_incompatible_override?(node, value); end
 
-  sig { params(node: ::Prism::Node).returns(T::Boolean) }
-  def braceless_shape?(node); end
-
   sig { returns(::RBI::Sig) }
   def current; end
 
@@ -1180,6 +1177,9 @@ class RBI::Parser::Visitor < ::Prism::Visitor
   sig { params(node: ::Prism::Node).returns(::Prism::Location) }
   def adjust_prism_location_for_heredoc(node); end
 
+  sig { params(node: ::Prism::Node).returns(T::Boolean) }
+  def braceless_shape?(node); end
+
   sig { params(node: ::Prism::Node).returns(::RBI::Loc) }
   def node_loc(node); end
 
@@ -1194,6 +1194,9 @@ class RBI::Parser::Visitor < ::Prism::Visitor
 
   sig { params(node: T.nilable(::Prism::Node)).returns(T::Boolean) }
   def t_sig_without_runtime?(node); end
+
+  sig { params(node: ::Prism::Node).returns(::String) }
+  def type_string(node); end
 end
 
 class RBI::Printer < ::RBI::Visitor

--- a/test/rbi/model_test.rb
+++ b/test/rbi/model_test.rb
@@ -228,7 +228,7 @@ module RBI
             sig.return_type = "void"
           end
 
-          node.add_sig(type_params: ["T", "U"]) do |sig|
+          node.add_sig(bind_type: "Parent", type_params: ["T", "U"]) do |sig|
             sig.is_abstract = true
             sig.is_override = true
             sig.is_overridable = true
@@ -248,7 +248,7 @@ module RBI
       assert_equal(<<~RBI, rbi.string)
         sig { params(p1: T.untyped, p2: String).returns(T.untyped) }
         sig { params(p3: T.untyped).void }
-        sig(:final) { abstract.override.overridable.type_parameters(:T, :U).checked(:never).params(p4: T.untyped).void }
+        sig(:final) { abstract.override.overridable.bind(Parent).type_parameters(:T, :U).checked(:never).params(p4: T.untyped).void }
         sig { params(p5: T.untyped).void }
         def foo(p1, p2 = 'value', *p3, p4:, p5: 'value', **p6, &p7); end
       RBI

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -242,6 +242,44 @@ module RBI
       RBI
     end
 
+    def test_parse_sigs_with_bind
+      rbi = <<~RBI
+        sig { bind(Foo).void }
+        def simple; end
+
+        sig { override.bind(T.class_of(Foo)).params(value: String).returns(Symbol) }
+        def chained(value); end
+      RBI
+
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
+    end
+
+    def test_parse_sigs_with_braceless_shape_bind_type
+      rbi = <<~RBI
+        sig { bind("foo" => Integer).void }
+        def string_key; end
+
+        sig { bind(:foo => Integer).void }
+        def symbol_key; end
+
+        sig { bind("foo" => Integer, :bar => String).void }
+        def mixed_keys; end
+      RBI
+
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string)
+        sig { bind({"foo" => Integer}).void }
+        def string_key; end
+
+        sig { bind({:foo => Integer}).void }
+        def symbol_key; end
+
+        sig { bind({"foo" => Integer, :bar => String}).void }
+        def mixed_keys; end
+      RBI
+    end
+
     def test_parse_sigs_with_braceless_shape_return_type
       rbi = <<~RBI
         sig { returns("foo" => Integer) }

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -489,6 +489,39 @@ module RBI
       RBI
     end
 
+    def test_parse_t_struct_fields_with_braceless_shape_types
+      rbi = <<~RBI
+        class Shapes < T::Struct
+          const :string_key, "foo" => Integer
+          const :symbol_key, :foo => Integer
+          prop :mixed_keys, "foo" => Integer, :bar => String
+          prop :multiple, "foo" => Integer, "bar" => String
+        end
+      RBI
+
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string)
+        class Shapes < T::Struct
+          const :string_key, {"foo" => Integer}
+          const :symbol_key, {:foo => Integer}
+          prop :mixed_keys, {"foo" => Integer, :bar => String}
+          prop :multiple, {"foo" => Integer, "bar" => String}
+        end
+      RBI
+    end
+
+    def test_parse_t_struct_fields_preserves_keyword_type_syntax
+      rbi = <<~RBI
+        class Invalid < T::Struct
+          const :keyword, foo: Integer
+          prop :mixed, "foo" => Integer, bar: String
+        end
+      RBI
+
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
+    end
+
     def test_parse_t_enums
       rbi = <<~RBI
         class Foo < T::Enum

--- a/test/rbi/printer_test.rb
+++ b/test/rbi/printer_test.rb
@@ -919,6 +919,18 @@ module RBI
       RBI
     end
 
+    def test_print_sig_with_bind
+      sig = Sig.new(bind_type: "Foo")
+
+      assert_equal("sig { bind(Foo).void }\n", sig.string)
+      assert_equal(<<~RBI, sig.string(max_line_length: 1))
+        sig do
+          bind(Foo)
+            .void
+        end
+      RBI
+    end
+
     def test_print_sig_over_max_line_length_with_all_modifiers
       sig = Sig.new
 

--- a/test/rbi/rbs_printer_test.rb
+++ b/test/rbi/rbs_printer_test.rb
@@ -1001,6 +1001,36 @@ module RBI
       RBI
     end
 
+    def test_print_t_structs_with_braceless_shape_types
+      rbi = parse_rbi(<<~RBI)
+        class Shapes < T::Struct
+          const :config, "foo" => Integer
+          prop :options, :bar => String
+        end
+      RBI
+
+      assert_equal(<<~RBS, rbi.rbs_string)
+        class Shapes
+          attr_reader config: {"foo" => Integer}
+          attr_accessor options: {bar: String}
+
+          def initialize: (config: {"foo" => Integer}, options: {bar: String}) -> void
+        end
+      RBS
+    end
+
+    def test_reject_t_struct_fields_with_keyword_type_syntax
+      rbi = parse_rbi(<<~RBI)
+        class Invalid < T::Struct
+          prop :options, foo: Integer
+        end
+      RBI
+
+      assert_raises(RBI::RBSPrinter::Error) do
+        rbi.rbs_string
+      end
+    end
+
     def test_print_t_enums
       rbi = parse_rbi(<<~RBI)
         class Foo < T::Enum

--- a/test/rbi/rbs_printer_test.rb
+++ b/test/rbi/rbs_printer_test.rb
@@ -606,6 +606,28 @@ module RBI
       RBI
     end
 
+    def test_print_method_sig_ignores_bind
+      rbi = parse_rbi(<<~RBI)
+        sig { bind(Foo).returns(String) }
+        def simple; end
+
+        sig { bind("foo" => Integer).void }
+        def shape; end
+
+        sig { bind({foo: Integer}).void }
+        def symbol_shape; end
+      RBI
+
+      # There is no equivalent for `bind` at the top level in RBS, so we just ignore it
+      assert_equal(<<~RBS, rbi.rbs_string)
+        def simple: -> String
+
+        def shape: -> void
+
+        def symbol_shape: -> void
+      RBS
+    end
+
     def test_print_breaks_long_signatures
       rbi_def = Method.new("foo") do |node|
         node.params << ReqParam.new("a")

--- a/test/rbi/rewriters/attr_to_methods_test.rb
+++ b/test/rbi/rewriters/attr_to_methods_test.rb
@@ -291,6 +291,23 @@ module RBI
       RBI
     end
 
+    def test_replacing_attr_accessor_copies_bind
+      tree = parse_rbi(<<~RBI)
+        sig { bind(Foo).returns(Integer) }
+        attr_accessor :value
+      RBI
+
+      tree.replace_attributes_with_methods!
+
+      assert_equal(<<~RBI, tree.string)
+        sig { bind(Foo).returns(Integer) }
+        def value; end
+
+        sig { bind(Foo).params(value: Integer).void }
+        def value=(value); end
+      RBI
+    end
+
     def test_raise_on_multiple_sigs
       tree = parse_rbi(<<~RBI)
         sig { returns(Integer) }


### PR DESCRIPTION
## Summary

Add support for Sorbet’s top-level `bind` signature modifier:

```ruby
sig { bind(Foo).params(value: String).returns(Symbol) }
```

Previously, the parser silently discarded `bind(Foo)`.

- store the bind type on `RBI::Sig`
- parse and print `bind(...)` when round-tripping RBI
- normalize braceless shape bind types:

  ```ruby
  sig { bind("foo" => Integer).void }
  ```

  becomes:

  ```ruby
  sig { bind({"foo" => Integer}).void }
  ```

- include bind types in signature equality and merge behavior
- preserve bind types when rewriting attributes into methods
- share type-argument extraction between `bind` and `returns`

RBS output intentionally omits top-level bind. Sorbet uses it to set the type of `self` while checking the method body, and RBS has no equivalent method-level self binding.