### PR TITLE
Do not instantiate `Public` visibility for implicit public defs and attrs

### DIFF
--- a/bench/allocation.rb
+++ b/bench/allocation.rb
@@ -15,7 +15,7 @@ def build_tree(num_methods: 200)
   klass << RBI::Extend.new("RelMethods")
   num_methods.times do |i|
     vis = case i % 10
-    when 0..6 then RBI::Public::DEFAULT
+    when 0..6 then RBI::Public.new
     when 7..8 then RBI::Private.new
     else RBI::Protected.new
     end #: RBI::Visibility

--- a/bench/benchmark.rb
+++ b/bench/benchmark.rb
@@ -36,7 +36,7 @@ def build_large_tree(num_methods: 200, num_attrs: 20, num_includes: 5, num_scope
   # Add methods (mix of public, private, singleton)
   num_methods.times do |i|
     visibility = case i % 10
-    when 0..6 then RBI::Public::DEFAULT
+    when 0..6 then RBI::Public.new
     when 7..8 then RBI::Private.new
     else RBI::Protected.new
     end #: RBI::Visibility

--- a/lib/rbi/model.rb
+++ b/lib/rbi/model.rb
@@ -326,8 +326,8 @@ module RBI
     #: Array[Symbol]
     attr_reader :names
 
-    #: Visibility
-    attr_accessor :visibility
+    #: Visibility?
+    attr_accessor :visibility # `nil` for implicit `public` visibility
 
     #: -> Array[Sig]
     def sigs
@@ -345,12 +345,12 @@ module RBI
     #: (
     #|   Symbol name,
     #|   Array[Symbol] names,
-    #|   ?visibility: Visibility,
+    #|   ?visibility: Visibility?,
     #|   ?sigs: Array[Sig]?,
     #|   ?loc: Loc?,
     #|   ?comments: Array[Comment]?
     #| ) -> void
-    def initialize(name, names, visibility: Public::DEFAULT, sigs: nil, loc: nil, comments: nil)
+    def initialize(name, names, visibility: nil, sigs: nil, loc: nil, comments: nil)
       super(loc: loc, comments: comments)
       @names = [name, *names] #: Array[Symbol]
       @visibility = visibility
@@ -366,12 +366,12 @@ module RBI
     #: (
     #|   Symbol name,
     #|   *Symbol names,
-    #|   ?visibility: Visibility,
+    #|   ?visibility: Visibility?,
     #|   ?sigs: Array[Sig]?,
     #|   ?loc: Loc?,
     #|   ?comments: Array[Comment]?
     #| ) ?{ (AttrAccessor node) -> void } -> void
-    def initialize(name, *names, visibility: Public::DEFAULT, sigs: nil, loc: nil, comments: nil, &block)
+    def initialize(name, *names, visibility: nil, sigs: nil, loc: nil, comments: nil, &block)
       super(name, names, loc: loc, visibility: visibility, sigs: sigs, comments: comments)
       block&.call(self)
     end
@@ -395,12 +395,12 @@ module RBI
     #: (
     #|   Symbol name,
     #|   *Symbol names,
-    #|   ?visibility: Visibility,
+    #|   ?visibility: Visibility?,
     #|   ?sigs: Array[Sig]?,
     #|   ?loc: Loc?,
     #|   ?comments: Array[Comment]?
     #| ) ?{ (AttrReader node) -> void } -> void
-    def initialize(name, *names, visibility: Public::DEFAULT, sigs: nil, loc: nil, comments: nil, &block)
+    def initialize(name, *names, visibility: nil, sigs: nil, loc: nil, comments: nil, &block)
       super(name, names, loc: loc, visibility: visibility, sigs: sigs, comments: comments)
       block&.call(self)
     end
@@ -424,12 +424,12 @@ module RBI
     #: (
     #|   Symbol name,
     #|   *Symbol names,
-    #|   ?visibility: Visibility,
+    #|   ?visibility: Visibility?,
     #|   ?sigs: Array[Sig]?,
     #|   ?loc: Loc?,
     #|   ?comments: Array[Comment]?
     #| ) ?{ (AttrWriter node) -> void } -> void
-    def initialize(name, *names, visibility: Public::DEFAULT, sigs: nil, loc: nil, comments: nil, &block)
+    def initialize(name, *names, visibility: nil, sigs: nil, loc: nil, comments: nil, &block)
       super(name, names, loc: loc, visibility: visibility, sigs: sigs, comments: comments)
       block&.call(self)
     end
@@ -463,8 +463,8 @@ module RBI
     #: bool
     attr_accessor :is_singleton
 
-    #: Visibility
-    attr_accessor :visibility
+    #: Visibility?
+    attr_accessor :visibility # `nil` for implicit `public` visibility
 
     #: -> Array[Sig]
     def sigs
@@ -483,7 +483,7 @@ module RBI
     #|   String name,
     #|   ?params: Array[Param]?,
     #|   ?is_singleton: bool,
-    #|   ?visibility: Visibility,
+    #|   ?visibility: Visibility?,
     #|   ?sigs: Array[Sig]?,
     #|   ?loc: Loc?,
     #|   ?comments: Array[Comment]?
@@ -492,7 +492,7 @@ module RBI
       name,
       params: nil,
       is_singleton: false,
-      visibility: Public::DEFAULT,
+      visibility: nil,
       sigs: nil,
       loc: nil,
       comments: nil,
@@ -991,9 +991,6 @@ module RBI
       super(:public, loc: loc, comments: comments)
       block&.call(self)
     end
-
-    # Shared default instance to avoid allocating a new Public on every Method/Attr creation.
-    DEFAULT = new.freeze #: Public
   end
 
   class Protected < Visibility

--- a/lib/rbi/printer.rb
+++ b/lib/rbi/printer.rb
@@ -285,8 +285,10 @@ module RBI
 
       print_loc(node)
       printt
-      unless in_visibility_group || node.visibility.public?
-        print(node.visibility.visibility.name)
+
+      visibility = node.visibility
+      unless in_visibility_group || visibility.nil? || visibility.public?
+        print(visibility.visibility.name)
         print(" ")
       end
       case node
@@ -319,8 +321,9 @@ module RBI
 
       print_loc(node)
       printt
-      unless in_visibility_group || node.visibility.public?
-        print(node.visibility.visibility.name)
+      visibility = node.visibility
+      unless in_visibility_group || visibility.nil? || visibility.public?
+        print(visibility.visibility.name)
         print(" ")
       end
       print("def ")

--- a/lib/rbi/rbs_printer.rb
+++ b/lib/rbi/rbs_printer.rb
@@ -283,8 +283,9 @@ module RBI
         visit_all(node.comments)
         print_loc(node)
         printt
-        unless in_visibility_group || node.visibility.public? || node.visibility.protected?
-          print(node.visibility.visibility.name)
+        visibility = node.visibility
+        unless in_visibility_group || visibility.nil? || visibility.public? || visibility.protected?
+          print(visibility.visibility.name)
           print(" ")
         end
         case node
@@ -363,8 +364,9 @@ module RBI
 
       print_loc(node)
       printt
-      unless in_visibility_group || node.visibility.public?
-        print(node.visibility.visibility.name)
+      visibility = node.visibility
+      unless in_visibility_group || visibility.nil? || visibility.public?
+        print(visibility.visibility.name)
         print(" ")
       end
       print("def ")

--- a/lib/rbi/rewriters/attr_to_methods.rb
+++ b/lib/rbi/rewriters/attr_to_methods.rb
@@ -76,7 +76,7 @@ module RBI
       [sig, attribute_type]
     end
 
-    #: (String name, Sig? sig, Visibility visibility, Loc? loc, Array[Comment] comments) -> Method
+    #: (String name, Sig? sig, Visibility? visibility, Loc? loc, Array[Comment] comments) -> Method
     def create_getter_method(name, sig, visibility, loc, comments)
       Method.new(
         name,
@@ -92,7 +92,7 @@ module RBI
     #|   String name,
     #|   Sig? sig,
     #|   (Type | String)? attribute_type,
-    #|   Visibility visibility,
+    #|   Visibility? visibility,
     #|   Loc? loc,
     #|   Array[Comment] comments
     #| ) -> Method

--- a/rbi/rbi.rbi
+++ b/rbi/rbi.rbi
@@ -29,7 +29,7 @@ class RBI::Attr < ::RBI::NodeWithComments
     params(
       name: ::Symbol,
       names: T::Array[::Symbol],
-      visibility: ::RBI::Visibility,
+      visibility: T.nilable(::RBI::Visibility),
       sigs: T.nilable(T::Array[::RBI::Sig]),
       loc: T.nilable(::RBI::Loc),
       comments: T.nilable(T::Array[::RBI::Comment])
@@ -64,7 +64,7 @@ class RBI::Attr < ::RBI::NodeWithComments
   sig { returns(T::Boolean) }
   def sigs?; end
 
-  sig { returns(::RBI::Visibility) }
+  sig { returns(T.nilable(::RBI::Visibility)) }
   def visibility; end
 
   def visibility=(_arg0); end
@@ -75,7 +75,7 @@ class RBI::Attr < ::RBI::NodeWithComments
     params(
       name: ::String,
       sig: T.nilable(::RBI::Sig),
-      visibility: ::RBI::Visibility,
+      visibility: T.nilable(::RBI::Visibility),
       loc: T.nilable(::RBI::Loc),
       comments: T::Array[::RBI::Comment]
     ).returns(::RBI::Method)
@@ -87,7 +87,7 @@ class RBI::Attr < ::RBI::NodeWithComments
       name: ::String,
       sig: T.nilable(::RBI::Sig),
       attribute_type: T.nilable(T.any(::RBI::Type, ::String)),
-      visibility: ::RBI::Visibility,
+      visibility: T.nilable(::RBI::Visibility),
       loc: T.nilable(::RBI::Loc),
       comments: T::Array[::RBI::Comment]
     ).returns(::RBI::Method)
@@ -103,7 +103,7 @@ class RBI::AttrAccessor < ::RBI::Attr
     params(
       name: ::Symbol,
       names: ::Symbol,
-      visibility: ::RBI::Visibility,
+      visibility: T.nilable(::RBI::Visibility),
       sigs: T.nilable(T::Array[::RBI::Sig]),
       loc: T.nilable(::RBI::Loc),
       comments: T.nilable(T::Array[::RBI::Comment]),
@@ -130,7 +130,7 @@ class RBI::AttrReader < ::RBI::Attr
     params(
       name: ::Symbol,
       names: ::Symbol,
-      visibility: ::RBI::Visibility,
+      visibility: T.nilable(::RBI::Visibility),
       sigs: T.nilable(T::Array[::RBI::Sig]),
       loc: T.nilable(::RBI::Loc),
       comments: T.nilable(T::Array[::RBI::Comment]),
@@ -157,7 +157,7 @@ class RBI::AttrWriter < ::RBI::Attr
     params(
       name: ::Symbol,
       names: ::Symbol,
-      visibility: ::RBI::Visibility,
+      visibility: T.nilable(::RBI::Visibility),
       sigs: T.nilable(T::Array[::RBI::Sig]),
       loc: T.nilable(::RBI::Loc),
       comments: T.nilable(T::Array[::RBI::Comment]),
@@ -697,7 +697,7 @@ class RBI::Method < ::RBI::NodeWithComments
       name: ::String,
       params: T.nilable(T::Array[::RBI::Param]),
       is_singleton: T::Boolean,
-      visibility: ::RBI::Visibility,
+      visibility: T.nilable(::RBI::Visibility),
       sigs: T.nilable(T::Array[::RBI::Sig]),
       loc: T.nilable(::RBI::Loc),
       comments: T.nilable(T::Array[::RBI::Comment]),
@@ -787,7 +787,7 @@ class RBI::Method < ::RBI::NodeWithComments
   sig { override.returns(::String) }
   def to_s; end
 
-  sig { returns(::RBI::Visibility) }
+  sig { returns(T.nilable(::RBI::Visibility)) }
   def visibility; end
 
   def visibility=(_arg0); end
@@ -1507,7 +1507,6 @@ class RBI::Public < ::RBI::Visibility
   def initialize(loc: T.unsafe(nil), comments: T.unsafe(nil), &block); end
 end
 
-RBI::Public::DEFAULT = T.let(T.unsafe(nil), RBI::Public)
 module RBI::RBS; end
 
 class RBI::RBS::MethodTypeTranslator


### PR DESCRIPTION
We can use `nil` to represent implicit public default visibility.

cc. @michaelherold.