### PR TITLE
Add test for Method#add_no_kw_param

### DIFF
--- a/test/rbi/model_test.rb
+++ b/test/rbi/model_test.rb
@@ -254,6 +254,18 @@ module RBI
       RBI
     end
 
+    def test_model_add_no_kw_param
+      rbi = Tree.new do |tree|
+        tree << Method.new("foo") do |method|
+          method.add_no_kw_param
+        end
+      end
+
+      assert_equal(<<~RBI, rbi.string)
+        def foo(**nil); end
+      RBI
+    end
+
     def test_model_fully_qualified_names
       mod = Module.new("Foo")
       assert_equal("::Foo", mod.fully_qualified_name)


### PR DESCRIPTION
## Summary

- exercise `RBI::Method#add_no_kw_param` through the model builder API
- assert that it renders `**nil` in the generated RBI

Closes https://github.com/Shopify/rbi/pull/648 by marking this public builder method as used so it is no longer reported as dead code.

## Test plan

- `bundle exec ruby -Itest test/rbi/model_test.rb`