### PR TITLE
Support braceless shape types in T::Struct fields

### DIFF
--- a/lib/rbi/parser.rb
+++ b/lib/rbi/parser.rb
@@ -139,6 +139,21 @@ module RBI
         node_string(node) #: as !nil
       end
 
+      #: (Prism::Node node) -> String
+      def type_string(node)
+        type = node_string!(node)
+        braceless_shape?(node) ? "{#{type}}" : type
+      end
+
+      #: (Prism::Node node) -> bool
+      def braceless_shape?(node)
+        return false unless node.is_a?(Prism::KeywordHashNode)
+
+        node.elements.all? do |element|
+          element.is_a?(Prism::AssocNode) && element.operator_loc
+        end
+      end
+
       #: (Prism::Node node) -> Prism::Location
       def adjust_prism_location_for_heredoc(node)
         visitor = HeredocLocationVisitor.new(
@@ -833,7 +848,7 @@ module RBI
         return unless type_arg
 
         name = node_string!(name_arg).delete_prefix(":")
-        type = node_string!(type_arg)
+        type = type_string(type_arg)
         loc = node_loc(send)
         comments = node_comments(send)
         default_value = nil #: String?
@@ -995,17 +1010,7 @@ module RBI
         type_node = args.arguments.first
         return unless type_node
 
-        type = node_string!(type_node)
-        braceless_shape?(type_node) ? "{#{type}}" : type
-      end
-
-      #: (Prism::Node node) -> bool
-      def braceless_shape?(node)
-        return false unless node.is_a?(Prism::KeywordHashNode)
-
-        node.elements.all? do |element|
-          element.is_a?(Prism::AssocNode) && element.operator_loc
-        end
+        type_string(type_node)
       end
 
       #: (Prism::Node node) -> String

--- a/rbi/rbi.rbi
+++ b/rbi/rbi.rbi
@@ -1057,9 +1057,6 @@ class RBI::Parser::SigBuilder < ::RBI::Parser::Visitor
   sig { params(node: ::Prism::CallNode, value: ::String).returns(T::Boolean) }
   def allow_incompatible_override?(node, value); end
 
-  sig { params(node: ::Prism::Node).returns(T::Boolean) }
-  def braceless_shape?(node); end
-
   sig { returns(::RBI::Sig) }
   def current; end
 
@@ -1180,6 +1177,9 @@ class RBI::Parser::Visitor < ::Prism::Visitor
   sig { params(node: ::Prism::Node).returns(::Prism::Location) }
   def adjust_prism_location_for_heredoc(node); end
 
+  sig { params(node: ::Prism::Node).returns(T::Boolean) }
+  def braceless_shape?(node); end
+
   sig { params(node: ::Prism::Node).returns(::RBI::Loc) }
   def node_loc(node); end
 
@@ -1194,6 +1194,9 @@ class RBI::Parser::Visitor < ::Prism::Visitor
 
   sig { params(node: T.nilable(::Prism::Node)).returns(T::Boolean) }
   def t_sig_without_runtime?(node); end
+
+  sig { params(node: ::Prism::Node).returns(::String) }
+  def type_string(node); end
 end
 
 class RBI::Printer < ::RBI::Visitor

--- a/test/rbi/parser_test.rb
+++ b/test/rbi/parser_test.rb
@@ -489,6 +489,39 @@ module RBI
       RBI
     end
 
+    def test_parse_t_struct_fields_with_braceless_shape_types
+      rbi = <<~RBI
+        class Shapes < T::Struct
+          const :string_key, "foo" => Integer
+          const :symbol_key, :foo => Integer
+          prop :mixed_keys, "foo" => Integer, :bar => String
+          prop :multiple, "foo" => Integer, "bar" => String
+        end
+      RBI
+
+      tree = parse_rbi(rbi)
+      assert_equal(<<~RBI, tree.string)
+        class Shapes < T::Struct
+          const :string_key, {"foo" => Integer}
+          const :symbol_key, {:foo => Integer}
+          prop :mixed_keys, {"foo" => Integer, :bar => String}
+          prop :multiple, {"foo" => Integer, "bar" => String}
+        end
+      RBI
+    end
+
+    def test_parse_t_struct_fields_preserves_keyword_type_syntax
+      rbi = <<~RBI
+        class Invalid < T::Struct
+          const :keyword, foo: Integer
+          prop :mixed, "foo" => Integer, bar: String
+        end
+      RBI
+
+      tree = parse_rbi(rbi)
+      assert_equal(rbi, tree.string)
+    end
+
     def test_parse_t_enums
       rbi = <<~RBI
         class Foo < T::Enum

--- a/test/rbi/rbs_printer_test.rb
+++ b/test/rbi/rbs_printer_test.rb
@@ -1001,6 +1001,36 @@ module RBI
       RBI
     end
 
+    def test_print_t_structs_with_braceless_shape_types
+      rbi = parse_rbi(<<~RBI)
+        class Shapes < T::Struct
+          const :config, "foo" => Integer
+          prop :options, :bar => String
+        end
+      RBI
+
+      assert_equal(<<~RBS, rbi.rbs_string)
+        class Shapes
+          attr_reader config: {"foo" => Integer}
+          attr_accessor options: {bar: String}
+
+          def initialize: (config: {"foo" => Integer}, options: {bar: String}) -> void
+        end
+      RBS
+    end
+
+    def test_reject_t_struct_fields_with_keyword_type_syntax
+      rbi = parse_rbi(<<~RBI)
+        class Invalid < T::Struct
+          prop :options, foo: Integer
+        end
+      RBI
+
+      assert_raises(RBI::RBSPrinter::Error) do
+        rbi.rbs_string
+      end
+    end
+
     def test_print_t_enums
       rbi = parse_rbi(<<~RBI)
         class Foo < T::Enum


### PR DESCRIPTION
## Summary

Depends on #645.

Add support for braceless hash-rocket shape types in `T::Struct` fields:

```ruby
class Configuration < T::Struct
  const :settings, "timeout" => Integer
  prop :options, :enabled => T::Boolean
end
```

The parser now restores the braces required to represent these values unambiguously as types:

```ruby
class Configuration < T::Struct
  const :settings, {"timeout" => Integer}
  prop :options, {:enabled => T::Boolean}
end
```

- support string, symbol, mixed, and multiple shape keys in `const` and `prop`
- move shared shape normalization into `Parser::Visitor`
- reuse the same normalization for `returns`, top-level `bind`, and `T::Struct` fields
- preserve keyword argument syntax such as `prop :options, enabled: T::Boolean` rather than treating it as a shape
- translate normalized fields into valid RBS attribute and constructor types